### PR TITLE
Updated build jobs to centralize configuration

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -3,3 +3,9 @@ rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
 
 [target.aarch64-apple-darwin]
 rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
+
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"
+
+[target.x86_64-pc-windows-gnu]
+linker = "x86_64-w64-mingw32-gcc"

--- a/.github/workflows/mono_workflow.yaml
+++ b/.github/workflows/mono_workflow.yaml
@@ -2,9 +2,9 @@ name: mono-workflow
 on:
   push:
     tags:
-      - "[0-9]+.[0-9]+.[0-9]+" # matches 0.1.0, 0.2.1, etc.
+      - '[0-9]+.[0-9]+.[0-9]+' # matches 0.1.0, 0.2.1, etc.
   schedule:
-    - cron: "0 1 * * *" # 1am UTC
+    - cron: '0 1 * * *' # 1am UTC
   pull_request:
     branches:
       - main
@@ -45,34 +45,34 @@ jobs:
     env:
       SCCACHE_AZURE_BLOB_CONTAINER: ${{ secrets.SCCACHE_AZURE_BLOB_CONTAINER }}
       SCCACHE_AZURE_CONNECTION_STRING: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
-      SCCACHE_AZURE_KEY_PREFIX: "wick-github-actions-test"
-      RUSTC_WRAPPER: "sccache"
+      SCCACHE_AZURE_KEY_PREFIX: 'wick-github-actions-test'
+      RUSTC_WRAPPER: 'sccache'
     strategy:
       matrix:
         config:
           - {
-              os: "ubuntu-latest",
-              name: "linux",
-              arch: "amd64",
-              target: "x86_64-unknown-linux-gnu",
+              os: 'ubuntu-latest',
+              name: 'linux',
+              arch: 'amd64',
+              target: 'x86_64-unknown-linux-gnu',
+            }
+          - {
+              os: 'ubuntu-latest',
+              name: 'linux',
+              target: 'aarch64-unknown-linux-gnu',
+              arch: 'aarch64',
             }
           # - {
-          #     os: "ubuntu-latest",
-          #     name: "linux",
-          #     target: "aarch64-unknown-linux-gnu",
-          #     arch: "aarch64",
+          #     os: 'macos-latest',
+          #     name: 'macos',
+          #     target: 'x86_64-apple-darwin',
+          #     arch: 'amd64',
           #   }
           # - {
-          #     os: "macos-latest",
-          #     name: "macos",
-          #     target: "x86_64-apple-darwin",
-          #     arch: "amd64",
-          #   }
-          # - {
-          #     os: "macos-latest",
-          #     name: "macos",
-          #     target: "aarch64-apple-darwin",
-          #     arch: "aarch64",
+          #     os: 'macos-latest',
+          #     name: 'macos',
+          #     target: 'aarch64-apple-darwin',
+          #     arch: 'aarch64',
           #   }
           # - {
           #     os: "ubuntu-latest",
@@ -97,8 +97,6 @@ jobs:
         run: |
           sudo apt update
           sudo apt install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu pkg-config
-          echo '[target.aarch64-unknown-linux-gnu]' >> ${HOME}/.cargo/config.toml
-          echo 'linker = "aarch64-linux-gnu-gcc"' >> ${HOME}/.cargo/config.toml
           echo "PKG_CONFIG_SYSROOT_DIR=/usr/aarch64-linux-gnu" >> $GITHUB_ENV
           echo "PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig" >> $GITHUB_ENV
           echo "PKG_CONFIG_ALLOW_CROSS=1" >> $GITHUB_ENV
@@ -107,8 +105,6 @@ jobs:
         run: |
           sudo apt update
           sudo apt install mingw-w64
-          echo '[target.x86_64-pc-windows-gnu]' >> ${HOME}/.cargo/config.toml
-          echo 'linker = "x86_64-w64-mingw32-gcc"' >> ${HOME}/.cargo/config.toml
           echo "PKG_CONFIG_SYSROOT_DIR=/usr/x86_64-w64-mingw32" >> $GITHUB_ENV
           echo "PKG_CONFIG_PATH=/usr/lib/x86_64-w64-mingw32/pkgconfig" >> $GITHUB_ENV
           echo "PKG_CONFIG_ALLOW_CROSS=1" >> $GITHUB_ENV
@@ -141,14 +137,11 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.68.0
-          default: true
           target: ${{ matrix.config.target }}
