### PR TITLE
Fix for path resolution and missing components in interpreter

### DIFF
--- a/crates/bins/wick/src/commands/invoke.rs
+++ b/crates/bins/wick/src/commands/invoke.rs
@@ -76,7 +76,7 @@ pub(crate) async fn handle_command(mut opts: InvokeCommand) -> Result<()> {
     .allow_latest(opts.fetch.allow_latest)
     .allow_insecure(&opts.fetch.insecure_registries);
 
-  let manifest = WickConfiguration::fetch(&opts.location, fetch_options)
+  let manifest = WickConfiguration::fetch(wick_config::str_to_url(&opts.location, None)?, fetch_options)
     .await?
     .try_component_config()?;
 

--- a/crates/bins/wick/src/commands/list.rs
+++ b/crates/bins/wick/src/commands/list.rs
@@ -30,7 +30,7 @@ pub(crate) async fn handle_command(opts: ListCommand) -> Result<()> {
     .allow_latest(opts.fetch.allow_latest)
     .allow_insecure(&opts.fetch.insecure_registries);
 
-  let manifest = WickConfiguration::fetch(&opts.location, fetch_options)
+  let manifest = WickConfiguration::fetch(wick_config::str_to_url(&opts.location, None)?, fetch_options)
     .await?
     .try_component_config()?;
 

--- a/crates/bins/wick/src/commands/serve.rs
+++ b/crates/bins/wick/src/commands/serve.rs
@@ -29,7 +29,7 @@ pub(crate) async fn handle_command(opts: ServeCommand) -> Result<()> {
     .allow_latest(opts.fetch.allow_latest)
     .allow_insecure(&opts.fetch.insecure_registries);
 
-  let manifest = WickConfiguration::fetch(&opts.location, fetch_options)
+  let manifest = WickConfiguration::fetch(wick_config::str_to_url(&opts.location, None)?, fetch_options)
     .await?
     .try_component_config()?;
 

--- a/crates/bins/wick/src/commands/test.rs
+++ b/crates/bins/wick/src/commands/test.rs
@@ -48,7 +48,7 @@ pub(crate) async fn handle_command(opts: TestCommand) -> Result<()> {
     .allow_latest(opts.fetch.allow_latest)
     .allow_insecure(&opts.fetch.insecure_registries);
 
-  let config = WickConfiguration::fetch(&opts.location, fetch_options)
+  let config = WickConfiguration::fetch(wick_config::str_to_url(&opts.location, None)?, fetch_options)
     .await?
     .try_component_config()?;
 

--- a/crates/bins/wick/src/utils.rs
+++ b/crates/bins/wick/src/utils.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use futures::StreamExt;
 use logger::{LoggingGuard, LoggingOptions};
 use wick_component_cli::options::DefaultCliOptions;
-use wick_config::config::{ComponentConfiguration, HttpConfig};
+use wick_config::config::{ComponentConfiguration, HttpConfig, LocationReference};
 use wick_packet::PacketStream;
 
 use crate::commands::FetchOptions;
@@ -41,22 +41,22 @@ pub(crate) fn merge_config(
         log_override("rpc.port", &mut manifest_opts.port, Some(to));
       }
       if let Some(to) = cli_opts.rpc_pem {
-        log_override("rpc.pem", &mut manifest_opts.pem, Some(to.into()));
+        log_override("rpc.pem", &mut manifest_opts.pem, Some(LocationReference::new(to)));
       }
       if let Some(to) = cli_opts.rpc_ca {
-        log_override("rpc.ca", &mut manifest_opts.ca, Some(to.into()));
+        log_override("rpc.ca", &mut manifest_opts.ca, Some(LocationReference::new(to)));
       }
       if let Some(to) = cli_opts.rpc_key {
-        log_override("rpc.key", &mut manifest_opts.key, Some(to.into()));
+        log_override("rpc.key", &mut manifest_opts.key, Some(LocationReference::new(to)));
       }
     } else {
       host_config.rpc = Some(HttpConfig {
         enabled: cli_opts.rpc_enabled,
         port: cli_opts.rpc_port,
         address: cli_opts.rpc_address,
-        pem: cli_opts.rpc_pem.map(Into::into),
-        key: cli_opts.rpc_key.map(Into::into),
-        ca: cli_opts.rpc_ca.map(Into::into),
+        pem: cli_opts.rpc_pem.map(LocationReference::new),
+        key: cli_opts.rpc_key.map(LocationReference::new),
+        ca: cli_opts.rpc_ca.map(LocationReference::new),
       });
     };
   }

--- a/crates/bins/wick/tests/cmd/run/anonymous-component.args.yaml
+++ b/crates/bins/wick/tests/cmd/run/anonymous-component.args.yaml
@@ -5,8 +5,8 @@ triggers:
     operation:
       name: main
       component:
-        kind: wick/component/wasmrs@v1
-        ref: ../../../../../integration/test-cli-trigger-component/build/test_cli_trigger_component.signed.wasm
+        kind: wick/component/manifest@v1
+        ref: ../../../../../integration/test-cli-trigger-component/component.yaml
     app:
       kind: wick/component/manifest@v1
       ref: ./noop.yaml

--- a/crates/bins/wick/tests/cmd/run/imported-component.args.yaml
+++ b/crates/bins/wick/tests/cmd/run/imported-component.args.yaml
@@ -3,8 +3,8 @@ kind: wick/app@v1
 import:
   - name: main
     component:
-      kind: wick/component/wasmrs@v1
-      ref: ../../../../../integration/test-cli-trigger-component/build/test_cli_trigger_component.signed.wasm
+      kind: wick/component/manifest@v1
+      ref: ../../../../../integration/test-cli-trigger-component/component.yaml
 triggers:
   - kind: wick/trigger/cli@v1
     operation: main::main

--- a/crates/misc/assets/src/error.rs
+++ b/crates/misc/assets/src/error.rs
@@ -12,6 +12,10 @@ pub enum Error {
   /// Could not load file.
   #[error("Could not read file {0}")]
   LoadError(String),
+
+  /// The location of the asset was in a format the Asset couldn't parse.
+  #[error("Could not parse location format: {0}")]
+  Parse(String),
 }
 
 impl From<std::io::Error> for Error {

--- a/crates/misc/derive-assets/tests/derive.rs
+++ b/crates/misc/derive-assets/tests/derive.rs
@@ -25,8 +25,10 @@ struct InnerStruct {
 struct Struct2 {
   one: TestAsset,
   #[asset(skip)]
+  #[allow(unused)]
   two: TestAsset,
   #[asset(skip)]
+  #[allow(unused)]
   three: String,
 }
 

--- a/crates/wick/flow-graph-interpreter/src/constants.rs
+++ b/crates/wick/flow-graph-interpreter/src/constants.rs
@@ -1,7 +1,7 @@
 pub(crate) use flow_graph::NS_SCHEMATIC as NS_INTERNAL;
 
 pub const NS_CORE: &str = "core";
-pub const NS_COLLECTIONS: &str = "collections";
+pub const NS_COMPONENTS: &str = "collections";
 pub const NS_SELF: &str = "self";
 
 pub(crate) const CORE_ID_SENDER: &str = "sender";

--- a/crates/wick/flow-graph-interpreter/src/interpreter/collections/collection_collection.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/collections/collection_collection.rs
@@ -13,11 +13,11 @@ pub(crate) enum Error {
 }
 
 #[derive(Debug)]
-pub(crate) struct CollectionCollection {
+pub(crate) struct ComponentComponent {
   signature: ComponentSignature,
 }
 
-impl CollectionCollection {
+impl ComponentComponent {
   pub(crate) fn new(list: &HandlerMap) -> Self {
     let mut signature = ComponentSignature::new("collections");
     for ns in list.collections().keys() {
@@ -32,14 +32,14 @@ impl CollectionCollection {
   }
 }
 
-impl Component for CollectionCollection {
+impl Component for ComponentComponent {
   fn handle(
     &self,
     invocation: Invocation,
     _stream: PacketStream,
     _config: Option<Value>,
   ) -> BoxFuture<Result<PacketStream, BoxError>> {
-    trace!(target = %invocation.target, namespace = NS_COLLECTIONS);
+    trace!(target = %invocation.target, namespace = NS_COMPONENTS);
 
     // This handler handles the NS_COLLECTIONS namespace and outputs the entity
     // to link to.

--- a/crates/wick/flow-graph-interpreter/src/interpreter/collections/schematic_collection.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/collections/schematic_collection.rs
@@ -20,17 +20,17 @@ pub(crate) enum Error {
 }
 
 #[derive(Debug)]
-pub(crate) struct SchematicCollection {
+pub(crate) struct SchematicComponent {
   signature: ComponentSignature,
   schematics: Arc<Vec<SchematicExecutor>>,
-  collections: Arc<HandlerMap>,
+  components: Arc<HandlerMap>,
   self_collection: Mutex<Option<Arc<Self>>>,
   rng: Random,
 }
 
-impl SchematicCollection {
+impl SchematicComponent {
   pub(crate) fn new(
-    collections: Arc<HandlerMap>,
+    components: Arc<HandlerMap>,
     state: &ProgramState,
     dispatcher: &InterpreterDispatchChannel,
     seed: Seed,
@@ -48,7 +48,7 @@ impl SchematicCollection {
       signature,
       schematics,
       self_collection: Mutex::new(None),
-      collections,
+      components,
       rng: Random::from_seed(seed),
     });
     collection.update_self_collection();
@@ -67,7 +67,7 @@ impl SchematicCollection {
   }
 }
 
-impl Component for SchematicCollection {
+impl Component for SchematicComponent {
   fn handle(
     &self,
     invocation: Invocation,
@@ -86,7 +86,7 @@ impl Component for SchematicCollection {
           invocation,
           stream,
           self.rng.seed(),
-          self.collections.clone(),
+          self.components.clone(),
           self.clone_self_collection(),
         )
       })

--- a/crates/wick/flow-graph-interpreter/src/interpreter/error.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/error.rs
@@ -19,6 +19,8 @@ pub enum Error {
   CollectionShutdown(String),
   #[error("Shutdown failed: {0}")]
   Shutdown(String),
+  #[error("Namespace '{0}' already exists, can not overwrite")]
+  DuplicateNamespace(String),
 }
 
 #[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]

--- a/crates/wick/flow-graph-interpreter/src/interpreter/program.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/program.rs
@@ -32,7 +32,7 @@ impl Program {
     &self.state
   }
 
-  pub(crate) fn schematics(&self) -> &[Schematic] {
+  pub(crate) fn operations(&self) -> &[Schematic] {
     self.state.network.schematics()
   }
 

--- a/crates/wick/flow-graph-interpreter/tests/test/mod.rs
+++ b/crates/wick/flow-graph-interpreter/tests/test/mod.rs
@@ -21,7 +21,8 @@ macro_rules! interp {
     let collections = HandlerMap::new(vec![NamespaceHandler::new(
       "test",
       Box::new(test::TestComponent::new()),
-    )]);
+    )])
+    .unwrap();
     let invocation = Invocation::new(Entity::test("test"), Entity::local($op), None);
     let mut interpreter = Interpreter::new(Some(Seed::unsafe_new(1)), network, None, Some(collections))?;
     interpreter.start(OPTIONS, None).await;

--- a/crates/wick/flow-graph-interpreter/tests/validation.rs
+++ b/crates/wick/flow-graph-interpreter/tests/validation.rs
@@ -36,6 +36,7 @@ fn collections(sig: ComponentSignature) -> HandlerMap {
     "test",
     Box::new(SignatureTestCollection(sig)),
   )])
+  .unwrap()
 }
 
 fn interp(path: &str, sig: ComponentSignature) -> std::result::Result<Interpreter, InterpreterError> {

--- a/crates/wick/wick-component-cli/src/options.rs
+++ b/crates/wick/wick-component-cli/src/options.rs
@@ -68,6 +68,7 @@ pub struct ServerOptions {
   pub ca: Option<wick_config::config::LocationReference>,
 }
 
+#[allow(clippy::expect_used)]
 impl From<DefaultCliOptions> for Options {
   fn from(opts: DefaultCliOptions) -> Self {
     let rpc = Some(ServerOptions {
@@ -75,11 +76,12 @@ impl From<DefaultCliOptions> for Options {
       port: opts.rpc_port,
       address: opts.rpc_address,
       #[cfg(feature = "grpc")]
-      pem: opts.rpc_pem.map(Into::into),
+      pem: opts.rpc_pem.map(wick_config::config::LocationReference::new),
       #[cfg(feature = "grpc")]
-      key: opts.rpc_key.map(Into::into),
+      key: opts.rpc_key.map(wick_config::config::LocationReference::new),
+
       #[cfg(feature = "grpc")]
-      ca: opts.rpc_ca.map(Into::into),
+      ca: opts.rpc_ca.map(wick_config::config::LocationReference::new),
     });
 
     let id = opts

--- a/crates/wick/wick-component-codegen/src/generate.rs
+++ b/crates/wick/wick-component-codegen/src/generate.rs
@@ -10,7 +10,7 @@ use quote::quote;
 use syn::parse::{Parse, ParseStream};
 use syn::{parse_macro_input, Expr, Lit, LitStr};
 use wick_config::config::{FlowOperation, OperationSignature};
-use wick_config::WickConfiguration;
+use wick_config::{path_to_url, WickConfiguration};
 use wick_interface_types::{EnumSignature, EnumVariant, StructSignature, TypeDefinition};
 
 fn snake(s: &str) -> String {
@@ -409,8 +409,7 @@ fn codegen(wick_config: WickConfiguration, gen_config: &config::Config) -> Resul
 #[allow(clippy::needless_pass_by_value)]
 pub fn build(config: config::Config) -> Result<()> {
   let wick_yaml = std::fs::read_to_string(&config.spec)?;
-  let wick_config =
-    wick_config::WickConfiguration::from_yaml(&wick_yaml, &Some(config.spec.to_string_lossy().to_string()))?;
+  let wick_config = wick_config::WickConfiguration::from_yaml(&wick_yaml, &Some(path_to_url(&config.spec, None)?))?;
 
   let src = codegen(wick_config, &config)?;
   std::fs::create_dir_all(&config.out_dir)?;

--- a/crates/wick/wick-config/definitions/v1/manifest.apex
+++ b/crates/wick/wick-config/definitions/v1/manifest.apex
@@ -196,7 +196,7 @@ type ComponentBinding {
 }
 
 "The possible types of components."
-union ComponentDefinition = WasmRsComponent | GrpcUrlComponent | ManifestComponent | ComponentReference
+union ComponentDefinition = GrpcUrlComponent | ManifestComponent | ComponentReference
 
 "A reference to a component in the application's scope."
 type ComponentReference  @tagged("wick/component/reference@v1") {
@@ -238,18 +238,6 @@ type HttpConfig {
 
   "Path to CA file."
   ca: LocationReference?,
-}
-
-"A WebAssembly component."
-type WasmRsComponent @tagged("wick/component/wasmrs@v1") {
-  "The URL (and optional tag) or local file path to find the .wasm module."
-  ref: LocationReference @rename("reference") @required
-
-  "Permissions to give this component"
-  permissions: Permissions
-
-  "Per-component configuration."
-  config: any
 }
 
 "Per-component permissions configuration."

--- a/crates/wick/wick-config/docs/v1.html
+++ b/crates/wick/wick-config/docs/v1.html
@@ -952,55 +952,6 @@
 </ul>
 </div></div></div><div class="definition">
 <h2 class="definition-name type-name">
-  <a name="WasmRsComponent">WasmRsComponent</a>
-</h2>
-
-<span class="description type-description">A WebAssembly component.</span>
-<div class=fields>
-<div class=field>
-
-<h3 class=field-name>
-  <a name="ref">ref</a>
-</h3>
-
-<span class="description field-description">The URL (and optional tag) or local file path to find the .wasm module.</span>
-
-
-<ul class="field-notes">
-<li><span class="type field-note">Type: <span class=field-type><a href="#LocationReference">LocationReference</a></span></span></li>
-<li><span class="annotation field-note">Required</span></li>
-
-</ul>
-</div><div class=field>
-
-<h3 class=field-name>
-  <a name="permissions">permissions</a>
-</h3>
-
-<span class="description field-description">Permissions to give this component</span>
-
-
-<ul class="field-notes">
-<li><span class="type field-note">Type: <span class=field-type><a href="#Permissions">Permissions</a></span></span></li>
-
-
-</ul>
-</div><div class=field>
-
-<h3 class=field-name>
-  <a name="config">config</a>
-</h3>
-
-<span class="description field-description">Per-component configuration.</span>
-
-
-<ul class="field-notes">
-<li><span class="type field-note">Type: <span class=field-type><a href="#any">any</a></span></span></li>
-
-
-</ul>
-</div></div></div><div class="definition">
-<h2 class="definition-name type-name">
   <a name="Permissions">Permissions</a>
 </h2>
 

--- a/crates/wick/wick-config/json-schema/manifest.json
+++ b/crates/wick/wick-config/json-schema/manifest.json
@@ -879,9 +879,6 @@
       "ComponentDefinition": {
         "oneOf": [
           {
-            "$ref": "#/$defs/v1/WasmRsComponent"
-          },
-          {
             "$ref": "#/$defs/v1/GrpcUrlComponent"
           },
           {
@@ -974,33 +971,6 @@
           }
         },
         "required": []
-      },
-      "WasmRsComponent": {
-        "$anchor": "#v1/WasmRsComponent",
-        "additionalProperties": false,
-        "properties": {
-          "kind": {
-            "type": "string",
-            "description": "The kind of the collection",
-            "enum": [
-              "wick/component/wasmrs@v1"
-            ]
-          },
-          "ref": {
-            "description": "The URL (and optional tag) or local file path to find the .wasm module.",
-            "type": "string"
-          },
-          "permissions": {
-            "description": "Permissions to give this component",
-            "$ref": "#/$defs/v1/Permissions"
-          },
-          "config": {
-            "description": "Per-component configuration."
-          }
-        },
-        "required": [
-          "ref"
-        ]
       },
       "Permissions": {
         "$anchor": "#v1/Permissions",

--- a/crates/wick/wick-config/json-schema/v1/manifest.json
+++ b/crates/wick/wick-config/json-schema/v1/manifest.json
@@ -532,7 +532,6 @@
 
     "ComponentDefinition": {
       "oneOf": [
-        { "$ref": "#/$defs/v1/WasmRsComponent" },
         { "$ref": "#/$defs/v1/GrpcUrlComponent" },
         { "$ref": "#/$defs/v1/ManifestComponent" },
         { "$ref": "#/$defs/v1/ComponentReference" }
@@ -630,32 +629,6 @@
         }
       },
       "required": []
-    },
-
-    "WasmRsComponent": {
-      "$anchor": "#v1/WasmRsComponent",
-      "additionalProperties": false,
-      "properties": {
-        "kind": {
-          "type": "string",
-          "description": "The kind of the collection",
-          "enum": ["wick/component/wasmrs@v1"]
-        },
-        "ref": {
-          "description": "The URL (and optional tag) or local file path to find the .wasm module.",
-
-          "type": "string"
-        },
-        "permissions": {
-          "description": "Permissions to give this component",
-
-          "$ref": "#/$defs/v1/Permissions"
-        },
-        "config": {
-          "description": "Per-component configuration."
-        }
-      },
-      "required": ["ref"]
     },
 
     "Permissions": {

--- a/crates/wick/wick-config/src/config/app_config.rs
+++ b/crates/wick/wick-config/src/config/app_config.rs
@@ -3,6 +3,7 @@ pub(super) mod resources;
 pub(super) mod triggers;
 
 use assets::AssetManager;
+use url::Url;
 
 pub use self::resources::*;
 pub use self::triggers::*;
@@ -19,7 +20,7 @@ pub struct AppConfiguration {
   #[asset(skip)]
   pub name: String,
   #[asset(skip)]
-  pub(crate) source: Option<String>,
+  pub(crate) source: Option<Url>,
   #[asset(skip)]
   pub(crate) metadata: Option<config::Metadata>,
   pub(crate) import: HashMap<String, BoundComponent>,
@@ -56,14 +57,15 @@ impl AppConfiguration {
 
   /// Return the underlying version of the source manifest.
   #[must_use]
-  pub fn source(&self) -> &Option<String> {
+  pub fn source(&self) -> &Option<Url> {
     &self.source
   }
 
   /// Set the source location of the configuration.
-  pub fn set_source(&mut self, source: impl AsRef<str>) {
-    self.source = Some(source.as_ref().to_owned());
-    self.set_baseurl(source.as_ref());
+  pub fn set_source(&mut self, source: Url) {
+    // Source is a file, so our baseurl needs to be the parent directory.
+    self.set_baseurl(source.join("./").unwrap().as_str());
+    self.source = Some(source);
   }
 
   #[must_use]

--- a/crates/wick/wick-config/src/config/common/component_definition.rs
+++ b/crates/wick/wick-config/src/config/common/component_definition.rs
@@ -85,6 +85,7 @@ impl BoundComponent {
   pub fn config(&self) -> Option<&Value> {
     match &self.kind {
       ComponentDefinition::Native(_) => None,
+      #[allow(deprecated)]
       ComponentDefinition::Wasm(v) => Some(&v.config),
       ComponentDefinition::GrpcUrl(v) => Some(&v.config),
       ComponentDefinition::Manifest(v) => Some(&v.config),
@@ -102,8 +103,9 @@ pub enum ComponentDefinition {
   #[asset(skip)]
   Native(NativeComponent),
   /// WebAssembly Collections.
+  #[deprecated(note = "Use ManifestComponent instead")]
   Wasm(WasmComponent),
-  /// WebAssembly Collections.
+  /// A component reference.
   #[asset(skip)]
   Reference(ComponentReference),
   /// Separate microservices that Wick can connect to.
@@ -128,14 +130,6 @@ impl ComponentReference {
 }
 
 impl ComponentDefinition {
-  /// Instantiate a new [CollectionKind].
-  pub fn new(def: impl TryInto<ComponentDefinition>) -> Result<Self, crate::Error> {
-    match def.try_into() {
-      Ok(v) => Ok(v),
-      Err(_e) => Err(crate::Error::Other("Could not load collection definition".to_owned())),
-    }
-  }
-
   /// Returns true if the definition is a reference to another component.
   #[must_use]
   pub fn is_reference(&self) -> bool {

--- a/crates/wick/wick-config/src/config/component_config.rs
+++ b/crates/wick/wick-config/src/config/component_config.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 
 use assets::AssetManager;
 pub use composite::CompositeComponentConfiguration;
+use url::Url;
 pub use wasm::{OperationSignature, WasmComponentConfiguration};
 use wick_interface_types::{ComponentMetadata, ComponentSignature, ComponentVersion, TypeDefinition};
 
@@ -64,7 +65,7 @@ pub struct ComponentConfiguration {
   #[asset(skip)]
   pub name: Option<String>,
   #[asset(skip)]
-  pub(crate) source: Option<String>,
+  pub(crate) source: Option<Url>,
   #[asset(skip)]
   pub(crate) host: config::HostConfig,
   #[asset(skip)]
@@ -98,9 +99,10 @@ impl ComponentConfiguration {
   }
 
   /// Set the source location of the configuration.
-  pub fn set_source(&mut self, source: impl AsRef<str>) {
-    self.source = Some(source.as_ref().to_owned());
-    self.set_baseurl(source.as_ref());
+  pub fn set_source(&mut self, source: Url) {
+    // Source is a file, so our baseurl needs to be the parent directory.
+    self.set_baseurl(source.join("./").unwrap().as_str());
+    self.source = Some(source);
   }
 
   /// Determine if the configuration allows for fetching artifacts with the :latest tag.
@@ -149,7 +151,7 @@ impl ComponentConfiguration {
 
   /// Return the underlying version of the source manifest.
   #[must_use]
-  pub fn source(&self) -> &Option<String> {
+  pub fn source(&self) -> &Option<Url> {
     &self.source
   }
 
@@ -181,7 +183,7 @@ impl ComponentConfiguration {
 #[must_use]
 pub struct ComponentConfigurationBuilder {
   name: Option<String>,
-  source: Option<String>,
+  source: Option<Url>,
   host: config::HostConfig,
   labels: HashMap<String, String>,
   tests: Vec<config::TestCase>,

--- a/crates/wick/wick-config/src/config/test_config.rs
+++ b/crates/wick/wick-config/src/config/test_config.rs
@@ -1,4 +1,5 @@
 use assets::AssetManager;
+use url::Url;
 
 use crate::config;
 
@@ -7,7 +8,7 @@ use crate::config;
 #[must_use]
 pub struct TestConfiguration {
   #[asset(skip)]
-  pub(crate) source: Option<String>,
+  pub(crate) source: Option<Url>,
   #[asset(skip)]
   pub(crate) tests: Vec<config::TestCase>,
 }
@@ -20,8 +21,9 @@ impl TestConfiguration {
   }
 
   /// Set the source location of the configuration.
-  pub fn set_source(&mut self, source: impl AsRef<str>) {
-    self.source = Some(source.as_ref().to_owned());
-    self.set_baseurl(source.as_ref());
+  pub fn set_source(&mut self, source: Url) {
+    // Source is a file, so our baseurl needs to be the parent directory.
+    self.set_baseurl(source.join("./").unwrap().as_str());
+    self.source = Some(source);
   }
 }

--- a/crates/wick/wick-config/src/config/types_config.rs
+++ b/crates/wick/wick-config/src/config/types_config.rs
@@ -1,4 +1,5 @@
 use assets::AssetManager;
+use url::Url;
 use wick_interface_types::TypeDefinition;
 
 #[derive(Debug, Clone, derive_assets::AssetManager)]
@@ -6,7 +7,7 @@ use wick_interface_types::TypeDefinition;
 #[must_use]
 pub struct TypesConfiguration {
   #[asset(skip)]
-  pub(crate) source: Option<String>,
+  pub(crate) source: Option<Url>,
   #[asset(skip)]
   pub(crate) types: Vec<TypeDefinition>,
 }
@@ -18,8 +19,9 @@ impl TypesConfiguration {
   }
 
   /// Set the source location of the configuration.
-  pub fn set_source(&mut self, source: impl AsRef<str>) {
-    self.source = Some(source.as_ref().to_owned());
-    self.set_baseurl(source.as_ref());
+  pub fn set_source(&mut self, source: Url) {
+    // Source is a file, so our baseurl needs to be the parent directory.
+    self.set_baseurl(source.join("./").unwrap().as_str());
+    self.source = Some(source);
   }
 }

--- a/crates/wick/wick-config/src/error.rs
+++ b/crates/wick/wick-config/src/error.rs
@@ -1,6 +1,5 @@
-use std::path::PathBuf;
-
 use thiserror::Error;
+use url::Url;
 
 use crate::config::{self};
 
@@ -13,13 +12,13 @@ pub enum ManifestError {
   #[error("Invalid Manifest Version '{0}'")]
   VersionError(String),
 
-  /// Could not create package cache.
-  #[error("Could not create package cache at '{path}': {error}")]
-  PackageCacheError { path: PathBuf, error: std::io::Error },
+  /// Location reference was not a URL or package reference
+  #[error("Could not parse {0} as a URL or reference")]
+  BadUrl(String),
 
-  /// No data stored in the current location reference.
-  #[error("No data available in the location reference at {0}")]
-  NoData(String),
+  /// Other URL Parsing error.
+  #[error(transparent)]
+  UrlParse(#[from] url::ParseError),
 
   /// No format version or kind found in the parsed manifest.
   #[error("Manifest needs a format version (v0) or kind (v1+)")]
@@ -31,7 +30,7 @@ pub enum ManifestError {
 
   /// Could not load file.
   #[error("Could not read file {0}: {1}")]
-  LoadError(String, String),
+  LoadError(Url, String),
 
   /// Thrown when a specific type of configuration was expected but a different type was found.
   #[error("Expected a {0} configuration but got a {1} configuration")]
@@ -42,28 +41,12 @@ pub enum ManifestError {
   UnexpectedComponentType(config::ComponentKind, config::ComponentKind),
 
   /// Error deserializing YAML manifest.
-  #[error("Could not parse manifest {0} as YAML: {1}")]
-  YamlError(String, String),
-
-  /// Default was requested when none present.
-  #[error("Connection '{0}' does not have a default but one was requested")]
-  NoDefault(config::ConnectionDefinition),
-
-  /// Error deserializing default value.
-  #[error("Error deserializing default value for connection: {0}=>{1} - Error was: '{2}'")]
-  DefaultsError(
-    config::ConnectionTargetDefinition,
-    config::ConnectionTargetDefinition,
-    String,
-  ),
+  #[error("Could not parse manifest {} as YAML: {1}", .0.as_ref().unwrap_or(&"<raw>".to_owned()))]
+  YamlError(Option<String>, String),
 
   /// Error parsing or serializing Sender data.
   #[error("Error parsing or serializing Sender data: {0}")]
   InvalidSenderData(String),
-
-  /// File path in manifest is invalid.
-  #[error("Invalid file path: {0}")]
-  BadPath(String),
 
   /// IP address in manifest is invalid.
   #[error("Invalid IP Address: {0}")]

--- a/crates/wick/wick-config/src/lib.rs
+++ b/crates/wick/wick-config/src/lib.rs
@@ -109,3 +109,5 @@ pub(crate) type Result<T> = std::result::Result<T, Error>;
 pub(crate) static SENDER_ID: &str = "core::sender";
 /// The name of SENDER's output port.
 pub(crate) static SENDER_PORT: &str = "output";
+
+pub use utils::{path_to_url, str_to_url};

--- a/crates/wick/wick-config/src/utils.rs
+++ b/crates/wick/wick-config/src/utils.rs
@@ -2,6 +2,7 @@ use std::net::Ipv4Addr;
 use std::str::FromStr;
 
 use serde::de::DeserializeOwned;
+use url::Url;
 
 use crate::error::ManifestError;
 use crate::{Error, Result};
@@ -13,20 +14,51 @@ pub(crate) fn opt_str_to_ipv4addr(v: &Option<String>) -> Result<Option<Ipv4Addr>
   })
 }
 
-pub(crate) fn from_yaml<T>(src: &str, path: &Option<String>) -> Result<T>
+pub(crate) fn from_yaml<T>(src: &str, path: &Option<Url>) -> Result<T>
 where
   T: DeserializeOwned,
 {
-  let result = serde_yaml::from_str(src)
-    .map_err(|e| Error::YamlError(path.clone().unwrap_or("<raw source>".to_owned()), e.to_string()))?;
+  let result =
+    serde_yaml::from_str(src).map_err(|e| Error::YamlError(path.as_ref().map(|v| v.as_ref().into()), e.to_string()))?;
   Ok(result)
 }
 
-pub(crate) fn from_bytes<T>(src: &[u8], path: &Option<String>) -> Result<T>
+pub(crate) fn from_bytes<T>(src: &[u8], path: &Option<Url>) -> Result<T>
 where
   T: DeserializeOwned,
 {
   let result = serde_yaml::from_slice(src)
-    .map_err(|e| Error::YamlError(path.clone().unwrap_or("<raw source>".to_owned()), e.to_string()))?;
+    .map_err(|e| Error::YamlError(path.as_ref().map(|v| v.as_ref().into()), e.to_string()))?;
   Ok(result)
+}
+
+pub fn path_to_url(path: &std::path::Path, base: Option<Url>) -> Result<Url> {
+  let pathstr = path.to_string_lossy().to_string();
+  str_to_url(&pathstr, base)
+}
+
+pub fn str_to_url(path: &str, base: Option<Url>) -> Result<Url> {
+  let url = match base {
+    Some(full_url) => {
+      if !full_url.path().ends_with('/') {
+        let mut url = full_url.clone();
+        url.set_path(&format!("{}/", full_url.path()));
+        url.join(path)?
+      } else {
+        full_url.join(path)?
+      }
+    }
+    None => match Url::from_str(path) {
+      Ok(url) => url,
+      Err(e) => match e {
+        url::ParseError::RelativeUrlWithoutBase => {
+          let mut cwd = std::env::current_dir().unwrap();
+          cwd.push(path);
+          Url::from_file_path(cwd).map_err(|_| Error::BadUrl(path.to_owned()))?
+        }
+        e => return Err(e.into()),
+      },
+    },
+  };
+  Ok(url)
 }

--- a/crates/wick/wick-config/src/v1.rs
+++ b/crates/wick/wick-config/src/v1.rs
@@ -411,9 +411,6 @@ pub(crate) struct ComponentBinding {
 #[serde(tag = "kind")]
 /// The possible types of components.
 pub(crate) enum ComponentDefinition {
-  /// A variant representing a [WasmRsComponent] type.
-  #[serde(rename = "wick/component/wasmrs@v1")]
-  WasmRsComponent(WasmRsComponent),
   /// A variant representing a [GrpcUrlComponent] type.
   #[serde(rename = "wick/component/grpc@v1")]
   GrpcUrlComponent(GrpcUrlComponent),
@@ -494,25 +491,6 @@ pub(crate) struct HttpConfig {
 
   #[serde(default)]
   pub(crate) ca: Option<crate::v1::helpers::LocationReference>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
-#[serde(deny_unknown_fields)]
-/// A WebAssembly component.
-pub(crate) struct WasmRsComponent {
-  /// The URL (and optional tag) or local file path to find the .wasm module.
-
-  #[serde(rename = "ref")]
-  pub(crate) reference: crate::v1::helpers::LocationReference,
-  /// Permissions to give this component
-
-  #[serde(default)]
-  pub(crate) permissions: Permissions,
-  /// Per-component configuration.
-
-  #[serde(default)]
-  #[serde(deserialize_with = "crate::helpers::deserialize_json_env")]
-  pub(crate) config: Value,
 }
 
 #[derive(Debug, Default, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/wick/wick-config/src/v1/helpers.rs
+++ b/crates/wick/wick-config/src/v1/helpers.rs
@@ -1,4 +1,6 @@
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub(crate) struct LocationReference(pub(super) String);
+pub(crate) struct LocationReference(
+  #[serde(deserialize_with = "serde_with_expand_env::with_expand_envs")] pub(super) String,
+);

--- a/crates/wick/wick-config/src/v1/impls.rs
+++ b/crates/wick/wick-config/src/v1/impls.rs
@@ -3,7 +3,6 @@ use super::ComponentDefinition;
 impl ComponentDefinition {
   pub(crate) fn component_id(&self) -> Option<&str> {
     match self {
-      ComponentDefinition::WasmRsComponent(_) => None,
       ComponentDefinition::GrpcUrlComponent(_) => None,
       ComponentDefinition::ManifestComponent(_) => None,
       ComponentDefinition::ComponentReference(v) => Some(&v.id),

--- a/crates/wick/wick-config/tests/manifests/v1/assets.yaml
+++ b/crates/wick/wick-config/tests/manifests/v1/assets.yaml
@@ -9,5 +9,5 @@ component:
   import:
     - name: one
       component:
-        kind: wick/component/wasmrs@v1
+        kind: wick/component/manifest@v1
         ref: assets/test.fake.wasm

--- a/crates/wick/wick-config/tests/manifests/v1/imported-component.yaml
+++ b/crates/wick/wick-config/tests/manifests/v1/imported-component.yaml
@@ -3,7 +3,7 @@ kind: wick/app@v1
 import:
   - name: main
     component:
-      kind: wick/component/wasmrs@v1
+      kind: wick/component/manifest@v1
       ref: ../../integration/test-cli-trigger-component/build/test_cli_trigger_component.signed.wasm
 triggers:
   - kind: wick/trigger/cli@v1

--- a/crates/wick/wick-config/tests/manifests/v1/logger.yaml
+++ b/crates/wick/wick-config/tests/manifests/v1/logger.yaml
@@ -12,7 +12,7 @@ component:
         ref: hey
     - name: bar
       component:
-        kind: wick/component/wasmrs@v1
+        kind: wick/component/manifest@v1
         ref: bar
   operations:
     - name: logger

--- a/crates/wick/wick-config/tests/manifests/v1/shell-expansion.yaml
+++ b/crates/wick/wick-config/tests/manifests/v1/shell-expansion.yaml
@@ -1,17 +1,13 @@
 # yaml-language-server: $schema=../../../json-schema/manifest.json
 ---
-metadata:
-  version: '1'
-
 kind: wick/component@v1
 component:
   kind: wick/component/composite@v1
   import:
     - name: test
       component:
-        kind: wick/component/wasmrs@v1
-        ref: bar
-        permissions:
-          dirs:
-            '/': '$PWD'
+        kind: wick/component/manifest@v1
+        ref: $PWD/test.fake.wasm
+        config:
+          pwd: $PWD
   operations: []

--- a/crates/wick/wick-config/tests/v0_load_from_file.rs
+++ b/crates/wick/wick-config/tests/v0_load_from_file.rs
@@ -49,7 +49,7 @@ async fn load_noversion_yaml() -> Result<(), ManifestError> {
 async fn load_bad_manifest_yaml() -> Result<(), ManifestError> {
   let manifest = load("./tests/manifests/v0/bad-yaml.yaml").await;
   if let Err(Error::YamlError(p, e)) = manifest {
-    debug!("{}, {:?}", p, e);
+    debug!("{:?}, {:?}", p, e);
   } else {
     panic!("Should have failed with YamlError but got : {:?}", manifest);
   }

--- a/crates/wick/wick-host/src/app_host.rs
+++ b/crates/wick/wick-host/src/app_host.rs
@@ -154,7 +154,7 @@ impl AppHostBuilder {
       .allow_latest(allow_latest)
       .allow_insecure(insecure_registries);
 
-    let manifest = WickConfiguration::fetch(location, fetch_options)
+    let manifest = WickConfiguration::fetch(wick_config::str_to_url(location, None)?, fetch_options)
       .await?
       .try_app_config()?;
     Ok(Self::from_definition(manifest))

--- a/crates/wick/wick-host/src/component_host.rs
+++ b/crates/wick/wick-host/src/component_host.rs
@@ -201,7 +201,7 @@ impl ComponentHostBuilder {
       .allow_latest(allow_latest)
       .allow_insecure(insecure_registries);
 
-    let manifest = WickConfiguration::fetch(location, fetch_options)
+    let manifest = WickConfiguration::fetch(wick_config::str_to_url(location, None)?, fetch_options)
       .await?
       .try_component_config()?;
     Ok(Self::from_definition(manifest))

--- a/crates/wick/wick-runtime/src/components/component_service.rs
+++ b/crates/wick/wick-runtime/src/components/component_service.rs
@@ -71,7 +71,7 @@ impl InvocationHandler for NativeComponentService {
     let task = async move {
       Ok(crate::dispatch::InvocationResponse::Stream {
         tx_id,
-        rx: fut.instrument(span).await?,
+        rx: fut.instrument(span).await.map_err(NetworkError::NativeComponent)?,
       })
     };
     Ok(Box::pin(task))

--- a/crates/wick/wick-runtime/src/components/error.rs
+++ b/crates/wick/wick-runtime/src/components/error.rs
@@ -2,17 +2,15 @@ use thiserror::Error;
 use wick_config::config::LocationReference;
 
 use crate::dev::prelude::*;
-use crate::BoxError;
 
 #[derive(Error, Debug)]
 pub enum ComponentError {
   #[error("Component not found: {0}")]
   ComponentNotFound(String),
+
   #[error("{0}")]
   NetworkError(String),
 
-  #[error("{0}")]
-  Mesh(String),
   #[error("Error initializing subnetwork '{0}' : {1}")]
   SubNetwork(LocationReference, String),
 
@@ -23,23 +21,14 @@ pub enum ComponentError {
   InvocationError(#[from] InvocationError),
 
   #[error(transparent)]
+  Configuration(#[from] wick_config::Error),
+
+  #[error(transparent)]
   RpcHandlerError(#[from] Box<wick_rpc::Error>),
 }
 
 impl From<wick_component_wasm::Error> for ComponentError {
   fn from(e: wick_component_wasm::Error) -> Self {
     ComponentError::Downstream(Box::new(e))
-  }
-}
-
-// impl From<wick_component_nats::error::MeshError> for CollectionError {
-//   fn from(e: wick_component_nats::error::MeshError) -> Self {
-//     CollectionError::Mesh(e.to_string())
-//   }
-// }
-
-impl From<BoxError> for ComponentError {
-  fn from(e: BoxError) -> Self {
-    ComponentError::Mesh(e.to_string())
   }
 }

--- a/crates/wick/wick-runtime/src/error.rs
+++ b/crates/wick/wick-runtime/src/error.rs
@@ -20,14 +20,8 @@ pub struct InvocationError(pub String);
 
 #[derive(Error, Debug)]
 pub enum RuntimeError {
-  #[error(transparent)]
-  SchematicGraph(#[from] flow_graph::error::Error),
-
   #[error("Invalid trigger configuration, expected configuration for {0}")]
   InvalidTriggerConfig(TriggerKind),
-
-  #[error(transparent)]
-  InvocationError(#[from] InvocationError),
 
   #[error("Trigger {0} requested resource '{1}' which could not be found")]
   ResourceNotFound(TriggerKind, String),
@@ -38,19 +32,18 @@ pub enum RuntimeError {
   #[error("Trigger {0} did not shutdown gracefully: {1}")]
   ShutdownFailed(TriggerKind, String),
 
-  #[error("Trigger {0} died prematurely: {1}")]
-  TriggerFailed(TriggerKind, String),
-
-  #[error(transparent)]
-  ComponentError(#[from] ComponentError),
-  #[error(transparent)]
-  NetworkError(#[from] NetworkError),
-
   #[error("The supplied id '{0}' does not point to the correct type: {1}")]
   ReferenceError(String, wick_config::error::ReferenceError),
 
   #[error("{0}")]
-  Serialization(String),
-  #[error("{0}")]
   InitializationFailed(String),
+
+  #[error(transparent)]
+  InvocationError(#[from] InvocationError),
+
+  #[error(transparent)]
+  ComponentError(#[from] ComponentError),
+
+  #[error("Request timeout out")]
+  Timeout,
 }

--- a/crates/wick/wick-runtime/src/network.rs
+++ b/crates/wick/wick-runtime/src/network.rs
@@ -60,7 +60,7 @@ impl Network {
 
     let response = tokio::time::timeout(self.timeout, self.inner.invoke(invocation, stream)?)
       .await
-      .map_err(|_| NetworkError::Timeout)??;
+      .map_err(|_| RuntimeError::Timeout)??;
     trace!(duration_ms=%time.elapsed().unwrap().as_millis(),"invocation complete");
 
     Ok(response.ok()?)

--- a/crates/wick/wick-runtime/src/network_service/error.rs
+++ b/crates/wick/wick-runtime/src/network_service/error.rs
@@ -3,26 +3,42 @@ use thiserror::Error;
 use crate::dev::prelude::*;
 #[derive(Error, Debug)]
 pub enum NetworkError {
-  #[error(transparent)]
-  SchematicGraph(#[from] flow_graph::error::Error),
-  #[error("Could not start interpreter from '{0}': {1}")]
-  InterpreterInit(String, flow_graph_interpreter::error::InterpreterError),
-  #[error(transparent)]
-  Manifest(#[from] wick_config::Error),
-
-  // OLD
-  #[error(transparent)]
-  CollectionError(#[from] ComponentError),
+  #[error("Could not start interpreter from '{}': {1}", .0.as_ref().map_or_else(|| "<unknown>".into(), |p| p.to_string()))]
+  InterpreterInit(Option<url::Url>, Box<flow_graph_interpreter::error::InterpreterError>),
 
   #[error(transparent)]
-  RpcHandlerError(#[from] Box<wick_rpc::Error>),
+  FlowGraph(#[from] Box<flow_graph::error::Error>),
 
-  #[error("Request timeout out")]
-  Timeout,
+  #[error(transparent)]
+  Manifest(#[from] Box<wick_config::Error>),
+
+  #[error(transparent)]
+  NativeComponent(#[from] Box<dyn std::error::Error + Send + Sync>),
+
+  #[error(transparent)]
+  Wasm(#[from] Box<wick_component_wasm::Error>),
 }
 
 impl From<NetworkError> for ComponentError {
   fn from(e: NetworkError) -> Self {
     ComponentError::NetworkError(e.to_string())
+  }
+}
+
+impl From<wick_component_wasm::Error> for NetworkError {
+  fn from(e: wick_component_wasm::Error) -> Self {
+    NetworkError::Wasm(Box::new(e))
+  }
+}
+
+impl From<flow_graph::error::Error> for NetworkError {
+  fn from(e: flow_graph::error::Error) -> Self {
+    NetworkError::FlowGraph(Box::new(e))
+  }
+}
+
+impl From<wick_config::Error> for NetworkError {
+  fn from(e: wick_config::Error) -> Self {
+    NetworkError::Manifest(Box::new(e))
   }
 }

--- a/crates/wick/wick-runtime/src/triggers/http.rs
+++ b/crates/wick/wick-runtime/src/triggers/http.rs
@@ -227,8 +227,8 @@ triggers:
           operation:
             name: http_handler
             component:
-              kind: wick/component/wasmrs@v1
-              ref: ../../integration/test-http-trigger-component/build/test_http_trigger_component.signed.wasm
+              kind: wick/component/manifest@v1
+              ref: ../../integration/test-http-trigger-component/component.yaml
     ";
     let app_config = config::WickConfiguration::from_yaml(yaml, &None)?.try_app_config()?;
     let trigger = Http::load_impl()?;


### PR DESCRIPTION
This PR fixes #181 #180 #179.

It fixes:
- how configuration resolves asset references relative to the configuration location
- successfully loaded wasmrs components that don't expose any operations.
- env variable expansion in configuration for asset location references.

Also includes more renaming from collection->component, etc.