### PR TITLE
Added cli test for wick test, fixed `wick test`

### DIFF
--- a/crates/bins/wick/src/commands/test.rs
+++ b/crates/bins/wick/src/commands/test.rs
@@ -59,9 +59,10 @@ pub(crate) async fn handle_command(opts: TestCommand) -> Result<()> {
   let mut host = ComponentHostBuilder::from_definition(config).build();
   host.start_engine(opts.seed.map(Seed::unsafe_new)).await?;
 
-  let component = wick_host::HostComponent::new(host);
+  let component = Arc::new(wick_host::HostComponent::new(host));
+  let id = component.id().to_owned();
 
-  let harness = suite.run(Some("__main"), Arc::new(component)).await?;
+  let harness = suite.run(Some(&id), component).await?;
 
   harness.print();
   let num_failed = harness.num_failed();

--- a/crates/bins/wick/tests/test.rs
+++ b/crates/bins/wick/tests/test.rs
@@ -1,0 +1,20 @@
+static DIR: &str = "test";
+
+#[test]
+fn wick_run() {
+  let kind = "unit";
+  trycmd::TestCases::new()
+    .case(format!("tests/{}/{}/*.toml", kind, DIR))
+    .case(format!("tests/{}/{}/*.trycmd", kind, DIR));
+}
+
+mod integration_test {
+  use super::DIR;
+  #[test]
+  fn wick_run() {
+    let kind = "integration";
+    trycmd::TestCases::new()
+      .case(format!("tests/{}/{}/*.toml", kind, DIR))
+      .case(format!("tests/{}/{}/*.trycmd", kind, DIR));
+  }
+}

--- a/crates/bins/wick/tests/unit/test/wasm.toml
+++ b/crates/bins/wick/tests/unit/test/wasm.toml
@@ -1,0 +1,21 @@
+bin.name = "wick"
+args = ["test", "../../integration/test-baseline-component/component.yaml"]
+stdout = """
+1..13 # Test
+# add 1 and 2: test operation 'add'
+ok 1 add 1 and 2: test operation 'add': correct port? ('output' == 'output')
+ok 2 add 1 and 2: test operation 'add': actual deserialized payload == expected deserialized payload?
+ok 3 add 1 and 2: test operation 'add': correct port? ('output' == 'output')
+ok 4 add 1 and 2: test operation 'add': actual raw packet == expected raw packet?
+ok 5 add 1 and 2: test operation 'add': total_outputs
+# add 2000 and 3292982: test operation 'add'
+ok 6 add 2000 and 3292982: test operation 'add': correct port? ('output' == 'output')
+ok 7 add 2000 and 3292982: test operation 'add': actual deserialized payload == expected deserialized payload?
+ok 8 add 2000 and 3292982: test operation 'add': correct port? ('output' == 'output')
+ok 9 add 2000 and 3292982: test operation 'add': actual raw packet == expected raw packet?
+ok 10 add 2000 and 3292982: test operation 'add': total_outputs
+# validate: test operation 'validate'
+ok 11 validate: test operation 'validate': correct port? ('output' == 'output')
+ok 12 validate: test operation 'validate': actual deserialized payload == expected deserialized payload?
+ok 13 validate: test operation 'validate': total_outputs
+"""

--- a/crates/integration/test-baseline-component/component.yaml
+++ b/crates/integration/test-baseline-component/component.yaml
@@ -1,5 +1,4 @@
 # yaml-language-server: $schema=../../wick/wick-config/json-schema/manifest.json
-# yaml-language-server: $schema=https://github.com/candlecorp/wick/releases/download/nightly/schema.json
 ---
 name: test-component
 kind: wick/component@v1
@@ -32,3 +31,38 @@ component:
       outputs:
         - name: output
           type: string
+tests:
+  - name: add 1 and 2
+    operation: add
+    input:
+      - name: left
+        data: 1
+      - name: right
+        data: 2
+    output:
+      - name: output
+        data: 3
+      - name: output
+        flags:
+          done: true
+  - name: add 2000 and 3292982
+    operation: add
+    input:
+      - name: left
+        data: 2000
+      - name: right
+        data: 3292982
+    output:
+      - name: output
+        data: 3294982
+      - name: output
+        flags:
+          done: true
+  - name: validate
+    operation: validate
+    input:
+      - name: input
+        data: 'hello'
+    output:
+      - name: output
+        message: Needs to be longer than 8 characters

--- a/crates/wick/wick-config/src/config/common/test_case.rs
+++ b/crates/wick/wick-config/src/config/common/test_case.rs
@@ -42,6 +42,24 @@ impl TestPacket {
       TestPacket::ErrorData(data) => &data.port,
     }
   }
+
+  /// Get the flags for the packet.
+  #[must_use]
+  pub fn flags(&self) -> Option<PacketFlags> {
+    match self {
+      TestPacket::PayloadData(data) => data.flags,
+      TestPacket::ErrorData(data) => data.flags,
+    }
+  }
+
+  /// Get the data for the packet.
+  #[must_use]
+  pub fn data(&self) -> Option<&Value> {
+    match self {
+      TestPacket::PayloadData(data) => data.data.as_ref(),
+      TestPacket::ErrorData(_) => None,
+    }
+  }
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/wick/wick-host/src/collection.rs
+++ b/crates/wick/wick-host/src/collection.rs
@@ -17,6 +17,7 @@ pub struct Context {
 #[derive(Clone, Debug)]
 #[must_use]
 pub struct HostComponent {
+  id: String,
   host: Arc<ComponentHost>,
   signature: ComponentSignature,
 }
@@ -26,9 +27,18 @@ impl HostComponent {
     let signature: ComponentSignature = host.get_signature().unwrap();
 
     Self {
+      id: host.get_host_id().to_owned(),
       host: Arc::new(host),
       signature,
     }
+  }
+}
+
+impl HostComponent {
+  /// Returns the host id
+  #[must_use]
+  pub fn id(&self) -> &str {
+    &self.id
   }
 }
 

--- a/crates/wick/wick-test/src/error.rs
+++ b/crates/wick/wick-test/src/error.rs
@@ -8,6 +8,8 @@ pub enum TestError {
   ParseFailed(String),
   #[error("Invocation failed: {0}")]
   InvocationFailed(String),
+  #[error("Invocation timed out: {0}")]
+  InvocationTimeout(String),
   #[error("Deserialization failed: {0}")]
   ConversionFailed(String),
 }


### PR DESCRIPTION
This PR fixes an issue with `wick test` using a hardcoded component id vs retrieving it from the host.