### PR TITLE
Fixed trigger import loading, removed aggressive http panic

### DIFF
--- a/crates/wick/wick-runtime/src/error.rs
+++ b/crates/wick/wick-runtime/src/error.rs
@@ -1,3 +1,5 @@
+use std::convert::Infallible;
+
 use thiserror::Error;
 use wick_config::config::TriggerKind;
 
@@ -58,4 +60,10 @@ pub enum RuntimeError {
 
   #[error("Component not found: {0}")]
   ComponentNotFound(String),
+}
+
+impl From<Infallible> for RuntimeError {
+  fn from(_: Infallible) -> Self {
+    unreachable!()
+  }
 }

--- a/crates/wick/wick-runtime/src/triggers.rs
+++ b/crates/wick/wick-runtime/src/triggers.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::convert::Infallible;
 use std::sync::Arc;
 mod cli;
 mod http;
@@ -12,6 +13,18 @@ use wick_config::config::{AppConfiguration, ComponentDefinition, TriggerDefiniti
 
 use crate::dev::prelude::*;
 use crate::resources::Resource;
+use crate::RuntimeBuilder;
+
+fn build_trigger_runtime(config: &AppConfiguration) -> Result<RuntimeBuilder, Infallible> {
+  let mut rt = RuntimeBuilder::default();
+  for import in config.imports().values() {
+    rt.add_import(import.clone());
+  }
+  for resource in config.resources().values() {
+    rt.add_resource(resource.clone());
+  }
+  Ok(rt)
+}
 
 #[async_trait]
 pub trait Trigger {

--- a/crates/wick/wick-runtime/src/triggers/cli.rs
+++ b/crates/wick/wick-runtime/src/triggers/cli.rs
@@ -12,7 +12,7 @@ use structured_output::StructuredOutput;
 use tokio_stream::StreamExt;
 use wick_packet::{packet_stream, Entity, Invocation};
 
-use super::{resolve_ref, Trigger, TriggerKind};
+use super::{build_trigger_runtime, resolve_ref, Trigger, TriggerKind};
 use crate::dev::prelude::*;
 use crate::resources::Resource;
 
@@ -56,15 +56,9 @@ impl Cli {
       Entity::operation(cli_binding.id(), config.operation().operation()),
       None,
     );
+    let mut runtime = build_trigger_runtime(&app_config)?;
 
-    let mut runtime = crate::RuntimeBuilder::new();
     runtime.add_import(cli_binding);
-    for import in app_config.imports().values() {
-      runtime.add_import(import.clone());
-    }
-    for resource in app_config.resources().values() {
-      runtime.add_resource(resource.clone());
-    }
     let runtime = runtime.build().await?;
 
     let is_interactive = IsInteractive {

--- a/crates/wick/wick-runtime/src/triggers/time.rs
+++ b/crates/wick/wick-runtime/src/triggers/time.rs
@@ -14,7 +14,7 @@ use tokio::time::Duration;
 use tokio_stream::StreamExt;
 use wick_packet::{Entity, Packet};
 
-use super::{Trigger, TriggerKind};
+use super::{build_trigger_runtime, Trigger, TriggerKind};
 use crate::dev::prelude::*;
 use crate::resources::Resource;
 use crate::triggers::resolve_ref;
@@ -56,7 +56,7 @@ async fn create_schedule(
       Err(err) => panic!("Unable to resolve component: {}", err),
     };
 
-    let mut runtime = crate::RuntimeBuilder::new();
+    let mut runtime = build_trigger_runtime(&app_config).unwrap();
     let schedule_binding = config::ImportBinding::component("0", schedule_component);
     runtime.add_import(schedule_binding);
     // needed for invoke command


### PR DESCRIPTION
This PR fixes an issue with the `time` and `http` triggers not properly loading their imports or resources.

It also removes a panic from the HTTP trigger that obscures an error that precedes it.