### PR TITLE
Upping resource class for CI tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,7 @@ executors:
     docker:
       - image: candlecorp/build-base:latest
         auth: *AUTH
-    resource_class: large
+    resource_class: xlarge
     environment:
       CARGO_BUILD_JOBS: 4
       RUSTC_WRAPPER: sccache


### PR DESCRIPTION
The builds were bumping up against the memory limit on the `large` executor on CircleCI.