### PR TITLE
Added Form Data codec

### DIFF
--- a/crates/wick/wick-config/definitions/v1/manifest.apex
+++ b/crates/wick/wick-config/definitions/v1/manifest.apex
@@ -670,6 +670,8 @@ enum Codec {
   Json = 0 as "json",
   "Raw"
   Raw = 1 as "raw",
+  "Form Data"
+  FormData = 2 as "form-data",
 }
 
 "Supported HTTP methods"

--- a/crates/wick/wick-config/docs/v1.html
+++ b/crates/wick/wick-config/docs/v1.html
@@ -2878,6 +2878,21 @@
 
 </ul>
 
+</div><div class=field>
+
+<h3 class=field-name>
+  <a name="FormData">FormData</a>
+</h3>
+
+<span class=field-description>Form Data</span>
+
+
+<ul class="field-notes">
+<li><span class="enum-index field-note">Index: <span class=field-type>2</span></span></li>
+
+
+</ul>
+
 </div></div>
 </div><div class="definition">
 <h2 class="definition-name type-name">

--- a/crates/wick/wick-config/json-schema/manifest.json
+++ b/crates/wick/wick-config/json-schema/manifest.json
@@ -2306,7 +2306,8 @@
         "$anchor": "#v1/Codec",
         "enum": [
           "Json",
-          "Raw"
+          "Raw",
+          "FormData"
         ]
       },
       "HttpMethod": {

--- a/crates/wick/wick-config/json-schema/v1/manifest.json
+++ b/crates/wick/wick-config/json-schema/v1/manifest.json
@@ -1883,7 +1883,7 @@
 
     "Codec": {
       "$anchor": "#v1/Codec",
-      "enum": ["Json", "Raw"]
+      "enum": ["Json", "Raw", "FormData"]
     },
 
     "HttpMethod": {

--- a/crates/wick/wick-config/src/config/components/http_client.rs
+++ b/crates/wick/wick-config/src/config/components/http_client.rs
@@ -52,6 +52,7 @@ impl From<HttpClientOperationDefinition> for wick_interface_types::OperationSign
           match operation.codec {
             Some(Codec::Json) => wick_interface_types::TypeSignature::Object,
             Some(Codec::Raw) => wick_interface_types::TypeSignature::Bytes,
+            Some(Codec::FormData) => wick_interface_types::TypeSignature::Object,
             None => wick_interface_types::TypeSignature::Object,
           },
         ),
@@ -177,6 +178,8 @@ pub enum Codec {
   Json = 0,
   /// Raw
   Raw = 1,
+  /// Form Data
+  FormData = 2,
 }
 
 impl Default for Codec {

--- a/crates/wick/wick-config/src/v1.rs
+++ b/crates/wick/wick-config/src/v1.rs
@@ -1420,6 +1420,8 @@ pub(crate) enum Codec {
   Json = 0,
   /// Raw
   Raw = 1,
+  /// Form Data
+  FormData = 2,
 }
 
 impl Default for Codec {
@@ -1433,6 +1435,7 @@ impl FromPrimitive for Codec {
     Some(match n {
       0 => Self::Json,
       1 => Self::Raw,
+      2 => Self::FormData,
       _ => {
         return None;
       }
@@ -1443,6 +1446,7 @@ impl FromPrimitive for Codec {
     Some(match n {
       0 => Self::Json,
       1 => Self::Raw,
+      2 => Self::FormData,
       _ => {
         return None;
       }

--- a/crates/wick/wick-config/src/v1/conversions.rs
+++ b/crates/wick/wick-config/src/v1/conversions.rs
@@ -785,6 +785,7 @@ impl From<config::components::Codec> for v1::Codec {
     match value {
       config::components::Codec::Json => Self::Json,
       config::components::Codec::Raw => Self::Raw,
+      config::components::Codec::FormData => Self::FormData,
     }
   }
 }
@@ -794,6 +795,7 @@ impl From<v1::Codec> for config::components::Codec {
     match value {
       v1::Codec::Json => Self::Json,
       v1::Codec::Raw => Self::Raw,
+      v1::Codec::FormData => Self::FormData,
     }
   }
 }

--- a/tests/testdata/manifests/app-http-component.wick
+++ b/tests/testdata/manifests/app-http-component.wick
@@ -1,4 +1,4 @@
-# yaml-language-server: $schema=../wick/crates/wick/wick-config/json-schema/manifest.json
+# yaml-language-server: $schema=../../../../wick/crates/wick/wick-config/json-schema/manifest.json
 ---
 kind: wick/app@v1
 name: candle_website


### PR DESCRIPTION
This PR lets users specify a FormData codec to so HTTP client requests can upload bodies as 'multipart/form-data'.

This PR also fixes an issue with the `switch` operation where packets received before the condition cause it to enter an infinite loop.