-          components: rustfmt, clippy, rustc, cargo, rust-docs, rust-std
-      - name: "rustup updates"
+      - name: 'rustup updates'
         run: |
           rustup target add wasm32-unknown-unknown wasm32-wasi
-          cargo install tomlq cargo-deny just
+          cargo install cargo-deny just
       #Updating rustup updates means that the github cache needs to be manually deleted.
       - name: Run just ci-tests
         id: just-ci-test
@@ -161,40 +154,40 @@ jobs:
     env:
       SCCACHE_AZURE_BLOB_CONTAINER: ${{ secrets.SCCACHE_AZURE_BLOB_CONTAINER }}
       SCCACHE_AZURE_CONNECTION_STRING: ${{ secrets.SCCACHE_AZURE_CONNECTION_STRING }}
-      SCCACHE_AZURE_KEY_PREFIX: "wick-github-actions"
-      RUSTC_WRAPPER: "sccache"
-      CARGO_PROFILE_RELEASE_DEBUG: "0" # https://doc.rust-lang.org/cargo/reference/profiles.html#debug
-      CARGO_INCREMENTAL: "true" # https://doc.rust-lang.org/cargo/reference/profiles.html#incremental
-      CARGO_PROFILE_RELEASE_LTO: "true" # https://doc.rust-lang.org/cargo/reference/profiles.html#lto
-      CARGO_PROFILE_RELEASE_OPT_LEVEL: "3" # https://doc.rust-lang.org/cargo/reference/profiles.html#opt-level
-      CARGO_PROFILE_RELEASE_CODEGEN_UNITS: "1" # https://doc.rust-lang.org/cargo/reference/profiles.html#codegen-units
-      CARGO_PROFILE_RELEASE_STRIP: "true" # https://doc.rust-lang.org/cargo/reference/unstable.html#profile-strip-option
+      SCCACHE_AZURE_KEY_PREFIX: 'wick-github-actions'
+      RUSTC_WRAPPER: 'sccache'
+      CARGO_PROFILE_RELEASE_DEBUG: '0' # https://doc.rust-lang.org/cargo/reference/profiles.html#debug
+      CARGO_INCREMENTAL: 'true' # https://doc.rust-lang.org/cargo/reference/profiles.html#incremental
+      CARGO_PROFILE_RELEASE_LTO: 'true' # https://doc.rust-lang.org/cargo/reference/profiles.html#lto
+      CARGO_PROFILE_RELEASE_OPT_LEVEL: '3' # https://doc.rust-lang.org/cargo/reference/profiles.html#opt-level
+      CARGO_PROFILE_RELEASE_CODEGEN_UNITS: '1' # https://doc.rust-lang.org/cargo/reference/profiles.html#codegen-units
+      CARGO_PROFILE_RELEASE_STRIP: 'true' # https://doc.rust-lang.org/cargo/reference/unstable.html#profile-strip-option
     strategy:
       matrix:
         config:
           - {
-              os: "ubuntu-latest",
-              name: "linux",
-              arch: "amd64",
-              target: "x86_64-unknown-linux-gnu",
+              os: 'ubuntu-latest',
+              name: 'linux',
+              arch: 'amd64',
+              target: 'x86_64-unknown-linux-gnu',
             }
           - {
-              os: "ubuntu-latest",
-              name: "linux",
-              target: "aarch64-unknown-linux-gnu",
-              arch: "aarch64",
+              os: 'ubuntu-latest',
+              name: 'linux',
+              target: 'aarch64-unknown-linux-gnu',
+              arch: 'aarch64',
             }
           - {
-              os: "macos-latest",
-              name: "macos",
-              target: "x86_64-apple-darwin",
-              arch: "amd64",
+              os: 'macos-latest',
+              name: 'macos',
+              target: 'x86_64-apple-darwin',
+              arch: 'amd64',
             }
           - {
-              os: "macos-latest",
-              name: "macos",
-              target: "aarch64-apple-darwin",
-              arch: "aarch64",
+              os: 'macos-latest',
+              name: 'macos',
+              target: 'aarch64-apple-darwin',
+              arch: 'aarch64',
             }
           # - {
           #     os: "ubuntu-latest",
@@ -213,8 +206,6 @@ jobs:
         run: |
           sudo apt update
           sudo apt install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu pkg-config
