### PR TITLE
chore: TS config tweaks

### DIFF
--- a/config/ts/iota_visitor.ts
+++ b/config/ts/iota_visitor.ts
@@ -40,6 +40,11 @@ import {
     context.accept(context, types);
   }
 
+  public visitContextAfter(context: Context): void {
+    const interfaces = new InterfacesVisitor(this.writer);
+    context.accept(context, interfaces);
+  }
+
   visitInterfaceBefore(context: Context): void {
     const args = new ArgsVisitor(this.writer);
     context.interface.accept(context, args);
@@ -270,5 +275,22 @@ class ClientVisitor extends BaseVisitor {
   visitInterfaceAfter(context: Context): void {
     this.write(`}\n\n`);
     super.triggerInterfaceAfter(context);
+  }
+}
+
+class InterfacesVisitor extends BaseVisitor {
+  visitContextBefore(_context: Context): void {
+    this.write("export const interfaces = {\n");
+  }
+
+  visitContextAfter(_context: Context): void {
+    this.write("}\n\n");
+  }
+
+  visitInterface(context: Context): void {
+    const { interface: iface } = context;
+    this.write(
+      `  ${iface.name},\n`,
+    );
   }
 }

--- a/config/ts/nanobus.ts
+++ b/config/ts/nanobus.ts
@@ -91,7 +91,7 @@ export function duration(value: string): Duration {
   return s as Duration;
 }
 
-export const codecs: { [name: string]: CodecRef } = {
+export const codecs: Record<string, CodecRef> = {
   JSON: "json" as CodecRef,
   MsgPack: "msgpack" as CodecRef,
   CloudEventsJSON: "cloudevents+json" as CodecRef,
@@ -100,11 +100,6 @@ export const codecs: { [name: string]: CodecRef } = {
 
 export interface IncludeOptions {
   resourceLinks?: { [key: string]: ResourceRef };
-}
-
-export interface Iota<T> {
-  $ref: string;
-  interfaces: T;
 }
 
 // For YAML serialization
@@ -320,14 +315,16 @@ export class Application {
 
   import<T>(
     instanceId: string,
-    iota: Iota<T>,
+    ref: string,
+    iota: T,
     options: IncludeOptions = {},
   ): T {
     this.config.imports[instanceId] = {
-      ref: iota.$ref,
+      ref: ref,
       ...options,
     };
-    return iota.interfaces;
+    // TODO: transfrom based on instanceId.
+    return iota;
   }
 
   initializer(name: string, comp: Component<unknown>): Application {
@@ -439,7 +436,7 @@ export class Application {
   }
 
   emit(): void {
-    const content = this.asYAML();
+    const content = this.asYAML().trim() + "\n";
     if (Deno.args.length == 1) {
       Deno.writeTextFileSync(Deno.args[0], content);
     } else {


### PR DESCRIPTION
This PR:

* Add `const interfaces` to `IotaVisitor` as an anchor to Iota's available interfaces
* Simplifies the `import` method in the TS config (Still likely to change in the future as we implement true Iota instantiation)