### PR TITLE
Propagated the network timeout to the interpreter

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,94 @@
+# This is the default config used by nextest. It is embedded in the binary at
+# build time. It may be used as a template for .config/nextest.toml.
+[store]
+# The directory under the workspace root at which nextest-related files are
+# written. Profile-specific storage is currently written to dir/<profile-name>.
+dir = "target/nextest"
+
+# This section defines the default nextest profile. Custom profiles are layered
+# on top of the default profile.
+[profile.default]
+# "retries" defines the number of times a test should be retried. If set to a
+# non-zero value, tests that succeed on a subsequent attempt will be marked as
+# non-flaky. Can be overridden through the `--retries` option.
+# Examples
+# * retries = 3
+# * retries = { backoff = "fixed", count = 2, delay = "1s" }
+# * retries = { backoff = "exponential", count = 10, delay = "1s", jitter = true, max-delay = "10s" }
+retries = 0
+# The number of threads to run tests with. Supported values are either an integer or
+# the string "num-cpus". Can be overridden through the `--test-threads` option.
+test-threads = "num-cpus"
+# The number of threads required for each test. This is generally used in overrides to
+# mark certain tests as heavier than others. However, it can also be set as a global parameter.
+threads-required = 1
+# Show these test statuses in the output.
+#
+# The possible values this can take are:
+# * none: no output
+# * fail: show failed (including exec-failed) tests
+# * retry: show flaky and retried tests
+# * slow: show slow tests
+# * pass: show passed tests
+# * skip: show skipped tests (most useful for CI)
+# * all: all of the above
+#
+# Each value includes all the values above it; for example, "slow" includes
+# failed and retried tests.
+#
+# Can be overridden through the `--status-level` flag.
+status-level = "pass"
+# Similar to status-level, show these test statuses at the end of the run.
+final-status-level = "flaky"
+# "failure-output" defines when standard output and standard error for failing tests are produced.
+# Accepted values are
+# * "immediate": output failures as soon as they happen
+# * "final": output failures at the end of the test run
+# * "immediate-final": output failures as soon as they happen and at the end of
+#   the test run; combination of "immediate" and "final"
+# * "never": don't output failures at all
+#
+# For large test suites and CI it is generally useful to use "immediate-final".
+#
+# Can be overridden through the `--failure-output` option.
+failure-output = "immediate"
+# "success-output" controls production of standard output and standard error on success. This should
+# generally be set to "never".
+success-output = "never"
+# Cancel the test run on the first failure. For CI runs, consider setting this
+# to false.
+fail-fast = true
+# Treat a test that takes longer than the configured 'period' as slow, and print a message.
+# See <https://nexte.st/book/slow-tests> for more information.
+#
+# Optional: specify the parameter 'terminate-after' with a non-zero integer,
+# which will cause slow tests to be terminated after the specified number of
+# periods have passed.
+# Example: slow-timeout = { period = "60s", terminate-after = 2 }
+slow-timeout = { period = "20s", terminate-after = 2 }
+# Treat a test as leaky if after the process is shut down, standard output and standard error
+# aren't closed within this duration.
+#
+# This usually happens in case of a test that creates a child process and lets it inherit those
+# handles, but doesn't clean the child process up (especially when it fails).
+#
+# See <https://nexte.st/book/leaky-tests> for more information.
+leak-timeout = "100ms"
+
+[profile.default.junit]
+# Output a JUnit report into the given file inside 'store.dir/<profile-name>'.
+# If unspecified, JUnit is not written out.
+# path = "junit.xml"
+# The name of the top-level "report" element in JUnit report. If aggregating
+# reports across different test runs, it may be useful to provide separate names
+# for each report.
+report-name = "nextest-run"
+# Whether standard output and standard error for passing tests should be stored in the JUnit report.
+# Output is stored in the <system-out> and <system-err> elements of the <testcase> element.
+store-success-output = false
+# Whether standard output and standard error for failing tests should be stored in the JUnit report.
+# Output is stored in the <system-out> and <system-err> elements of the <testcase> element.
+#
+# Note that if a description can be extracted from the output, it is always stored in the
+# <description> element.
+store-failure-output = true

--- a/crates/wick/flow-graph-interpreter/src/interpreter.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter.rs
@@ -6,6 +6,7 @@ pub(crate) mod executor;
 pub(crate) mod program;
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use seeded_random::{Random, Seed};
 use tracing_futures::Instrument;
@@ -211,13 +212,28 @@ impl Interpreter {
   }
 }
 
-#[derive(Default, Debug, Clone)]
+#[derive(Debug, Clone)]
 #[allow(missing_copy_implementations)]
 pub struct InterpreterOptions {
   /// Stop the interpreter and return an error on any hung transactions.
   pub error_on_hung: bool,
   /// Stop the interpreter and return an error if any messages come after a transaction has completed.
   pub error_on_missing: bool,
+  /// Timeout after which a component that has received no output is considered dead.
+  pub output_timeout: Duration,
+  /// Timeout after which a transaction that has had no events is considered hung.
+  pub hung_tx_timeout: Duration,
+}
+
+impl Default for InterpreterOptions {
+  fn default() -> Self {
+    Self {
+      error_on_hung: false,
+      error_on_missing: false,
+      output_timeout: Duration::from_secs(5),
+      hung_tx_timeout: Duration::from_millis(500),
+    }
+  }
 }
 
 #[cfg(test)]