-          echo '[target.aarch64-unknown-linux-gnu]' >> ${HOME}/.cargo/config.toml
-          echo 'linker = "aarch64-linux-gnu-gcc"' >> ${HOME}/.cargo/config.toml
           echo "PKG_CONFIG_SYSROOT_DIR=/usr/aarch64-linux-gnu" >> $GITHUB_ENV
           echo "PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig" >> $GITHUB_ENV
           echo "PKG_CONFIG_ALLOW_CROSS=1" >> $GITHUB_ENV
@@ -223,8 +214,6 @@ jobs:
         run: |
           sudo apt update
           sudo apt install mingw-w64
-          echo '[target.x86_64-pc-windows-gnu]' >> ${HOME}/.cargo/config.toml
-          echo 'linker = "x86_64-w64-mingw32-gcc"' >> ${HOME}/.cargo/config.toml
           echo "PKG_CONFIG_SYSROOT_DIR=/usr/x86_64-w64-mingw32" >> $GITHUB_ENV
           echo "PKG_CONFIG_PATH=/usr/lib/x86_64-w64-mingw32/pkgconfig" >> $GITHUB_ENV
           echo "PKG_CONFIG_ALLOW_CROSS=1" >> $GITHUB_ENV
@@ -257,20 +246,12 @@ jobs:
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.68.0
-          default: true
           target: ${{ matrix.config.target }}
-          components: rustfmt, clippy, rustc, cargo, rust-docs, rust-std
-      - name: "rustup updates"
-        run: |
-          rustup target add wasm32-unknown-unknown wasm32-wasi
-          cargo install tomlq cargo-deny just
-      #Updating rustup updates means that the github cache needs to be manually deleted.
-      - name: "build binary"
+      - name: 'build binary'
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release -p wick --target=${{ matrix.config.target }} --features openssl/vendored
+          args: --release -p wick --target=${{ matrix.config.target }}
       - name: package release assets
         if: matrix.config.target != 'x86_64-pc-windows-gnu'
         run: |
@@ -304,8 +285,6 @@ jobs:
     needs: [test, build]
     steps:
       - uses: actions/checkout@v3
-      - name: Install jq
-        run: sudo apt-get install -y jq
       - name: Download artifacts
         uses: actions/download-artifact@v3
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -81,64 +81,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-channel"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf46fee83e5ccffc220104713af3292ff9bc7c64c7de289f66dae8e38d826833"
-dependencies = [
- "concurrent-queue",
- "event-listener",
- "futures-core",
-]
-
-[[package]]
-name = "async-io"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc5b45d93ef0529756f812ca52e44c221b35341892d3dcc34132ac02f3dd2af"
-dependencies = [
- "async-lock",
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-lite",
- "log",
- "parking",
- "polling",
- "rustix 0.37.7",
- "slab",
- "socket2",
- "waker-fn",
-]
-
-[[package]]
-name = "async-lock"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa24f727524730b077666307f2734b4a1a1c57acb79193127dcc8914d5242dd7"
-dependencies = [
- "event-listener",
-]
-
-[[package]]
-name = "async-process"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6381ead98388605d0d9ff86371043b5aa922a3905824244de40dc263a14fcba4"
-dependencies = [
- "async-io",
- "async-lock",
- "autocfg",
- "blocking",
- "cfg-if",
- "event-listener",
- "futures-lite",
- "libc",
- "signal-hook",
- "windows-sys 0.42.0",
-]
-
-[[package]]
 name = "async-recursion"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,12 +114,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-task"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc7ab41815b3c653ccd2978ec3255c81349336702dfdf62ee6f7069b12a3aae"
-
-[[package]]
 name = "async-trait"
 version = "0.1.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,12 +132,6 @@ checksum = "e3ff7eb3f316534d83a8a2c3d1674ace8a5a71198eba31e2e2b597833f699b28"
 dependencies = [
  "critical-section",
 ]
-
-[[package]]
-name = "atomic-waker"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "debc29dde2e69f9e47506b525f639ed42300fc014a3e007832592448fa8e4599"
 
 [[package]]
 name = "atty"
