### PR TITLE
Added reverse proxy router

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2235,6 +2235,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-reverse-proxy"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc1af9b1b483fb9f33bd1cda26b35eacf902f0d116fcf0d56075ea5e5923b935"
+dependencies = [
+ "hyper",
+ "lazy_static",
+ "unicase",
+]
+
+[[package]]
 name = "hyper-rustls"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6605,6 +6616,7 @@ dependencies = [
  "flow-graph-interpreter",
  "futures",
  "hyper",
+ "hyper-reverse-proxy",
  "hyper-staticfile",
  "lazy_static",
  "once_cell",

--- a/crates/wick/wick-config/definitions/v1/manifest.apex
+++ b/crates/wick/wick-config/definitions/v1/manifest.apex
@@ -96,7 +96,18 @@ type HttpTrigger @tagged("wick/trigger/http@v1") {
   routers: [HttpRouter]
 }
 
-union HttpRouter = RawRouter | RestRouter | StaticRouter
+union HttpRouter = RawRouter | RestRouter | StaticRouter | ProxyRouter
+
+type ProxyRouter @tagged("wick/router/proxy@v1") {
+  "The path to start serving this router from."
+  path: string @required
+
+  "The URL resource to proxy to."
+  url: string @required
+
+  "Whether or not to strip the router's path from the proxied request."
+  strip_path: bool
+}
 
 type RestRouter @tagged("wick/router/rest@v1") {
   "The path to start serving this router from."

--- a/crates/wick/wick-config/docs/v1.html
+++ b/crates/wick/wick-config/docs/v1.html
@@ -423,6 +423,55 @@
 </div></div></div><div class="definition">## unhandled
     panic!()</div><div class="definition">
 <h2 class="definition-name type-name">
+  <a name="ProxyRouter">ProxyRouter</a>
+</h2>
+
+
+<div class=fields>
+<div class=field>
+
+<h3 class=field-name>
+  <a name="path">path</a>
+</h3>
+
+<span class="description field-description">The path to start serving this router from.</span>
+
+
+<ul class="field-notes">
+<li><span class="type field-note">Type: <span class=field-type>string</span></span></li>
+<li><span class="annotation field-note">Required</span></li>
+
+</ul>
+</div><div class=field>
+
+<h3 class=field-name>
+  <a name="url">url</a>
+</h3>
+
+<span class="description field-description">The URL resource to proxy to.</span>
+
+
+<ul class="field-notes">
+<li><span class="type field-note">Type: <span class=field-type>string</span></span></li>
+<li><span class="annotation field-note">Required</span></li>
+
+</ul>
+</div><div class=field>
+
+<h3 class=field-name>
+  <a name="strip_path">strip_path</a>
+</h3>
+
+<span class="description field-description">Whether or not to strip the router's path from the proxied request.</span>
+
+
+<ul class="field-notes">
+<li><span class="type field-note">Type: <span class=field-type>bool</span></span></li>
+
+
+</ul>
+</div></div></div><div class="definition">
+<h2 class="definition-name type-name">
   <a name="RestRouter">RestRouter</a>
 </h2>
 

--- a/crates/wick/wick-config/json-schema/manifest.json
+++ b/crates/wick/wick-config/json-schema/manifest.json
@@ -632,7 +632,39 @@
           },
           {
             "$ref": "#/$defs/v1/StaticRouter"
+          },
+          {
+            "$ref": "#/$defs/v1/ProxyRouter"
           }
+        ]
+      },
+      "ProxyRouter": {
+        "$anchor": "#v1/ProxyRouter",
+        "additionalProperties": false,
+        "properties": {
+          "kind": {
+            "type": "string",
+            "description": "The kind of the collection",
+            "enum": [
+              "wick/router/proxy@v1"
+            ]
+          },
+          "path": {
+            "description": "The path to start serving this router from.",
+            "type": "string"
+          },
+          "url": {
+            "description": "The URL resource to proxy to.",
+            "type": "string"
+          },
+          "strip_path": {
+            "description": "Whether or not to strip the router&#x27;s path from the proxied request.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "path",
+          "url"
         ]
       },
       "RestRouter": {

--- a/crates/wick/wick-config/json-schema/v1/manifest.json
+++ b/crates/wick/wick-config/json-schema/v1/manifest.json
@@ -272,8 +272,37 @@
       "oneOf": [
         { "$ref": "#/$defs/v1/RawRouter" },
         { "$ref": "#/$defs/v1/RestRouter" },
-        { "$ref": "#/$defs/v1/StaticRouter" }
+        { "$ref": "#/$defs/v1/StaticRouter" },
+        { "$ref": "#/$defs/v1/ProxyRouter" }
       ]
+    },
+
+    "ProxyRouter": {
+      "$anchor": "#v1/ProxyRouter",
+      "additionalProperties": false,
+      "properties": {
+        "kind": {
+          "type": "string",
+          "description": "The kind of the collection",
+          "enum": ["wick/router/proxy@v1"]
+        },
+        "path": {
+          "description": "The path to start serving this router from.",
+
+          "type": "string"
+        },
+        "url": {
+          "description": "The URL resource to proxy to.",
+
+          "type": "string"
+        },
+        "strip_path": {
+          "description": "Whether or not to strip the router&#x27;s path from the proxied request.",
+
+          "type": "boolean"
+        }
+      },
+      "required": ["path", "url"]
     },
 
     "RestRouter": {

--- a/crates/wick/wick-config/src/config/app_config/resources.rs
+++ b/crates/wick/wick-config/src/config/app_config/resources.rs
@@ -105,6 +105,12 @@ impl UrlResource {
     Self { url }
   }
 
+  /// Get the URL.
+  #[must_use]
+  pub fn into_inner(self) -> Url {
+    self.url
+  }
+
   /// Get the scheme
   #[must_use]
   pub fn scheme(&self) -> &str {
@@ -145,6 +151,14 @@ impl UrlResource {
     self
       .port()
       .map_or_else(|| self.host().to_owned(), |port| format!("{}:{}", self.host(), port))
+  }
+}
+
+impl std::ops::Deref for UrlResource {
+  type Target = Url;
+
+  fn deref(&self) -> &Self::Target {
+    &self.url
   }
 }
 

--- a/crates/wick/wick-config/src/config/app_config/triggers.rs
+++ b/crates/wick/wick-config/src/config/app_config/triggers.rs
@@ -1,6 +1,13 @@
 use serde_json::Value;
 
 use crate::config::*;
+mod cli;
+mod http;
+mod time;
+
+pub use cli::*;
+pub use http::*;
+pub use time::*;
 
 #[derive(Debug, Clone, derive_asset_container::AssetManager)]
 #[asset(AssetReference)]
@@ -50,156 +57,6 @@ impl std::fmt::Display for TriggerKind {
 
 #[derive(Debug, Clone, PartialEq, derive_asset_container::AssetManager)]
 #[asset(AssetReference)]
-
-/// Normalized representation of a CLI trigger configuration.
-pub struct CliConfig {
-  pub(crate) operation: ComponentOperationExpression,
-  pub(crate) app: Option<ComponentDefinition>,
-}
-
-#[derive(Debug, Clone, derive_asset_container::AssetManager)]
-#[asset(AssetReference)]
-#[must_use]
-pub struct HttpTriggerConfig {
-  #[asset(skip)]
-  pub(crate) resource: String,
-  pub(crate) routers: Vec<HttpRouterConfig>,
-}
-
-impl HttpTriggerConfig {
-  #[must_use]
-  pub fn resource_id(&self) -> &str {
-    &self.resource
-  }
-  pub fn routers(&self) -> &[HttpRouterConfig] {
-    &self.routers
-  }
-}
-
-#[derive(Debug, Clone, derive_asset_container::AssetManager)]
-#[asset(AssetReference)]
-#[must_use]
-pub struct RawRouterConfig {
-  #[asset(skip)]
-  pub(crate) path: String,
-  pub(crate) operation: ComponentOperationExpression,
-}
-
-impl RawRouterConfig {
-  #[must_use]
-  pub fn path(&self) -> &str {
-    &self.path
-  }
-  #[must_use]
-  pub fn operation(&self) -> &ComponentOperationExpression {
-    &self.operation
-  }
-}
-
-#[derive(Debug, Clone, derive_asset_container::AssetManager)]
-#[asset(AssetReference)]
-#[must_use]
-pub struct RestRouterConfig {
-  #[asset(skip)]
-  pub(crate) path: String,
-  pub(crate) component: ComponentDefinition,
-}
-
-impl RestRouterConfig {
-  #[must_use]
-  pub fn path(&self) -> &str {
-    &self.path
-  }
-  pub fn component(&self) -> &ComponentDefinition {
-    &self.component
-  }
-}
-
-#[derive(Debug, Clone, derive_asset_container::AssetManager)]
-#[asset(AssetReference)]
-#[must_use]
-pub struct StaticRouterConfig {
-  #[asset(skip)]
-  pub(crate) path: String,
-  #[asset(skip)]
-  pub(crate) volume: String,
-}
-
-impl StaticRouterConfig {
-  /// Returns the path for the static router.
-  #[must_use]
-  pub fn path(&self) -> &str {
-    &self.path
-  }
-  /// Returns the volume name for the static router.
-  #[must_use]
-  pub fn volume(&self) -> &str {
-    &self.volume
-  }
-}
-
-#[derive(Debug, Clone, derive_asset_container::AssetManager)]
-#[asset(AssetReference)]
-#[must_use]
-pub enum HttpRouterConfig {
-  RawRouter(RawRouterConfig),
-  RestRouter(RestRouterConfig),
-  StaticRouter(StaticRouterConfig),
-}
-
-impl CliConfig {
-  /// Returns the component id for the CLI trigger.
-  pub fn component(&self) -> &ComponentDefinition {
-    &self.operation.component
-  }
-
-  /// Returns the operation name for the CLI trigger.
-  #[must_use]
-  pub fn operation(&self) -> &str {
-    &self.operation.operation
-  }
-
-  /// Returns the app definition for the CLI trigger.
-  #[must_use]
-  pub fn app(&self) -> Option<&ComponentDefinition> {
-    self.app.as_ref()
-  }
-}
-
-#[derive(Debug, Clone, PartialEq, derive_asset_container::AssetManager)]
-#[asset(AssetReference)]
-/// Normalized representation of a Time trigger configuration.
-pub struct TimeTriggerConfig {
-  pub(crate) schedule: ScheduleConfig,
-  pub(crate) operation: ComponentOperationExpression,
-  #[asset(skip)]
-  pub(crate) payload: Vec<OperationInputConfig>,
-}
-
-impl TimeTriggerConfig {
-  /// Returns the component id for the Time trigger.
-  pub fn component(&self) -> &ComponentDefinition {
-    &self.operation.component
-  }
-
-  /// Returns the payload for the Time trigger.
-  #[must_use]
-  pub fn payload(&self) -> &Vec<OperationInputConfig> {
-    &self.payload
-  }
-
-  /// Returns the operation name for the Time trigger.
-  #[must_use]
-  pub fn operation(&self) -> &str {
-    &self.operation.operation
-  }
-  pub fn schedule(&self) -> &ScheduleConfig {
-    &self.schedule
-  }
-}
-
-#[derive(Debug, Clone, PartialEq, derive_asset_container::AssetManager)]
-#[asset(AssetReference)]
 #[must_use]
 
 pub struct OperationInputConfig {
@@ -218,27 +75,5 @@ impl OperationInputConfig {
   #[must_use]
   pub fn value(&self) -> &Value {
     &self.value
-  }
-}
-
-#[derive(Debug, Clone, PartialEq, derive_asset_container::AssetManager)]
-#[asset(AssetReference)]
-#[must_use]
-pub struct ScheduleConfig {
-  #[asset(skip)]
-  pub(crate) cron: String,
-  #[asset(skip)]
-  pub(crate) repeat: u16,
-}
-
-impl ScheduleConfig {
-  #[must_use]
-  pub fn cron(&self) -> &String {
-    &self.cron
-  }
-
-  #[must_use]
-  pub fn repeat(&self) -> u16 {
-    self.repeat
   }
 }

--- a/crates/wick/wick-config/src/config/app_config/triggers/cli.rs
+++ b/crates/wick/wick-config/src/config/app_config/triggers/cli.rs
@@ -1,0 +1,31 @@
+use wick_asset_reference::AssetReference;
+
+use crate::config::{ComponentDefinition, ComponentOperationExpression};
+
+#[derive(Debug, Clone, PartialEq, derive_asset_container::AssetManager)]
+#[asset(AssetReference)]
+
+/// Normalized representation of a CLI trigger configuration.
+pub struct CliConfig {
+  pub(crate) operation: ComponentOperationExpression,
+  pub(crate) app: Option<ComponentDefinition>,
+}
+
+impl CliConfig {
+  /// Returns the component id for the CLI trigger.
+  pub fn component(&self) -> &ComponentDefinition {
+    &self.operation.component
+  }
+
+  /// Returns the operation name for the CLI trigger.
+  #[must_use]
+  pub fn operation(&self) -> &str {
+    &self.operation.operation
+  }
+
+  /// Returns the app definition for the CLI trigger.
+  #[must_use]
+  pub fn app(&self) -> Option<&ComponentDefinition> {
+    self.app.as_ref()
+  }
+}

--- a/crates/wick/wick-config/src/config/app_config/triggers/http.rs
+++ b/crates/wick/wick-config/src/config/app_config/triggers/http.rs
@@ -1,0 +1,126 @@
+use wick_asset_reference::AssetReference;
+
+use crate::config::{ComponentDefinition, ComponentOperationExpression};
+
+#[derive(Debug, Clone, derive_asset_container::AssetManager)]
+#[asset(AssetReference)]
+#[must_use]
+pub struct HttpTriggerConfig {
+  #[asset(skip)]
+  pub(crate) resource: String,
+  pub(crate) routers: Vec<HttpRouterConfig>,
+}
+
+impl HttpTriggerConfig {
+  #[must_use]
+  pub fn resource_id(&self) -> &str {
+    &self.resource
+  }
+  pub fn routers(&self) -> &[HttpRouterConfig] {
+    &self.routers
+  }
+}
+
+#[derive(Debug, Clone, derive_asset_container::AssetManager)]
+#[asset(AssetReference)]
+#[must_use]
+pub struct RawRouterConfig {
+  #[asset(skip)]
+  pub(crate) path: String,
+  pub(crate) operation: ComponentOperationExpression,
+}
+
+impl RawRouterConfig {
+  #[must_use]
+  pub fn path(&self) -> &str {
+    &self.path
+  }
+  #[must_use]
+  pub fn operation(&self) -> &ComponentOperationExpression {
+    &self.operation
+  }
+}
+
+#[derive(Debug, Clone, derive_asset_container::AssetManager)]
+#[asset(AssetReference)]
+#[must_use]
+pub struct RestRouterConfig {
+  #[asset(skip)]
+  pub(crate) path: String,
+  pub(crate) component: ComponentDefinition,
+}
+
+impl RestRouterConfig {
+  #[must_use]
+  pub fn path(&self) -> &str {
+    &self.path
+  }
+  pub fn component(&self) -> &ComponentDefinition {
+    &self.component
+  }
+}
+
+#[derive(Debug, Clone, derive_asset_container::AssetManager)]
+#[asset(AssetReference)]
+#[must_use]
+pub struct StaticRouterConfig {
+  #[asset(skip)]
+  pub(crate) path: String,
+  #[asset(skip)]
+  pub(crate) volume: String,
+}
+
+impl StaticRouterConfig {
+  /// Returns the path for the static router.
+  #[must_use]
+  pub fn path(&self) -> &str {
+    &self.path
+  }
+  /// Returns the volume name for the static router.
+  #[must_use]
+  pub fn volume(&self) -> &str {
+    &self.volume
+  }
+}
+
+#[derive(Debug, Clone, derive_asset_container::AssetManager)]
+#[asset(AssetReference)]
+#[must_use]
+pub enum HttpRouterConfig {
+  RawRouter(RawRouterConfig),
+  RestRouter(RestRouterConfig),
+  StaticRouter(StaticRouterConfig),
+  ProxyRouter(ProxyRouterConfig),
+}
+
+#[derive(Debug, Clone, derive_asset_container::AssetManager)]
+#[asset(AssetReference)]
+pub struct ProxyRouterConfig {
+  /// The path to start serving this router from.
+  #[asset(skip)]
+  pub(crate) path: String,
+  /// The URL resource to proxy to.
+  #[asset(skip)]
+  pub(crate) url: String,
+  /// Whether or not to strip the router's path from the proxied request.
+  #[asset(skip)]
+  pub(crate) strip_path: bool,
+}
+
+impl ProxyRouterConfig {
+  /// Returns the path the proxy router is configured to start proxying from.
+  #[must_use]
+  pub fn path(&self) -> &str {
+    &self.path
+  }
+  /// Returns the URL for the proxy router.
+  #[must_use]
+  pub fn url(&self) -> &str {
+    &self.url
+  }
+  /// Returns whether or not to strip the router's path from the proxied request.
+  #[must_use]
+  pub fn strip_path(&self) -> bool {
+    self.strip_path
+  }
+}

--- a/crates/wick/wick-config/src/config/app_config/triggers/time.rs
+++ b/crates/wick/wick-config/src/config/app_config/triggers/time.rs
@@ -1,0 +1,58 @@
+use wick_asset_reference::AssetReference;
+
+use super::OperationInputConfig;
+use crate::config::{ComponentDefinition, ComponentOperationExpression};
+
+#[derive(Debug, Clone, PartialEq, derive_asset_container::AssetManager)]
+#[asset(AssetReference)]
+/// Normalized representation of a Time trigger configuration.
+pub struct TimeTriggerConfig {
+  pub(crate) schedule: ScheduleConfig,
+  pub(crate) operation: ComponentOperationExpression,
+  #[asset(skip)]
+  pub(crate) payload: Vec<OperationInputConfig>,
+}
+
+impl TimeTriggerConfig {
+  /// Returns the component id for the Time trigger.
+  pub fn component(&self) -> &ComponentDefinition {
+    &self.operation.component
+  }
+
+  /// Returns the payload for the Time trigger.
+  #[must_use]
+  pub fn payload(&self) -> &Vec<OperationInputConfig> {
+    &self.payload
+  }
+
+  /// Returns the operation name for the Time trigger.
+  #[must_use]
+  pub fn operation(&self) -> &str {
+    &self.operation.operation
+  }
+  pub fn schedule(&self) -> &ScheduleConfig {
+    &self.schedule
+  }
+}
+
+#[derive(Debug, Clone, PartialEq, derive_asset_container::AssetManager)]
+#[asset(AssetReference)]
+#[must_use]
+pub struct ScheduleConfig {
+  #[asset(skip)]
+  pub(crate) cron: String,
+  #[asset(skip)]
+  pub(crate) repeat: u16,
+}
+
+impl ScheduleConfig {
+  #[must_use]
+  pub fn cron(&self) -> &String {
+    &self.cron
+  }
+
+  #[must_use]
+  pub fn repeat(&self) -> u16 {
+    self.repeat
+  }
+}

--- a/crates/wick/wick-config/src/v1.rs
+++ b/crates/wick/wick-config/src/v1.rs
@@ -245,6 +245,27 @@ pub(crate) enum HttpRouter {
   /// A variant representing a [StaticRouter] type.
   #[serde(rename = "wick/router/static@v1")]
   StaticRouter(StaticRouter),
+  /// A variant representing a [ProxyRouter] type.
+  #[serde(rename = "wick/router/proxy@v1")]
+  ProxyRouter(ProxyRouter),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
+pub(crate) struct ProxyRouter {
+  /// The path to start serving this router from.
+
+  #[serde(deserialize_with = "crate::helpers::with_expand_envs_string")]
+  pub(crate) path: String,
+  /// The URL resource to proxy to.
+
+  #[serde(deserialize_with = "crate::helpers::with_expand_envs_string")]
+  pub(crate) url: String,
+  /// Whether or not to strip the router&#x27;s path from the proxied request.
+
+  #[serde(default)]
+  #[serde(deserialize_with = "with_expand_envs")]
+  pub(crate) strip_path: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/wick/wick-config/src/v1/conversions.rs
+++ b/crates/wick/wick-config/src/v1/conversions.rs
@@ -11,6 +11,7 @@ use crate::app_config::{
   CliConfig,
   HttpRouterConfig,
   HttpTriggerConfig,
+  ProxyRouterConfig,
   RawRouterConfig,
   ResourceDefinition,
   RestRouterConfig,
@@ -397,6 +398,18 @@ impl TryFrom<HttpRouterConfig> for v1::HttpRouter {
       HttpRouterConfig::RawRouter(v) => v1::HttpRouter::RawRouter(v.try_into()?),
       HttpRouterConfig::RestRouter(v) => v1::HttpRouter::RestRouter(v.try_into()?),
       HttpRouterConfig::StaticRouter(v) => v1::HttpRouter::StaticRouter(v.try_into()?),
+      HttpRouterConfig::ProxyRouter(v) => v1::HttpRouter::ProxyRouter(v.try_into()?),
+    })
+  }
+}
+
+impl TryFrom<ProxyRouterConfig> for v1::ProxyRouter {
+  type Error = ManifestError;
+  fn try_from(value: ProxyRouterConfig) -> Result<Self> {
+    Ok(Self {
+      path: value.path,
+      url: value.url,
+      strip_path: value.strip_path,
     })
   }
 }
@@ -875,6 +888,11 @@ impl TryFrom<v1::HttpRouter> for HttpRouterConfig {
       v1::HttpRouter::StaticRouter(v) => Self::StaticRouter(StaticRouterConfig {
         path: v.path,
         volume: v.volume,
+      }),
+      v1::HttpRouter::ProxyRouter(v) => Self::ProxyRouter(ProxyRouterConfig {
+        path: v.path,
+        url: v.url,
+        strip_path: v.strip_path,
       }),
     };
     Ok(rv)

--- a/crates/wick/wick-runtime/Cargo.toml
+++ b/crates/wick/wick-runtime/Cargo.toml
@@ -47,6 +47,7 @@ url = { workspace = true }
 bytes = { workspace = true }
 regex = { workspace = true }
 hyper-staticfile = "0.9"
+hyper-reverse-proxy = "0.5"
 
 [dev-dependencies]
 wick-invocation-server = { workspace = true }

--- a/crates/wick/wick-runtime/src/triggers/http/proxy_component.rs
+++ b/crates/wick/wick-runtime/src/triggers/http/proxy_component.rs
@@ -1,0 +1,56 @@
+use std::net::SocketAddr;
+
+use futures::future::BoxFuture;
+use hyper::{Body, Request, Response, StatusCode};
+use wick_config::config::UrlResource;
+
+use super::{HttpError, RawRouter};
+
+#[derive()]
+#[must_use]
+pub(super) struct ProxyComponent {
+  url: String,
+  strip: Option<String>,
+}
+
+impl ProxyComponent {
+  pub(super) fn new(url: UrlResource, strip: Option<String>) -> Self {
+    let url = url.to_string();
+    let url = url.trim_end_matches('/').to_owned();
+    Self { url, strip }
+  }
+}
+
+impl RawRouter for ProxyComponent {
+  fn handle(
+    &self,
+    remote_addr: SocketAddr,
+    mut request: Request<Body>,
+  ) -> BoxFuture<Result<Response<Body>, HttpError>> {
+    let url = self.url.clone();
+    let client_ip = remote_addr.ip();
+    if let Some(to_strip) = &self.strip {
+      let orig_path = request.uri().path_and_query().unwrap().as_str().to_owned();
+      let path = orig_path.trim_start_matches(to_strip);
+      *request.uri_mut() = path.parse().unwrap();
+      trace!(to= url, orig = orig_path, uri = %request.uri(), "http:trigger:proxy proxying");
+    } else {
+      trace!(to= url, uri = %request.uri(), "http:trigger:proxy proxying");
+    }
+    // the proxy library does not set the appropriate host header, but if we delete
+    // the header, it will get made correctly for us.
+    request.headers_mut().remove("host");
+    let fut = async move {
+      match hyper_reverse_proxy::call(client_ip, &url, request).await {
+        Ok(response) => Ok(response),
+        Err(_error) => Ok(
+          Response::builder()
+            .status(StatusCode::INTERNAL_SERVER_ERROR)
+            .body(Body::empty())
+            .unwrap(),
+        ),
+      }
+    };
+    Box::pin(fut)
+  }
+}

--- a/crates/wick/wick-runtime/src/triggers/http/static_component.rs
+++ b/crates/wick/wick-runtime/src/triggers/http/static_component.rs
@@ -1,8 +1,10 @@
+use std::net::SocketAddr;
+
 use futures::future::BoxFuture;
 use hyper::{Body, Request, Response};
 use hyper_staticfile::Static;
 
-use super::HttpError;
+use super::{HttpError, RawRouter};
 
 #[derive()]
 #[must_use]
@@ -17,12 +19,8 @@ impl StaticComponent {
   }
 }
 
-pub(super) trait RawRouter {
-  fn handle(&self, request: Request<Body>) -> BoxFuture<Result<Response<Body>, HttpError>>;
-}
-
 impl RawRouter for StaticComponent {
-  fn handle(&self, request: Request<Body>) -> BoxFuture<Result<Response<Body>, HttpError>> {
+  fn handle(&self, _remote_addr: SocketAddr, request: Request<Body>) -> BoxFuture<Result<Response<Body>, HttpError>> {
     let handler = self.handler.clone();
     let fut = async move {
       let response = handler

--- a/examples/proxy.wick
+++ b/examples/proxy.wick
@@ -1,0 +1,36 @@
+---
+kind: wick/app@v1
+name: serve_http_component
+metadata:
+  description: Serve raw HTTP with a WASM component
+  version: 0.0.1
+  authors:
+    - 'Wick Maintainers'
+  vendors:
+    - 'Candle Corporation'
+  licenses:
+    - Apache-2.0
+resources:
+  - name: http
+    resource:
+      kind: wick/resource/tcpport@v1
+      port: 8999
+      address: 0.0.0.0
+  - name: DIR
+    resource:
+      kind: wick/resource/volume@v1
+      path: $PWD
+  - name: PROXY_URL
+    resource:
+      kind: wick/resource/url@v1
+      url: http://localhost:5173
+triggers:
+  - kind: wick/trigger/http@v1
+    resource: http
+    routers:
+      - kind: wick/router/proxy@v1
+        url: PROXY_URL
+        path: /proxied
+      - kind: wick/router/static@v1
+        path: /
+        volume: DIR


### PR DESCRIPTION
This PR adds a reverse proxy router to the HTTP trigger that lets you proxy to backend servers filtered by path.

It's been tested to work on Vite & Svelte's local development environment server with the configuration below. This allows `wick` sites that include static files & APIs to proxy their app endpoints to dev servers during development.

```js
import { defineConfig } from 'vite';
import { svelte } from '@sveltejs/vite-plugin-svelte';

export default defineConfig({
  plugins: [svelte({})],
  base: '/app-dir',

  server: {
    strictPort: true,
    port: 5173,
    base: '/app-dir',
    hmr: {
      host: 'localhost',
      clientPort: 5173,
    },
  },
});
```