--- a/crates/wick/flow-graph-interpreter/src/interpreter/event_loop.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/event_loop.rs
@@ -120,7 +120,10 @@ async fn event_loop(
           EventKind::PortData(data) => state.handle_port_data(tx_id, data).instrument(span).await,
           EventKind::TransactionDone => state.handle_transaction_done(tx_id).instrument(span).await,
           EventKind::TransactionStart(transaction) => {
-            state.handle_transaction_start(*transaction).instrument(span).await
+            state
+              .handle_transaction_start(*transaction, &options)
+              .instrument(span)
+              .await
           }
           EventKind::Ping(ping) => {
             trace!(ping);

--- a/crates/wick/flow-graph-interpreter/src/interpreter/event_loop/state.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/event_loop/state.rs
@@ -8,6 +8,7 @@ use super::EventLoop;
 use crate::interpreter::channel::{CallComplete, InterpreterDispatchChannel};
 use crate::interpreter::executor::error::ExecutionError;
 use crate::interpreter::executor::transaction::Transaction;
+use crate::InterpreterOptions;
 
 #[derive(Debug)]
 pub struct State {
@@ -69,8 +70,12 @@ impl State {
     self.transactions.remove(tx_id)
   }
 
-  pub(super) async fn handle_transaction_start(&mut self, mut transaction: Transaction) -> Result<(), ExecutionError> {
-    let result = match transaction.start().await {
+  pub(super) async fn handle_transaction_start(
+    &mut self,
+    mut transaction: Transaction,
+    options: &InterpreterOptions,
+  ) -> Result<(), ExecutionError> {
+    let result = match transaction.start(options).await {
       Ok(_) => {
         self.transactions.init_tx(transaction.id(), transaction);
         Ok(())

--- a/crates/wick/flow-graph-interpreter/src/interpreter/executor/transaction.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/executor/transaction.rs
@@ -16,7 +16,7 @@ use crate::graph::types::*;
 use crate::interpreter::channel::InterpreterDispatchChannel;
 use crate::interpreter::error::StateError;
 use crate::interpreter::executor::transaction::operation::port::PortStatus;
-use crate::{Component, HandlerMap};
+use crate::{Component, HandlerMap, InterpreterOptions};
 
 pub(crate) mod operation;
 
@@ -129,7 +129,7 @@ impl Transaction {
   }
 
   #[instrument(parent = &self.span, skip_all, name = "tx_start", fields(id = %self.id()))]
-  pub(crate) async fn start(&mut self) -> Result<()> {
+  pub(crate) async fn start(&mut self, options: &InterpreterOptions) -> Result<()> {
     self.stats.mark("start");
     self.stats.start("execution");
     trace!("starting transaction");
@@ -144,7 +144,7 @@ impl Transaction {
         .next_tx(self.invocation.origin.clone(), instance.entity());
       instance
         .clone()
-        .start(self.id(), invocation, self.channel.clone())
+        .start(self.id(), invocation, self.channel.clone(), options)
         .await?;
     }
 

--- a/crates/wick/flow-graph-interpreter/tests/test/mod.rs
+++ b/crates/wick/flow-graph-interpreter/tests/test/mod.rs
@@ -28,11 +28,12 @@ pub(crate) async fn base_setup(
   use flow_graph_interpreter::{HandlerMap, InterpreterOptions, NamespaceHandler};
   use tokio_stream::StreamExt;
   use wick_packet::{Entity, Invocation};
-  const OPTIONS: Option<InterpreterOptions> = Some(InterpreterOptions {
+  let options = Some(InterpreterOptions {
     error_on_hung: true,
     // TODO: improve logic to ensure no remaining packets are sent after completion.
     // Turn this on to make tests fail in these cases.
     error_on_missing: false,
+    ..Default::default()
   });
   let def = wick_config::WickConfiguration::load_from_file_sync(manifest)?.try_component_config()?;
   let network = from_def(&def)?;
@@ -43,7 +44,7 @@ pub(crate) async fn base_setup(
   .unwrap();
   let invocation = Invocation::new(Entity::test("test"), entity, None);
   let mut interpreter = Interpreter::new(Some(Seed::unsafe_new(1)), network, None, Some(collections))?;
-  interpreter.start(OPTIONS, None).await;
+  interpreter.start(options, None).await;
   let stream = wick_packet::PacketStream::new(Box::new(futures::stream::iter(packets.into_iter().map(Ok))));
   let stream = interpreter.invoke(invocation, stream).await?;
   let outputs: Vec<_> = stream.collect().await;

--- a/crates/wick/wick-runtime/tests/validation.rs
+++ b/crates/wick/wick-runtime/tests/validation.rs
@@ -1,10 +1,16 @@
 mod utils;
+use std::time::Duration;
+
 use utils::*;
 type Result<T> = anyhow::Result<T, anyhow::Error>;
 
 #[test_logger::test(tokio::test)]
 async fn missing_collection() -> Result<()> {
-  let result = init_network_from_yaml("./manifests/v0/validation/missing-collection.yaml").await;
+  let result = init_network_from_yaml(
+    "./manifests/v0/validation/missing-collection.yaml",
+    Duration::from_secs(1),
+  )
+  .await;
   println!("result: {:?}", result);
 
   assert!(result.is_err());


### PR DESCRIPTION
This PR propagates the `timeout` option specified during Network initialization over to the interpreter to make sure they can never be misaligned and to make the interpreter timeout configurable.

This PR also adds `nextest` configuration because it's great. It won't be the default runner in CI nor required for tests but it likely will be soon.

Closes #184 