@@ -317,20 +247,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "blocking"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c67b173a56acffd6d2326fb7ab938ba0b00a71480e14902b2591c87bc5741e8"
-dependencies = [
- "async-channel",
- "async-lock",
- "async-task",
- "atomic-waker",
- "fastrand",
- "futures-lite",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -375,7 +291,7 @@ dependencies = [
  "io-lifetimes",
  "ipnet",
  "maybe-owned",
- "rustix 0.36.9",
+ "rustix",
  "windows-sys 0.45.0",
  "winx",
 ]
@@ -400,7 +316,7 @@ dependencies = [
  "io-extras",
  "io-lifetimes",
  "ipnet",
- "rustix 0.36.9",
+ "rustix",
 ]
 
 [[package]]
@@ -411,7 +327,7 @@ checksum = "472931750f90fbf0731c886c2937521e25772942577a182e7ace5bc561d10e3b"
 dependencies = [
  "cap-primitives",
  "once_cell",
- "rustix 0.36.9",
+ "rustix",
  "winx",
 ]
 
@@ -441,21 +357,6 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
-dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim 0.8.0",
- "textwrap 0.11.0",
- "unicode-width",
- "vec_map",
-]
-
-[[package]]
-name = "clap"
 version = "3.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
@@ -466,9 +367,9 @@ dependencies = [
  "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
- "textwrap 0.16.0",
+ "textwrap",
 ]
 
 [[package]]
@@ -482,7 +383,7 @@ dependencies = [
  "clap_lex 0.3.2",
  "is-terminal",
  "once_cell",
- "strsim 0.10.0",
+ "strsim",
  "termcolor",
 ]
 
@@ -546,15 +447,6 @@ name = "concolor-query"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a90734b3d5dcf656e7624cca6bce9c3a90ee11f900e80141a7427ccfb3d317"
-
-[[package]]
-name = "concurrent-queue"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c278839b831783b70278b14df4d45e1beb1aad306c07bb796637de9a0e323e8e"
-dependencies = [
- "crossbeam-utils",
-]
 
 [[package]]
 name = "const-oid"
@@ -991,17 +883,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "errno"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d6a0976c999d473fe89ad888d5a284e55366d9dc9038b1ba2aa15128c4afa0"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "windows-sys 0.45.0",
-]
-
-[[package]]
 name = "errno-dragonfly"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1010,12 +891,6 @@ dependencies = [
  "cc",
  "libc",
 ]
-
-[[package]]
-name = "event-listener"
-version = "2.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
 name = "fallible-iterator"
@@ -1039,7 +914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ef1a30ae415c3a691a4f41afddc2dbcd6d70baf338368d85ebc1e8ed92cedb9"
 dependencies = [
  "cfg-if",
- "rustix 0.36.9",
+ "rustix",
  "windows-sys 0.45.0",
 ]
 
@@ -1110,7 +985,6 @@ dependencies = [
  "flow-expression-parser",
  "flow-graph",
  "futures",
- "integra8",
  "logger",
  "parking_lot",
  "performance-mark",
@@ -1173,7 +1047,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "857cf27edcb26c2a36d84b2954019573d335bb289876113aceacacdca47a4fd4"
 dependencies = [
  "io-lifetimes",
- "rustix 0.36.9",
+ "rustix",
  "windows-sys 0.45.0",
 ]
 
@@ -1224,21 +1098,6 @@ name = "futures-io"
 version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89d422fa3cbe3b40dca574ab087abb5bc98258ea57eea3fd6f1fa7162c778b91"
-
-[[package]]
-name = "futures-lite"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694489acd39452c77daa48516b894c153f192c3578d5a839b62c58099fcbf48"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "memchr",
- "parking",
- "pin-project-lite",
- "waker-fn",
-]
 
 [[package]]
 name = "futures-macro"
@@ -1646,49 +1505,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
-name = "integra8"
-version = "0.0.5-rc1"
-source = "git+https://github.com/jamesjharper/integra8.git#461f494132c362fd6377fb30179c6db80b2720d8"
-dependencies = [
- "async-process",
- "async-trait",
- "futures",
- "humantime",
- "indexmap",
- "integra8_decorations_impl",
- "integra8_impl",
- "linkme",
- "num_cpus",
- "serde",
- "serde_json",
- "structopt",
- "tokio",
-]
-
-[[package]]
-name = "integra8_decorations_impl"
-version = "0.0.5-rc1"
-source = "git+https://github.com/jamesjharper/integra8.git#461f494132c362fd6377fb30179c6db80b2720d8"
-dependencies = [
- "humantime",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "integra8_impl"
-version = "0.0.5-rc1"
-source = "git+https://github.com/jamesjharper/integra8.git#461f494132c362fd6377fb30179c6db80b2720d8"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "io-extras"
 version = "0.17.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1722,7 +1538,7 @@ checksum = "21b6b32576413a8e69b90e952e4a026476040d81017b80445deda5f2d3921857"
 dependencies = [
  "hermit-abi 0.3.1",
  "io-lifetimes",
- "rustix 0.36.9",
+ "rustix",
  "windows-sys 0.45.0",
 ]
 
@@ -1841,36 +1657,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
 
 [[package]]
-name = "linkme"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd4ad156b9934dc21cad96fd17278a7cb6f30a5657a9d976cd7b71d6d49c02c"
-dependencies = [
- "linkme-impl",
-]
-
-[[package]]
-name = "linkme-impl"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73fd9dc7072de7168cbdaba9125e8f742cd3a965aa12bde994b4611a174488d8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
 
 [[package]]
 name = "lock_api"
@@ -1966,7 +1756,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b20a59d985586e4a5aef64564ac77299f8586d8be6cf9106a5a40207e8908efb"
 dependencies = [
- "rustix 0.36.9",
+ "rustix",
 ]
 
 [[package]]
@@ -2368,12 +2158,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
 
 [[package]]
-name = "parking"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "427c3892f9e783d91cc128285287e70a59e206ca452770ece88a76f7a3eddd72"
-
-[[package]]
 name = "parking_lot"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2485,22 +2269,6 @@ name = "pkg-config"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
-
-[[package]]
-name = "polling"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e1f879b2998099c2d69ab9605d145d5b661195627eccc680002c4918a7fb6fa"
-dependencies = [
- "autocfg",
- "bitflags",
- "cfg-if",
- "concurrent-queue",
- "libc",
- "log",
- "pin-project-lite",
- "windows-sys 0.45.0",
-]
 
 [[package]]
 name = "ppv-lite86"
@@ -2853,26 +2621,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd5c6ff11fecd55b40746d1995a02f2eb375bf8c00d192d521ee09f42bef37bc"
 dependencies = [
  "bitflags",
- "errno 0.2.8",
+ "errno",
  "io-lifetimes",
  "itoa",
  "libc",
- "linux-raw-sys 0.1.4",
+ "linux-raw-sys",
  "once_cell",
- "windows-sys 0.45.0",
-]
-
-[[package]]
-name = "rustix"
-version = "0.37.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aae838e49b3d63e9274e1c01833cc8139d3fec468c3b84688c628f44b1ae11d"
-dependencies = [
- "bitflags",
- "errno 0.3.0",
- "io-lifetimes",
- "libc",
- "linux-raw-sys 0.3.1",
  "windows-sys 0.45.0",
 ]
 
@@ -3188,16 +2942,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
-name = "signal-hook"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "732768f1176d21d09e076c23a93123d40bba92d50c4058da34d45c8de8e682b9"
-dependencies = [
- "libc",
- "signal-hook-registry",
-]
-
-[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3321,39 +3065,9 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "structopt"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c6b5c64445ba8094a6ab0c3cd2ad323e07171012d9c98b0b15651daf1787a10"
-dependencies = [
- "clap 2.34.0",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck 0.3.3",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
 
 [[package]]
 name = "strum"
@@ -3434,7 +3148,7 @@ dependencies = [
  "cap-std",
  "fd-lock",
  "io-lifetimes",
- "rustix 0.36.9",
+ "rustix",
  "windows-sys 0.45.0",
  "winx",
 ]
@@ -3473,7 +3187,7 @@ dependencies = [
  "cfg-if",
  "fastrand",
  "redox_syscall",
- "rustix 0.36.9",
+ "rustix",
  "windows-sys 0.42.0",
 ]
 
@@ -3538,15 +3252,6 @@ name = "testanything"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3267904a41217696eb8e16fb2b50f42ebe764c67deee46016dbdd18cd546453"
-
-[[package]]
-name = "textwrap"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
 
 [[package]]
 name = "textwrap"
@@ -4117,12 +3822,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
-
-[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4136,12 +3835,6 @@ checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "waker-fn"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
 
 [[package]]
 name = "walkdir"
@@ -4234,7 +3927,7 @@ dependencies = [
  "io-lifetimes",
  "is-terminal",
  "once_cell",
- "rustix 0.36.9",
+ "rustix",
  "system-interface",
  "tracing",
  "wasi-common",
@@ -4253,7 +3946,7 @@ dependencies = [
  "cap-std",
  "io-extras",
  "log",
- "rustix 0.36.9",
+ "rustix",
  "thiserror",
  "tracing",
  "wasmtime",
@@ -4576,7 +4269,7 @@ dependencies = [
  "directories-next",
  "file-per-thread-logger",
  "log",
- "rustix 0.36.9",
+ "rustix",
  "serde",
  "sha2 0.10.6",
  "toml",
@@ -4653,7 +4346,7 @@ checksum = "01b1192624694399f601de28db78975ed20fa859da8e048bf8250bd3b38d302b"
 dependencies = [
  "cc",
  "cfg-if",
- "rustix 0.36.9",
+ "rustix",
  "wasmtime-asm-macros",
  "windows-sys 0.45.0",
 ]
@@ -4691,7 +4384,7 @@ checksum = "17e35d335dd2461c631ba24d2326d993bd3a4bdb4b0217e5bda4f518ba0e29f3"
 dependencies = [
  "object",
  "once_cell",
- "rustix 0.36.9",
+ "rustix",
 ]
 
 [[package]]
@@ -4722,7 +4415,7 @@ dependencies = [
  "memoffset",
  "paste",
  "rand",
- "rustix 0.36.9",
+ "rustix",
  "wasmtime-asm-macros",
  "wasmtime-environ",
  "wasmtime-fiber",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4851,7 +4851,6 @@ dependencies = [
  "markup-converter",
  "nkeys",
  "oci-distribution",
- "openssl",
  "regex",
  "seeded-random",
  "serde",

--- a/crates/bins/wick/Cargo.toml
+++ b/crates/bins/wick/Cargo.toml
@@ -41,7 +41,6 @@ oci-distribution = { workspace = true, features = [
   "rustls-tls",
 ], default-features = false }
 async-recursion = { workspace = true }
-openssl = { workspace = true } #required for cross compilation (don't remove)
 
 [dev-dependencies]
 test_bin = { workspace = true }

--- a/crates/wick/flow-graph-interpreter/Cargo.toml
+++ b/crates/wick/flow-graph-interpreter/Cargo.toml
@@ -31,7 +31,6 @@ serde-value = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 rand = { workspace = true }
 bytes = { workspace = true }
-integra8 = { git = "https://github.com/jamesjharper/integra8.git" }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/wick/wick-component-cli/Cargo.toml
+++ b/crates/wick/wick-component-cli/Cargo.toml
@@ -49,6 +49,6 @@ logger = { workspace = true }
 test-logger = { workspace = true }
 test-native-component = { workspace = true }
 once_cell = { workspace = true }
-reqwest = { workspace = true, features = ["json"] }
+reqwest = { workspace = true, features = ["json"], default-features = false }
 anyhow = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/wick/wick-package/Cargo.toml
+++ b/crates/wick/wick-package/Cargo.toml
@@ -10,7 +10,9 @@ repository = "https://github.com/candlecorp/wick"
 wick-config = { workspace = true }
 wick-oci-utils = { workspace = true }
 assets = { workspace = true }
-oci-distribution = { workspace = true, features = ["rustls-tls"] }
+oci-distribution = { workspace = true, features = [
+  "rustls-tls"
+], default-features = false }
 thiserror = { workspace = true }
 tracing = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/wick/wick-rpc/Cargo.toml
+++ b/crates/wick/wick-rpc/Cargo.toml
@@ -31,7 +31,6 @@ uuid = { workspace = true }
 [build-dependencies]
 tonic-build = { workspace = true, default-features = false, features = [
   "prost",
-  "transport",
 ] }
 
 [dev-dependencies]

--- a/crates/wick/wick-runtime/Cargo.toml
+++ b/crates/wick/wick-runtime/Cargo.toml
@@ -55,5 +55,5 @@ futures = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 tokio = { workspace = true, features = ["time"] }
-reqwest = { workspace = true }
+reqwest = { workspace = true, default-features = false }
 wasmrs-codec = { workspace = true }

--- a/crates/wick/wick-test/Cargo.toml
+++ b/crates/wick/wick-test/Cargo.toml
@@ -28,7 +28,4 @@ tracing = { workspace = true }
 logger = { workspace = true }
 test-logger = { workspace = true }
 test-native-component = { workspace = true }
-# once_cell = { workspace = true }
-# reqwest = { workspace = true, features = ["json"] }
 anyhow = { workspace = true }
-# serde_json = { workspace = true }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.68.2" #changing this means you need to change the github actions workflows as well
+channel = "1.68.2"
 components = ["rustfmt", "clippy"]
 targets = ["wasm32-unknown-unknown", "wasm32-wasi"]


### PR DESCRIPTION
This PR updates the mono_workflow to defer to `rust-toolchain.toml` or cargo config when possible.