### PR TITLE
Fixed tracing spans, removed jaeger support, added otlp

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -35,7 +35,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.9",
  "once_cell",
  "version_check",
 ]
@@ -1611,6 +1610,7 @@ dependencies = [
  "futures",
  "serde",
  "serde_json",
+ "tracing",
  "wick-interface-types",
  "wick-packet",
 ]
@@ -1860,16 +1860,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gethostname"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2013,31 +2003,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69fe1fcf8b4278d860ad0548329f892a3631fb63f82574df68275f34cdbe0ffa"
 dependencies = [
  "hashbrown 0.12.3",
-]
-
-[[package]]
-name = "headers"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3e372db8e5c0d213e0cd0b9be18be2aca3d44cf2fe30a9d46a65581cd454584"
-dependencies = [
- "base64 0.13.1",
- "bitflags 1.3.2",
- "bytes",
- "headers-core",
- "http",
- "httpdate",
- "mime",
- "sha1",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
-dependencies = [
- "http",
 ]
 
 [[package]]
@@ -2397,12 +2362,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "integer-encoding"
-version = "3.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
-
-[[package]]
 name = "integration"
 version = "0.1.0"
 dependencies = [
@@ -2417,7 +2376,7 @@ dependencies = [
  "test-logger",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.9.2",
  "tracing",
  "wick-component",
  "wick-component-cli",
@@ -3112,47 +3071,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-http"
-version = "0.7.0"
+name = "opentelemetry-otlp"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc79add46364183ece1a4542592ca593e6421c60807232f5b8f7a31703825d"
-dependencies = [
- "async-trait",
- "bytes",
- "http",
- "hyper",
- "opentelemetry_api",
- "tokio",
-]
-
-[[package]]
-name = "opentelemetry-jaeger"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e785d273968748578931e4dc3b4f5ec86b26e09d9e0d66b55adda7fce742f7a"
+checksum = "d1c928609d087790fc936a1067bdc310ae702bdf3b090c3f281b713622c8bbde"
 dependencies = [
  "async-trait",
  "futures",
- "futures-executor",
- "headers",
+ "futures-util",
  "http",
- "hyper",
- "once_cell",
  "opentelemetry",
- "opentelemetry-http",
- "opentelemetry-semantic-conventions",
+ "opentelemetry-proto",
+ "prost",
  "thiserror",
- "thrift",
  "tokio",
+ "tonic 0.8.3",
 ]
 
 [[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.10.0"
+name = "opentelemetry-proto"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b02e0230abb0ab6636d18e2ba8fa02903ea63772281340ccac18e0af3ec9eeb"
+checksum = "d61a2f56df5574508dd86aaca016c917489e589ece4141df1b5e349af8d66c28"
 dependencies = [
+ "futures",
+ "futures-util",
  "opentelemetry",
+ "prost",
+ "tonic 0.8.3",
+ "tonic-build 0.8.4",
 ]
 
 [[package]]
@@ -3204,15 +3151,6 @@ name = "option-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1800ff62dcf34d7de2c7b7c84e3107a19708578441bd998eaddadb1134a4b007"
-
-[[package]]
-name = "ordered-float"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3305af35278dd29f46fcdd139e0b1fbfae2153f0e5928b39b035542dd31e37b7"
-dependencies = [
- "num-traits",
-]
 
 [[package]]
 name = "ordered-float"
@@ -4162,7 +4100,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
- "ordered-float 2.10.0",
+ "ordered-float",
  "serde",
 ]
 
@@ -4927,28 +4865,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "threadpool"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
-dependencies = [
- "num_cpus",
-]
-
-[[package]]
-name = "thrift"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09678c4cdbb4eed72e18b7c2af1329c69825ed16fcbac62d083fc3e2b0590ff0"
-dependencies = [
- "byteorder",
- "integer-encoding",
- "log",
- "ordered-float 1.1.1",
- "threadpool",
-]
-
-[[package]]
 name = "tiberius"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5173,6 +5089,38 @@ dependencies = [
 
 [[package]]
 name = "tonic"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f219fad3b929bef19b1f86fbc0358d35daed8f2cac972037ac0dc10bbb8d5fb"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.13.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-timeout",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "prost-derive",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+ "tracing-futures",
+]
+
+[[package]]
+name = "tonic"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
@@ -5204,6 +5152,19 @@ dependencies = [
 
 [[package]]
 name = "tonic-build"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf5e9b9c0f7e0a7c027dcfaba7b2c60816c7049171f679d99ee2ff65d0de8c4"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "tonic-build"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6fdaae4c2c638bb70fe42803a26fbd6fc6ac8c72f5c59f67ecc2a2dcabf4b07"
@@ -5225,7 +5186,7 @@ dependencies = [
  "prost-types",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.9.2",
 ]
 
 [[package]]
@@ -5296,24 +5257,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-bunyan-formatter"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25a348912d4e90923cb93343691d3be97e3409607363706c400fc935bb032fb0"
-dependencies = [
- "ahash 0.8.3",
- "gethostname",
- "log",
- "serde",
- "serde_json",
- "time 0.3.20",
- "tracing",
- "tracing-core",
- "tracing-log",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "tracing-core"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5359,16 +5302,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5377,9 +5310,8 @@ dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
+ "parking_lot 0.12.1",
  "regex",
- "serde",
- "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -5387,7 +5319,6 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-serde",
 ]
 
 [[package]]
@@ -6402,7 +6333,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.9.2",
  "tonic-reflection",
  "tracing",
  "uuid",
@@ -6509,6 +6440,7 @@ name = "wick-host"
 version = "0.4.0"
 dependencies = [
  "anyhow",
+ "derive_builder",
  "flow-component",
  "futures",
  "http",
@@ -6604,7 +6536,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tonic",
+ "tonic 0.9.2",
  "tracing",
  "wick-logger",
  "wick-packet",
@@ -6617,13 +6549,13 @@ version = "0.2.0"
 dependencies = [
  "ansi_term",
  "opentelemetry",
- "opentelemetry-jaeger",
+ "opentelemetry-otlp",
  "thiserror",
  "time 0.3.20",
  "tokio",
+ "tokio-stream",
  "tracing",
  "tracing-appender",
- "tracing-bunyan-formatter",
  "tracing-opentelemetry",
  "tracing-subscriber",
  "wick-xdg",
@@ -6717,8 +6649,8 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
- "tonic",
- "tonic-build",
+ "tonic 0.9.2",
+ "tonic-build 0.9.2",
  "tracing",
  "uuid",
  "wick-interface-types",
@@ -6735,6 +6667,7 @@ dependencies = [
  "bytes",
  "chrono",
  "cron",
+ "derive_builder",
  "flow-component",
  "flow-graph",
  "flow-graph-interpreter",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ wasmrs-rx = { version = "0.11" }
 wasmrs-wasmtime = { version = "0.11" }
 #
 # Other
+ansi_term = "0.12"
 anyhow = "1.0"
 async-recursion = "1.0"
 async-stream = "0.3"
@@ -107,7 +108,7 @@ once_cell = "1.8"
 openssl = "0.10"
 option-utils = "0.1"
 opentelemetry = { version = "0.18.0" }
-opentelemetry-jaeger = { version = "0.17.0" }
+opentelemetry-otlp = { version = "0.11.0" }
 parking_lot = "0.12"
 paste = "1.0"
 postgres-openssl = "0.5"
@@ -140,10 +141,12 @@ structmeta = "0.2"
 structured-output = "0.1.1"
 tar = "0.4"
 flate2 = "1"
+tracing-appender = "0.2"
 test_bin = "0.4"
 test-log = "0.2"
 testanything = "0.4"
 thiserror = "1.0"
+time = "0.3"
 tokio = "1"
 tokio-postgres = "0.7"
 tokio-stream = "0.1"

--- a/crates/bins/wick/Cargo.toml
+++ b/crates/bins/wick/Cargo.toml
@@ -27,7 +27,7 @@ wick-oci-utils = { workspace = true }
 wick-package = { workspace = true }
 wick-logger = { workspace = true }
 seeded-random = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
 tracing = { workspace = true }
 serde_json = { workspace = true }
 anyhow = { workspace = true }

--- a/crates/bins/wick/src/commands/init.rs
+++ b/crates/bins/wick/src/commands/init.rs
@@ -17,18 +17,21 @@ pub(crate) struct InitCommand {
 }
 
 #[allow(clippy::field_reassign_with_default)]
-pub(crate) async fn handle(opts: InitCommand, _settings: wick_settings::Settings) -> Result<()> {
-  let files: Vec<(PathBuf, String)> = if opts.component {
-    info!("Initializing wick component project: {}", opts.name);
-    let mut config = ComponentConfiguration::default();
-    config.set_name(opts.name);
-    vec![("component.wick".into(), config.into_v1_yaml()?)]
-  } else {
-    info!("Initializing wick application: {}", opts.name);
-    let mut config = AppConfiguration::default();
-    config.set_name(opts.name);
-    vec![("app.wick".into(), config.into_v1_yaml()?)]
-  };
+pub(crate) async fn handle(opts: InitCommand, _settings: wick_settings::Settings, span: tracing::Span) -> Result<()> {
+  let files: Result<Vec<(PathBuf, String)>> = span.in_scope(|| {
+    if opts.component {
+      info!("Initializing wick component project: {}", opts.name);
+      let mut config = ComponentConfiguration::default();
+      config.set_name(opts.name);
+      Ok(vec![("component.wick".into(), config.into_v1_yaml()?)])
+    } else {
+      info!("Initializing wick application: {}", opts.name);
+      let mut config = AppConfiguration::default();
+      config.set_name(opts.name);
+      Ok(vec![("app.wick".into(), config.into_v1_yaml()?)])
+    }
+  });
+  let files = files?;
 
   for (file, _) in &files {
     if file.exists() {
@@ -37,7 +40,8 @@ pub(crate) async fn handle(opts: InitCommand, _settings: wick_settings::Settings
   }
 
   for (file, contents) in files {
-    info!("Writing file: {}", file.display());
+    span.in_scope(|| info!("Writing file: {}", file.display()));
+
     crate::io::write_bytes(file, contents.as_bytes()).await?;
   }
 

--- a/crates/bins/wick/src/commands/key/gen.rs
+++ b/crates/bins/wick/src/commands/key/gen.rs
@@ -16,7 +16,8 @@ pub(crate) struct KeyGenCommand {
 }
 
 #[allow(clippy::unused_async)]
-pub(crate) async fn handle(opts: KeyGenCommand, _settings: wick_settings::Settings) -> Result<()> {
+pub(crate) async fn handle(opts: KeyGenCommand, _settings: wick_settings::Settings, span: tracing::Span) -> Result<()> {
+  let _enter = span.enter();
   debug!("Generating {} key", crate::keys::keypair_type_to_string(&opts.keytype));
 
   let kp = KeyPair::new(opts.keytype);

--- a/crates/bins/wick/src/commands/key/get.rs
+++ b/crates/bins/wick/src/commands/key/get.rs
@@ -16,7 +16,8 @@ pub(crate) struct KeyGetCommand {
 }
 
 #[allow(clippy::unused_async)]
-pub(crate) async fn handle(opts: KeyGetCommand, _settings: wick_settings::Settings) -> Result<()> {
+pub(crate) async fn handle(opts: KeyGetCommand, _settings: wick_settings::Settings, span: tracing::Span) -> Result<()> {
+  let _span = span.enter();
   println!("Reading key: {}\n", opts.path.to_string_lossy());
   let kp = crate::keys::get_key(opts.directory, opts.path).await?;
 

--- a/crates/bins/wick/src/commands/key/list.rs
+++ b/crates/bins/wick/src/commands/key/list.rs
@@ -14,7 +14,12 @@ pub(crate) struct KeyListCommand {
 }
 
 #[allow(clippy::unused_async)]
-pub(crate) async fn handle(opts: KeyListCommand, _settings: wick_settings::Settings) -> Result<()> {
+pub(crate) async fn handle(
+  opts: KeyListCommand,
+  _settings: wick_settings::Settings,
+  span: tracing::Span,
+) -> Result<()> {
+  let _enter = span.enter();
   debug!("Listing keys");
   let (dir, keys) = get_key_files(opts.directory)?;
   info!("Listing keys in {}", dir.to_string_lossy());

--- a/crates/bins/wick/src/commands/list.rs
+++ b/crates/bins/wick/src/commands/list.rs
@@ -20,7 +20,7 @@ pub(crate) struct ListCommand {
   pub(crate) json: bool,
 }
 
-pub(crate) async fn handle(opts: ListCommand, _settings: wick_settings::Settings) -> Result<()> {
+pub(crate) async fn handle(opts: ListCommand, _settings: wick_settings::Settings, span: tracing::Span) -> Result<()> {
   let fetch_options = wick_config::config::FetchOptions::new()
     .allow_latest(opts.oci.allow_latest)
     .allow_insecure(&opts.oci.insecure_registries);
@@ -35,10 +35,8 @@ pub(crate) async fn handle(opts: ListCommand, _settings: wick_settings::Settings
   // Disable everything but the mesh
   config.host_mut().set_rpc(None);
 
-  let host_builder = ComponentHostBuilder::from_definition(config);
+  let mut host = ComponentHostBuilder::default().manifest(config).span(span).build()?;
 
-  let mut host = host_builder.build();
-  // host.connect_to_mesh().await?;
   host.start_engine(None).await?;
   let signature = host.get_signature()?;
 

--- a/crates/bins/wick/src/commands/query.rs
+++ b/crates/bins/wick/src/commands/query.rs
@@ -47,7 +47,7 @@ impl FromStr for MarkupKind {
   }
 }
 
-pub(crate) async fn handle(opts: QueryCommand, _settings: wick_settings::Settings) -> Result<()> {
+pub(crate) async fn handle(opts: QueryCommand, _settings: wick_settings::Settings, span: tracing::Span) -> Result<()> {
   let input = if let Some(path) = opts.path {
     match opts.kind {
       None => Transcoder::from_path(&path)?.to_json()?,
@@ -73,6 +73,7 @@ pub(crate) async fn handle(opts: QueryCommand, _settings: wick_settings::Setting
       Some(MarkupKind::Yaml) => Transcoder::new(Format::yaml(&markup)?)?.to_json()?,
     }
   };
+  let _enter = span.enter();
 
   let filter = &opts.query;
 

--- a/crates/bins/wick/src/commands/registry/login.rs
+++ b/crates/bins/wick/src/commands/registry/login.rs
@@ -15,7 +15,12 @@ pub(crate) struct RegistryLoginCommand {
 }
 
 #[allow(clippy::unused_async)]
-pub(crate) async fn handle(opts: RegistryLoginCommand, mut settings: wick_settings::Settings) -> Result<()> {
+pub(crate) async fn handle(
+  opts: RegistryLoginCommand,
+  mut settings: wick_settings::Settings,
+  span: tracing::Span,
+) -> Result<()> {
+  let _enter = span.enter();
   let creds = settings.credentials.iter_mut().find(|c| c.scope == opts.registry);
   println!(
     "Use your registry's UI (i.e. open {} in a browser) to retrieve a token and paste it below.\n",

--- a/crates/bins/wick/src/commands/rpc/list.rs
+++ b/crates/bins/wick/src/commands/rpc/list.rs
@@ -8,7 +8,12 @@ pub(crate) struct RpcListCommand {
   pub(crate) connection: super::ConnectOptions,
 }
 
-pub(crate) async fn handle(opts: RpcListCommand, _settings: wick_settings::Settings) -> Result<()> {
+pub(crate) async fn handle(
+  opts: RpcListCommand,
+  _settings: wick_settings::Settings,
+  span: tracing::Span,
+) -> Result<()> {
+  let _span = span.enter();
   let mut client = wick_rpc::make_rpc_client(
     format!("http://{}:{}", opts.connection.address, opts.connection.port),
     opts.connection.pem,

--- a/crates/bins/wick/src/commands/rpc/stats.rs
+++ b/crates/bins/wick/src/commands/rpc/stats.rs
@@ -10,7 +10,12 @@ pub(crate) struct RpcStatsCommand {
   pub(crate) connection: super::ConnectOptions,
 }
 
-pub(crate) async fn handle(opts: RpcStatsCommand, _settings: wick_settings::Settings) -> Result<()> {
+pub(crate) async fn handle(
+  opts: RpcStatsCommand,
+  _settings: wick_settings::Settings,
+  span: tracing::Span,
+) -> Result<()> {
+  let _span = span.enter();
   let mut client = wick_rpc::make_rpc_client(
     format!("http://{}:{}", opts.connection.address, opts.connection.port),
     opts.connection.pem,

--- a/crates/bins/wick/src/commands/run.rs
+++ b/crates/bins/wick/src/commands/run.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use clap::Args;
+use tracing::Instrument;
 use wick_config::WickConfiguration;
 use wick_host::AppHostBuilder;
 
@@ -22,16 +23,22 @@ pub(crate) struct RunCommand {
   args: Vec<String>,
 }
 
-pub(crate) async fn handle(opts: RunCommand, _settings: wick_settings::Settings) -> Result<()> {
-  debug!(args = ?opts.args, "rest args");
+pub(crate) async fn handle(opts: RunCommand, _settings: wick_settings::Settings, span: tracing::Span) -> Result<()> {
+  span.in_scope(|| trace!(args = ?opts.args, "rest args"));
   let app_config = WickConfiguration::fetch_all(&opts.path, opts.oci.into())
+    .instrument(span.clone())
     .await?
     .try_app_config()?;
 
-  let mut host = AppHostBuilder::from_definition(app_config.clone()).build();
+  let mut host = AppHostBuilder::default()
+    .manifest(app_config.clone())
+    .span(span.clone())
+    .build()?;
+
   host.start(opts.seed)?;
-  debug!("Waiting on triggers to finish or interrupt...");
-  host.wait_for_done().await?;
+  span.in_scope(|| debug!("Waiting on triggers to finish or interrupt..."));
+
+  host.wait_for_done().instrument(span.clone()).await?;
 
   Ok(())
 }

--- a/crates/bins/wick/src/commands/serve.rs
+++ b/crates/bins/wick/src/commands/serve.rs
@@ -22,7 +22,7 @@ pub(crate) struct ServeCommand {
   pub(crate) location: String,
 }
 
-pub(crate) async fn handle(opts: ServeCommand, _settings: wick_settings::Settings) -> Result<()> {
+pub(crate) async fn handle(opts: ServeCommand, _settings: wick_settings::Settings, span: tracing::Span) -> Result<()> {
   let fetch_options = wick_config::config::FetchOptions::new()
     .allow_latest(opts.oci.allow_latest)
     .allow_insecure(&opts.oci.insecure_registries);
@@ -33,9 +33,7 @@ pub(crate) async fn handle(opts: ServeCommand, _settings: wick_settings::Setting
 
   let config = merge_config(&manifest, &opts.oci, Some(opts.cli));
 
-  let host_builder = ComponentHostBuilder::from_definition(config);
-
-  let mut host = host_builder.build();
+  let mut host = ComponentHostBuilder::default().manifest(config).span(span).build()?;
 
   host.start(Some(0)).await?;
   info!("Host started");

--- a/crates/bins/wick/src/commands/test.rs
+++ b/crates/bins/wick/src/commands/test.rs
@@ -36,7 +36,7 @@ pub(crate) struct TestCommand {
   filter: Vec<String>,
 }
 
-pub(crate) async fn handle(opts: TestCommand, _settings: wick_settings::Settings) -> Result<()> {
+pub(crate) async fn handle(opts: TestCommand, _settings: wick_settings::Settings, span: tracing::Span) -> Result<()> {
   let fetch_options = wick_config::config::FetchOptions::new()
     .allow_latest(opts.oci.allow_latest)
     .allow_insecure(&opts.oci.insecure_registries);
@@ -50,7 +50,7 @@ pub(crate) async fn handle(opts: TestCommand, _settings: wick_settings::Settings
 
   let config = merge_config(&config, &opts.oci, Some(server_options));
 
-  let mut host = ComponentHostBuilder::from_definition(config).build();
+  let mut host = ComponentHostBuilder::default().manifest(config).span(span).build()?;
   host.start_engine(opts.seed.map(Seed::unsafe_new)).await?;
 
   let component = Arc::new(wick_host::HostComponent::new(host));

--- a/crates/bins/wick/src/commands/wasm/inspect.rs
+++ b/crates/bins/wick/src/commands/wasm/inspect.rs
@@ -13,7 +13,12 @@ pub(crate) struct WasmInspectCommand {
 }
 
 #[allow(clippy::unused_async)]
-pub(crate) async fn handle(opts: WasmInspectCommand, _settings: wick_settings::Settings) -> Result<()> {
+pub(crate) async fn handle(
+  opts: WasmInspectCommand,
+  _settings: wick_settings::Settings,
+  span: tracing::Span,
+) -> Result<()> {
+  let _enter = span.enter();
   let mut file = File::open(opts.module)?;
   let mut buf = Vec::new();
   file.read_to_end(&mut buf)?;

--- a/crates/bins/wick/src/commands/wasm/sign.rs
+++ b/crates/bins/wick/src/commands/wasm/sign.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 
 use anyhow::Result;
 use clap::Args;
+use tracing::Instrument;
 use wick_config::WickConfiguration;
 use wick_wascap::{sign_buffer_with_claims, ClaimsOptions};
 
@@ -36,11 +37,18 @@ pub(crate) struct WasmSignCommand {
 }
 
 #[allow(clippy::unused_async)]
-pub(crate) async fn handle(opts: WasmSignCommand, _settings: wick_settings::Settings) -> Result<()> {
-  debug!("Signing module");
+pub(crate) async fn handle(
+  opts: WasmSignCommand,
+  _settings: wick_settings::Settings,
+  span: tracing::Span,
+) -> Result<()> {
+  span.in_scope(|| {
+    debug!("Signing module");
+    debug!("Reading from {}", opts.interface);
+  });
 
-  debug!("Reading from {}", opts.interface);
   let interface = WickConfiguration::fetch(&opts.interface, wick_config::FetchOptions::default())
+    .instrument(span.clone())
     .await?
     .try_component_config()?;
 
@@ -55,12 +63,6 @@ pub(crate) async fn handle(opts: WasmSignCommand, _settings: wick_settings::Sett
     opts.common.subject,
   )
   .await?;
-
-  debug!(
-    "Signing module (orig: {} bytes) with interface : {:#?}",
-    buf.len(),
-    interface.signature()?
-  );
 
   let signed = sign_buffer_with_claims(
     &buf,
@@ -98,17 +100,17 @@ pub(crate) async fn handle(opts: WasmSignCommand, _settings: wick_settings::Sett
       }
     }
   };
-  debug!("Destination : {}", destination);
+  span.in_scope(|| debug!("Destination : {}", destination));
 
   let mut outfile = File::create(&destination).unwrap();
-  match outfile.write(&signed) {
+  span.in_scope(|| match outfile.write(&signed) {
     Ok(_) => {
       info!("Successfully signed {}", destination,);
     }
     Err(e) => {
       error!("Error signing: {}", e);
     }
-  }
+  });
 
   Ok(())
 }

--- a/crates/bins/wick/src/options.rs
+++ b/crates/bins/wick/src/options.rs
@@ -46,10 +46,10 @@ impl From<LoggingOptions> for wick_logger::LoggingOptions {
       silly: value.verbose == 2,
       level: if value.quiet {
         wick_logger::LogLevel::Quiet
-      } else if value.debug {
-        wick_logger::LogLevel::Debug
       } else if value.trace {
         wick_logger::LogLevel::Trace
+      } else if value.debug {
+        wick_logger::LogLevel::Debug
       } else {
         wick_logger::LogLevel::Info
       },

--- a/crates/bins/wick/src/options.rs
+++ b/crates/bins/wick/src/options.rs
@@ -62,20 +62,23 @@ impl From<LoggingOptions> for wick_logger::LoggingOptions {
 }
 
 pub(crate) fn apply_log_settings(settings: &wick_settings::Settings, options: &mut LoggingOptions) {
-  if settings.logging.level == wick_settings::LogLevel::Debug {
+  if settings.trace.level == wick_settings::LogLevel::Debug {
     options.debug = true;
   }
-  if settings.logging.level == wick_settings::LogLevel::Trace {
+  if settings.trace.level == wick_settings::LogLevel::Trace {
     options.trace = true;
   }
-  if settings.logging.level == wick_settings::LogLevel::Off {
+  if settings.trace.level == wick_settings::LogLevel::Off {
     options.quiet = true;
   }
-  if settings.logging.modifier == wick_settings::LogModifier::Verbose {
+  if settings.trace.modifier == wick_settings::LogModifier::Verbose {
     options.verbose = 1;
   }
-  if settings.logging.modifier == wick_settings::LogModifier::Silly {
+  if settings.trace.modifier == wick_settings::LogModifier::Silly {
     options.verbose = 2;
+  }
+  if options.jaeger_endpoint.is_none() {
+    options.jaeger_endpoint = settings.trace.jaeger.clone();
   }
 }
 

--- a/crates/bins/wick/src/panic.rs
+++ b/crates/bins/wick/src/panic.rs
@@ -1,0 +1,19 @@
+#[allow(clippy::expect_used)]
+pub(super) fn setup(style: human_panic::PanicStyle) {
+  match style {
+    human_panic::PanicStyle::Debug => {}
+    human_panic::PanicStyle::Human => {
+      let meta = human_panic::Metadata {
+        name: crate::BIN_NAME.into(),
+        version: env!("CARGO_PKG_VERSION").into(),
+        authors: "wick authors".into(),
+        homepage: "https://github.com/candlecorp/wick".into(),
+      };
+
+      std::panic::set_hook(Box::new(move |info: &std::panic::PanicInfo| {
+        let file_path = human_panic::handle_dump(&meta, info);
+        human_panic::print_msg(file_path, &meta).expect("human-panic: printing error message to console failed");
+      }));
+    }
+  }
+}

--- a/crates/components/wick-sqlx/src/component.rs
+++ b/crates/components/wick-sqlx/src/component.rs
@@ -273,7 +273,7 @@ async fn exec(
   args: Vec<(TypeSignature, Packet)>,
   stmt: Arc<(String, String)>,
 ) -> Result<(), Error> {
-  debug!(stmt = %stmt.0, "executing  query");
+  debug!(stmt = %stmt.0, "executing query");
 
   let mut bound_args = Vec::new();
   for arg in def.arguments() {

--- a/crates/misc/test-logger/src/lib.rs
+++ b/crates/misc/test-logger/src/lib.rs
@@ -101,7 +101,8 @@ fn expand_logging_init() -> Tokens {
         level: crate::LogLevel::Trace,
         silly: true,
         app_name: "test".to_owned(),
-        jaeger_endpoint: std::env::var("OTEL_EXPORTER_JAEGER_ENDPOINT").ok(),
+        otlp_endpoint: std::env::var("OTLP_ENDPOINT").ok(),
+        global:true,
         ..Default::default()
       });
     },
@@ -114,7 +115,8 @@ fn expand_logging_init() -> Tokens {
             level: #ident::LogLevel::Trace,
             silly: true,
             app_name: "test".to_owned(),
-            jaeger_endpoint: std::env::var("OTEL_EXPORTER_JAEGER_ENDPOINT").ok(),
+            otlp_endpoint: std::env::var("OTLP_ENDPOINT").ok(),
+            global:true,
             ..Default::default()
           });
 

--- a/crates/wick/flow-component/Cargo.toml
+++ b/crates/wick/flow-component/Cargo.toml
@@ -18,5 +18,6 @@ serde_json = { workspace = true }
 futures = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+tracing = { workspace = true }
 
 [dev-dependencies]

--- a/crates/wick/flow-component/src/traits.rs
+++ b/crates/wick/flow-component/src/traits.rs
@@ -34,6 +34,7 @@ pub trait Operation {
   type Config: std::fmt::Debug + DeserializeOwned + Serialize + Send + Sync + 'static;
   fn handle(
     &self,
+    invocation: Invocation,
     payload: PacketStream,
     context: Context<Self::Config>,
   ) -> BoxFuture<Result<PacketStream, ComponentError>>;
@@ -51,13 +52,14 @@ pub type RuntimeCallback = dyn Fn(
     PacketStream,
     Option<InherentData>,
     Option<OperationConfig>,
+    &tracing::Span,
   ) -> BoxFuture<'static, Result<PacketStream, ComponentError>>
   + Send
   + Sync;
 
 #[must_use]
 pub fn panic_callback() -> Arc<RuntimeCallback> {
-  Arc::new(|_, _, _, _, _| {
+  Arc::new(|_, _, _, _, _, _| {
     Box::pin(async move {
       panic!("Panic callback invoked. This should never happen outside of tests.");
     })

--- a/crates/wick/flow-graph-interpreter/.vscode/launch.json
+++ b/crates/wick/flow-graph-interpreter/.vscode/launch.json
@@ -17,7 +17,6 @@
         ]
       },
       "env": {
-        "OTEL_EXPORTER_JAEGER_ENDPOINT": "nas.glhf.lan:6831"
       },
       "args": [],
       "cwd": "${workspaceFolder}"

--- a/crates/wick/flow-graph-interpreter/src/graph.rs
+++ b/crates/wick/flow-graph-interpreter/src/graph.rs
@@ -104,7 +104,7 @@ fn register_operation(
           .map(|component| component.add_input(to.port()));
 
         if to_port.is_none() {
-          println!("Missing downstream: instance {:?}", to);
+          error!("Missing downstream: instance {:?}", to);
           return Err(flow_graph::error::Error::MissingDownstream(
             to.instance().id().unwrap().to_owned(),
           ));

--- a/crates/wick/flow-graph-interpreter/src/interpreter/components.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/components.rs
@@ -51,7 +51,7 @@ impl HandlerMap {
   }
 
   pub(crate) fn add_core(&mut self, network: &Network) -> Result<(), InterpreterError> {
-    self.add(NamespaceHandler::new(NS_CORE, Box::new(CoreCollection::new(network))))
+    self.add(NamespaceHandler::new(NS_CORE, Box::new(CoreCollection::new(network)?)))
   }
 
   #[must_use]
@@ -74,7 +74,6 @@ impl HandlerMap {
   }
 
   pub fn add(&mut self, component: NamespaceHandler) -> Result<(), InterpreterError> {
-    trace!(namespace = %component.namespace, "adding component");
     if self.components.contains_key(&component.namespace) {
       return Err(InterpreterError::DuplicateNamespace(component.namespace));
     }

--- a/crates/wick/flow-graph-interpreter/src/interpreter/components/core_collection.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/components/core_collection.rs
@@ -21,6 +21,40 @@ pub(crate) struct CoreCollection {
   switch: switch::Op,
 }
 
+struct OpInitError {
+  error: ComponentError,
+  kind: DynamicOperation,
+}
+
+impl OpInitError {
+  fn new(error: ComponentError, kind: DynamicOperation) -> Self {
+    Self { error, kind }
+  }
+}
+
+impl std::fmt::Display for OpInitError {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    f.write_str("dynamic ")?;
+    self.kind.fmt(f)?;
+    f.write_str(" component failed to initialize: ")?;
+    self.error.fmt(f)
+  }
+}
+
+enum DynamicOperation {
+  Merge,
+  Switch,
+}
+
+impl std::fmt::Display for DynamicOperation {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      DynamicOperation::Merge => f.write_str("merge"),
+      DynamicOperation::Switch => f.write_str("switch"),
+    }
+  }
+}
+
 impl CoreCollection {
   pub(crate) fn new(graph: &Network) -> Self {
     let mut this = Self {
@@ -41,35 +75,33 @@ impl CoreCollection {
           continue;
         }
 
-        match operation.cref().name() {
-          merge::Op::ID => {
-            let config = match merge::Op::decode_config(operation.data().clone()) {
-              Ok(c) => c,
-              Err(e) => {
-                error!("Configuration for dynamic merge component invalid: {}", e);
-                panic!()
-              }
-            };
-            let id = dyn_component_id(merge::Op::ID, schematic.name(), operation.id());
-            debug!(%id,"adding dynamic type signature for merge component");
-            let (op_sig, output_sig) = merge::Op::gen_signature(id, config);
+        let result = match operation.cref().name() {
+          merge::Op::ID => match merge::Op::decode_config(operation.data().clone()) {
+            Ok(config) => {
+              let id = dyn_component_id(merge::Op::ID, schematic.name(), operation.id());
+              debug!(%id,"adding dynamic type signature for merge component");
+              let (op_sig, output_sig) = merge::Op::gen_signature(id, config);
 
-            this.signature.types.push(TypeDefinition::Struct(output_sig));
-            this.signature.operations.push(op_sig);
-          }
-          switch::Op::ID => {
-            let config = match switch::Op::decode_config(operation.data().clone()) {
-              Ok(c) => c,
-              Err(e) => {
-                error!("Configuration for dynamic switch component invalid: {}", e);
-                panic!();
-              }
-            };
-            let op_sig = this.switch.gen_signature(graph, config);
+              this.signature.types.push(TypeDefinition::Struct(output_sig));
+              this.signature.operations.push(op_sig);
+              Ok(())
+            }
+            Err(e) => Err(OpInitError::new(e, DynamicOperation::Merge)),
+          },
+          switch::Op::ID => match switch::Op::decode_config(operation.data().clone()) {
+            Ok(config) => {
+              let op_sig = this.switch.gen_signature(graph, config);
 
-            this.signature.operations.push(op_sig);
-          }
-          _ => {}
+              this.signature.operations.push(op_sig);
+              Ok(())
+            }
+            Err(e) => Err(OpInitError::new(e, DynamicOperation::Switch)),
+          },
+          _ => Ok(()),
+        };
+        if let Err(error) = result {
+          error!(%error, "Failed to add dynamic signature");
+          panic!("Failed to add dynamic signature: {}", error);
         }
       }
     }

--- a/crates/wick/flow-graph-interpreter/src/interpreter/components/core_collection/pluck.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/components/core_collection/pluck.rs
@@ -1,7 +1,7 @@
 use flow_component::{ComponentError, Context, Operation};
 use futures::{FutureExt, StreamExt};
 use wick_interface_types::{operation, OperationSignature};
-use wick_packet::{Packet, PacketStream, StreamMap};
+use wick_packet::{Invocation, Packet, PacketStream, StreamMap};
 
 use crate::BoxFuture;
 pub(crate) struct Op {
@@ -39,6 +39,7 @@ impl Operation for Op {
   type Config = Config;
   fn handle(
     &self,
+    _invocation: Invocation,
     stream: PacketStream,
     context: Context<Self::Config>,
   ) -> BoxFuture<Result<PacketStream, ComponentError>> {
@@ -89,7 +90,7 @@ impl Operation for Op {
 mod test {
   use anyhow::Result;
   use flow_component::panic_callback;
-  use wick_packet::packet_stream;
+  use wick_packet::{packet_stream, Entity};
 
   use super::*;
 
@@ -107,8 +108,9 @@ mod test {
         "dont_pluck_this": "unused",
       })
     ));
+    let inv = Invocation::test(file!(), Entity::test("noop"), None)?;
     let mut packets = op
-      .handle(stream, Context::new(config, None, panic_callback()))
+      .handle(inv, stream, Context::new(config, None, panic_callback()))
       .await?
       .collect::<Vec<_>>()
       .await;

--- a/crates/wick/flow-graph-interpreter/src/interpreter/components/core_collection/sender.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/components/core_collection/sender.rs
@@ -1,7 +1,7 @@
 use flow_component::{ComponentError, Context, Operation};
 use serde_json::Value;
 use wick_interface_types::{operation, OperationSignature};
-use wick_packet::{packet_stream, PacketStream};
+use wick_packet::{packet_stream, Invocation, PacketStream};
 
 use crate::BoxFuture;
 #[derive()]
@@ -33,6 +33,7 @@ impl Operation for Op {
   type Config = SenderData;
   fn handle(
     &self,
+    _invocation: Invocation,
     _payload: PacketStream,
     context: Context<Self::Config>,
   ) -> BoxFuture<Result<PacketStream, ComponentError>> {

--- a/crates/wick/flow-graph-interpreter/src/interpreter/components/internal_collection.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/components/internal_collection.rs
@@ -35,7 +35,7 @@ impl Component for InternalCollection {
     _config: Option<wick_packet::OperationConfig>,
     _callback: std::sync::Arc<RuntimeCallback>,
   ) -> BoxFuture<Result<PacketStream, ComponentError>> {
-    trace!(target = %invocation.target, id=%invocation.id,namespace = NS_INTERNAL);
+    invocation.trace(|| trace!(target = %invocation.target, id=%invocation.id,namespace = NS_INTERNAL));
     let op = invocation.target.operation_id().to_owned();
 
     let is_oneshot = op == SCHEMATIC_INPUT || op == INTERNAL_ID_INHERENT;

--- a/crates/wick/flow-graph-interpreter/src/interpreter/components/null_component.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/components/null_component.rs
@@ -32,7 +32,7 @@ impl Component for NullComponent {
     _data: Option<wick_packet::OperationConfig>,
     _callback: std::sync::Arc<RuntimeCallback>,
   ) -> BoxFuture<Result<PacketStream, ComponentError>> {
-    trace!(target = %invocation.target, namespace = NS_CORE);
+    invocation.trace(|| trace!(target = %invocation.target, namespace = NS_CORE));
     async move { Ok(PacketStream::empty()) }.boxed()
   }
 

--- a/crates/wick/flow-graph-interpreter/src/interpreter/components/schematic_component.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/components/schematic_component.rs
@@ -75,7 +75,7 @@ impl Component for SchematicComponent {
     _config: Option<wick_packet::OperationConfig>,
     callback: Arc<RuntimeCallback>,
   ) -> BoxFuture<Result<PacketStream, ComponentError>> {
-    trace!(target = %invocation.target, namespace = NS_SELF);
+    invocation.trace(|| trace!(target = %invocation.target, namespace = NS_SELF));
 
     let operation = invocation.target.operation_id().to_owned();
     let fut = self
@@ -93,7 +93,6 @@ impl Component for SchematicComponent {
         )
       })
       .ok_or_else(|| Error::SchematicNotFound(operation.clone()));
-    trace!(%operation, "operation");
 
     Box::pin(async move {
       let span = trace_span!("ns_self", name = %operation);

--- a/crates/wick/flow-graph-interpreter/src/interpreter/error.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/error.rs
@@ -1,5 +1,6 @@
 use wick_packet::Entity;
 
+use super::components::core_collection::OpInitError;
 use super::executor::error::ExecutionError;
 use super::program::validator::error::{OperationInvalid, ValidationError};
 
@@ -21,6 +22,8 @@ pub enum Error {
   Shutdown(String),
   #[error("Namespace '{0}' already exists, can not overwrite")]
   DuplicateNamespace(String),
+  #[error(transparent)]
+  OperationInit(#[from] OpInitError),
 }
 
 #[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]

--- a/crates/wick/flow-graph-interpreter/src/interpreter/event_loop/state.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/event_loop/state.rs
@@ -123,9 +123,6 @@ impl State {
     tx.stats
       .mark(format!("input:{}:{}:ready", port.node_index(), port.port_index()));
 
-    let span = trace_span!("input", port = port_name, component = instance.id());
-    let _guard = span.enter();
-
     let is_schematic_output = port.node_index() == graph.output().index();
 
     if is_schematic_output {
@@ -157,9 +154,6 @@ impl State {
       port = port_name,
       "handling port output"
     );
-
-    let span = trace_span!("output", port = port_name, component = instance.id());
-    let _guard = span.enter();
 
     tx.stats
       .mark(format!("output:{}:{}:ready", port.node_index(), port.port_index()));

--- a/crates/wick/flow-graph-interpreter/src/interpreter/executor.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/executor.rs
@@ -44,7 +44,7 @@ impl SchematicExecutor {
     self_component: Arc<dyn Component + Send + Sync>,
     callback: Arc<RuntimeCallback>,
   ) -> Result<PacketStream> {
-    debug!(schematic = self.name(), ?invocation,);
+    invocation.trace(|| debug!(schematic = self.name(), ?invocation,));
 
     let seed = invocation.seed().map_or(seed, Seed::unsafe_new);
 
@@ -58,7 +58,6 @@ impl SchematicExecutor {
       callback,
       seed,
     );
-    trace!(tx_id = %transaction.id(), "invoking schematic");
     let stream = transaction.take_stream().unwrap();
     self.channel.dispatch_start(Box::new(transaction)).await;
     Ok(stream)

--- a/crates/wick/flow-graph-interpreter/src/interpreter/program/validator/error.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/program/validator/error.rs
@@ -54,7 +54,7 @@ impl std::fmt::Display for OperationInvalid {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     write!(
       f,
-      "Schematic '{}' could not be validated: {}",
+      "Flow '{}' could not be validated: {}",
       self.schematic,
       self.errors.iter().map(|e| e.to_string()).collect::<Vec<_>>().join(", ")
     )

--- a/crates/wick/flow-graph-interpreter/tests/test/mod.rs
+++ b/crates/wick/flow-graph-interpreter/tests/test/mod.rs
@@ -44,7 +44,7 @@ pub(crate) async fn base_setup(
     Box::new(test::TestComponent::new()),
   )])
   .unwrap();
-  let invocation = Invocation::new(Entity::test("test"), entity, None);
+  let invocation = Invocation::test("test", entity, None)?;
 
   let mut interpreter = Interpreter::new(
     Some(Seed::unsafe_new(1)),

--- a/crates/wick/flow-graph-interpreter/tests/test/mod.rs
+++ b/crates/wick/flow-graph-interpreter/tests/test/mod.rs
@@ -52,6 +52,7 @@ pub(crate) async fn base_setup(
     None,
     Some(collections),
     panic_callback(),
+    &tracing::Span::current(),
   )?;
   interpreter.start(options, None).await;
   let stream = wick_packet::PacketStream::new(Box::new(futures::stream::iter(packets.into_iter().map(Ok))));

--- a/crates/wick/flow-graph-interpreter/tests/test/test_component.rs
+++ b/crates/wick/flow-graph-interpreter/tests/test/test_component.rs
@@ -8,7 +8,7 @@ use futures::{Future, StreamExt};
 use seeded_random::{Random, Seed};
 use tokio::spawn;
 use tokio::task::JoinHandle;
-use tracing::trace;
+use tracing::{trace, Span};
 use wasmrs_rx::{FluxChannel, Observer};
 use wick_interface_types::{ComponentSignature, OperationSignature, TypeSignature};
 use wick_packet::{fan_out, packet_stream, ComponentReference, Invocation, Packet, PacketStream};
@@ -213,7 +213,9 @@ fn handler(
           let link: ComponentReference = component.deserialize().unwrap();
           let message: String = message.deserialize().unwrap();
           let packets = packet_stream!(("input", message));
-          let mut response = callback(link, "reverse".to_owned(), packets, None, None).await.unwrap();
+          let mut response = callback(link, "reverse".to_owned(), packets, None, None, &Span::current())
+            .await
+            .unwrap();
           while let Some(Ok(res)) = response.next().await {
             defer(vec![send(res.set_port("output"))]);
           }

--- a/crates/wick/flow-graph/Cargo.toml
+++ b/crates/wick/flow-graph/Cargo.toml
@@ -9,7 +9,6 @@ description = "A representation of a graph data structure for flow-based program
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 thiserror = { workspace = true }
-tracing = { workspace = true }
 
 [dev-dependencies]
 serde_json = { workspace = true }
@@ -20,3 +19,4 @@ tokio = { workspace = true, features = ["macros", "rt"] }
 wick-logger = { workspace = true }
 test-logger = { workspace = true }
 anyhow = { workspace = true }
+tracing = { workspace = true }

--- a/crates/wick/flow-graph/src/lib.rs
+++ b/crates/wick/flow-graph/src/lib.rs
@@ -111,6 +111,3 @@ pub use schematic::{
 };
 
 pub(crate) mod util;
-
-#[macro_use]
-extern crate tracing;

--- a/crates/wick/flow-graph/src/network.rs
+++ b/crates/wick/flow-graph/src/network.rs
@@ -42,7 +42,7 @@ mod test {
   {
   }
 
-  #[test_logger::test]
+  #[test]
   fn test_sync_send() -> Result<()> {
     sync_send::<Network<Option<()>>>();
     Ok(())

--- a/crates/wick/flow-graph/src/node.rs
+++ b/crates/wick/flow-graph/src/node.rs
@@ -164,7 +164,7 @@ where
   }
 
   pub fn add_input<T: AsStr>(&mut self, port: T) -> PortReference {
-    let port_ref = match self.kind {
+    match self.kind {
       NodeKind::Output(_) => {
         self.outputs.add(&port, self.index);
         self.inputs.add(&port, self.index)
@@ -174,15 +174,7 @@ where
         panic!("You can not manually add inputs to {} nodes", self.kind);
       }
       NodeKind::External(_) => self.inputs.add(&port, self.index),
-    };
-    trace!(
-      index = self.index,
-      port = port.as_ref(),
-      node = self.id(),
-      r#ref = %port_ref,
-      "added input port"
-    );
-    port_ref
+    }
   }
 
   pub(crate) fn connect_input(&mut self, port: PortIndex, connection: ConnectionIndex) -> Result<(), Error> {
@@ -217,7 +209,7 @@ where
   }
 
   pub fn add_output<T: AsStr>(&mut self, port: T) -> PortReference {
-    let port_ref = match self.kind {
+    match self.kind {
       NodeKind::Input(_) | NodeKind::Inherent(_) => {
         self.inputs.add(&port, self.index);
         self.outputs.add(&port, self.index)
@@ -227,16 +219,7 @@ where
         panic!("You can not manually add outputs to {} nodes", self.kind);
       }
       NodeKind::External(_) => self.outputs.add(&port, self.index),
-    };
-    trace!(
-      index = self.index,
-      port = port.as_ref(),
-      node = self.id(),
-      r#ref = %port_ref,
-      "added output port"
-    );
-
-    port_ref
+    }
   }
 
   pub(crate) fn connect_output(&mut self, port: PortIndex, connection: ConnectionIndex) -> Result<(), Error> {

--- a/crates/wick/flow-graph/src/schematic.rs
+++ b/crates/wick/flow-graph/src/schematic.rs
@@ -111,14 +111,12 @@ where
   }
 
   pub fn add_input<T: AsStr>(&mut self, port: T) -> PortReference {
-    trace!(port=%port.as_ref(), "add schematic input");
     let input = self.get_mut(self.input).unwrap();
     input.add_input(&port);
     input.add_output(port)
   }
 
   pub fn add_output<T: AsStr>(&mut self, port: T) -> PortReference {
-    trace!(port=%port.as_ref(), "add schematic output");
     let output = self.get_mut(self.output).unwrap();
     output.add_output(&port);
     output.add_input(port)
@@ -204,13 +202,11 @@ where
 
   pub fn add_external<T: AsStr>(&mut self, name: T, reference: NodeReference, data: Option<DATA>) -> NodeIndex {
     let name = name.as_ref().to_owned();
-    trace!(%name, %reference, "adding external node");
     self.add_node(name, NodeKind::External(reference), data)
   }
 
   pub fn add_inherent<T: AsStr>(&mut self, name: T, reference: NodeReference, data: Option<DATA>) -> NodeIndex {
     let name = name.as_ref().to_owned();
-    trace!(%name, %reference, "adding inherent node");
     self.add_node(name, NodeKind::Inherent(reference), data)
   }
 
@@ -218,13 +214,9 @@ where
     let existing_index = self.node_map.get(&name);
 
     match existing_index {
-      Some(index) => {
-        trace!(%name, index, %kind, "retrieving existing node");
-        *index
-      }
+      Some(index) => *index,
       None => {
         let index = self.nodes.len();
-        trace!(%name, index, %kind, "added node");
         let node = Node::new(&name, index, kind, data);
         self.nodes.push(node);
         self.node_map.insert(name, index);
@@ -234,7 +226,6 @@ where
   }
 
   pub fn connect(&mut self, from: PortReference, to: PortReference, data: Option<DATA>) -> Result<(), Error> {
-    trace!(%from, %to, "connecting");
     let connection_index = self.connections.len();
     let downstream_node = &mut self.nodes[to.node_index];
     downstream_node.connect_input(to.port_index, connection_index)?;

--- a/crates/wick/wick-asset-reference/src/asset_reference.rs
+++ b/crates/wick/wick-asset-reference/src/asset_reference.rs
@@ -291,7 +291,6 @@ impl Asset for AssetReference {
     let path = self.path();
     let location = self.location().to_owned();
 
-    debug!(path = ?path, "fetching asset");
     let cache_location = self.cache_location.clone();
     Box::pin(async move {
       let path = path.map_err(|e| assets::Error::Parse(e.to_string()))?;
@@ -301,6 +300,7 @@ impl Asset for AssetReference {
       }
       let file = tokio::fs::File::open(&pb).await;
       if file.is_ok() {
+        debug!(path = ?path, "fetching local asset");
         let mut file = tokio::fs::File::open(&path)
           .await
           .map_err(|err| assets::Error::FileOpen(path.clone(), err.to_string()))?;
@@ -308,6 +308,7 @@ impl Asset for AssetReference {
         file.read_to_end(&mut bytes).await?;
         Ok(bytes)
       } else {
+        debug!(path = ?path, "fetching remote asset");
         let (cache_loc, bytes) = retrieve_remote(&location, options)
           .await
           .map_err(|err| assets::Error::FileOpen(path.clone(), err.to_string()))?;

--- a/crates/wick/wick-component-cli/src/cli.rs
+++ b/crates/wick/wick-component-cli/src/cli.rs
@@ -18,7 +18,7 @@ pub struct Mesh(); // Dummy struct if "mesh" feature is not enabled
 #[cfg(feature = "reflection")]
 pub(crate) const FILE_DESCRIPTOR_SET: &[u8] = include_bytes!("../../wick-rpc/src/generated/descriptors.bin");
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[must_use]
 /// Metadata for the running server.
 pub struct ServerState {
@@ -30,6 +30,7 @@ pub struct ServerState {
 }
 
 /// Struct that holds control methods and metadata for a running service.
+#[derive(Clone)]
 pub struct ServerControl {
   /// The address of the RPC server.
   pub addr: SocketAddr,

--- a/crates/wick/wick-component-wasm/src/wasm_host.rs
+++ b/crates/wick/wick-component-wasm/src/wasm_host.rs
@@ -6,6 +6,7 @@ use std::time::Instant;
 use flow_component::RuntimeCallback;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
+use tracing::Span;
 use wasmrs::{GenericError, OperationHandler, RSocket, RawPayload};
 use wasmrs_codec::messagepack::serialize;
 use wasmrs_host::{CallContext, Host, WasiParams};
@@ -24,6 +25,7 @@ pub struct WasmHostBuilder {
   callback: Option<Arc<RuntimeCallback>>,
   min_threads: usize,
   max_threads: usize,
+  span: Span,
 }
 
 impl std::fmt::Debug for WasmHostBuilder {
@@ -35,10 +37,11 @@ impl std::fmt::Debug for WasmHostBuilder {
 }
 
 impl WasmHostBuilder {
-  pub fn new() -> Self {
+  pub fn new(span: Span) -> Self {
     Self {
       wasi_params: None,
       callback: None,
+      span,
       min_threads: 1,
       max_threads: 1,
     }
@@ -68,6 +71,7 @@ impl WasmHostBuilder {
       &self.callback,
       self.min_threads,
       self.max_threads,
+      self.span,
     )
   }
 
@@ -82,12 +86,6 @@ impl WasmHostBuilder {
   }
 }
 
-impl Default for WasmHostBuilder {
-  fn default() -> Self {
-    Self::new()
-  }
-}
-
 #[derive()]
 pub struct WasmHost {
   #[allow(unused)]
@@ -95,6 +93,7 @@ pub struct WasmHost {
   claims: Claims<CollectionClaims>,
   ctx: Arc<CallContext>,
   _rng: seeded_random::Random,
+  span: Span,
 }
 
 impl std::fmt::Debug for WasmHost {
@@ -110,8 +109,10 @@ impl WasmHost {
     callback: &Option<Arc<RuntimeCallback>>,
     _min_threads: usize,
     _max_threads: usize,
+    span: Span,
   ) -> Result<Self> {
     let jwt = &module.token.jwt;
+    let _span = span.enter();
 
     wick_wascap::validate_token::<CollectionClaims>(jwt).map_err(|e| Error::ClaimsInvalid(e.to_string()))?;
 
@@ -137,11 +138,13 @@ impl WasmHost {
     }
     let ctx = host.new_context(128 * 1024, 128 * 1024).unwrap();
 
+    drop(_span);
     Ok(Self {
       claims: module.claims().clone(),
       host: Arc::new(Mutex::new(host)),
       ctx: Arc::new(ctx),
       _rng: seeded_random::Random::new(),
+      span,
     })
   }
 
@@ -152,6 +155,7 @@ impl WasmHost {
     stream: PacketStream,
     config: Option<wick_packet::OperationConfig>,
   ) -> Result<PacketStream> {
+    let _span = self.span.enter();
     let component_name = invocation.target.operation_id();
     debug!(component = component_name, "wasm invoke");
     let seed = invocation.seed();
@@ -175,27 +179,34 @@ impl WasmHost {
   }
 
   pub async fn setup(&self, provided: SetupPayload) -> Result<()> {
-    debug!("wasm setup");
-
     let ctx = self.ctx.clone();
-    let index = ctx
-      .get_export("wick", "__setup")
-      .map_err(|_| crate::Error::SetupOperation)?;
-    let metadata = wasmrs::Metadata::new(index);
-    let data = serialize(&provided).unwrap();
-    let payload = RawPayload::new(metadata.encode(), data.into());
-    match ctx.request_response(payload).await {
-      Ok(_) => {
-        debug!("setup finished");
-      }
-      Err(e) => {
-        error!("setup failed: {}", e);
-        return Err(Error::Setup(e));
-      }
-    }
+    let payload = self.span.in_scope(|| {
+      debug!("wasm setup");
 
-    trace!("wasm setup finished");
-    Ok(())
+      let index = ctx
+        .get_export("wick", "__setup")
+        .map_err(|_| crate::Error::SetupOperation)?;
+      let metadata = wasmrs::Metadata::new(index);
+      let data = serialize(&provided).unwrap();
+      Ok::<_, WasmCollectionError>(RawPayload::new(metadata.encode(), data.into()))
+    })?;
+
+    let result = ctx.request_response(payload).await;
+
+    self.span.in_scope(|| {
+      match result {
+        Ok(_) => {
+          debug!("setup finished");
+        }
+        Err(e) => {
+          error!("setup failed: {}", e);
+          return Err(Error::Setup(e));
+        }
+      }
+
+      trace!("wasm setup finished");
+      Ok(())
+    })
   }
 
   pub fn get_operations(&self) -> &ComponentSignature {
@@ -215,35 +226,37 @@ fn make_host_callback(
   rt_cb: &Arc<RuntimeCallback>,
 ) -> OperationHandler<wasmrs::IncomingStream, wasmrs::OutgoingStream> {
   let cb = rt_cb.clone();
+  let span = tracing::info_span!("wasmrs callback");
   let func = move |mut incoming: wasmrs::IncomingStream| -> std::result::Result<wasmrs::OutgoingStream, GenericError> {
     use tokio_stream::StreamExt;
     let (tx, rx) = FluxChannel::new_parts();
     let cb = cb.clone();
+    let span = span.clone();
     tokio::spawn(async move {
       let first = incoming.next().await;
       let meta = if let Some(Ok(first)) = first {
         match wasmrs_codec::messagepack::deserialize::<InvocationPayload>(&first.data) {
           Ok(p) => p,
           Err(e) => {
-            error!("bad component ref invocation: {}", e);
+            span.in_scope(|| error!("bad component ref invocation: {}", e));
             let _ = tx.error(wick_packet::Error::component_error(e.to_string()));
             return;
           }
         }
       } else {
-        error!("bad component ref invocation: no payload");
+        span.in_scope(|| error!("bad component ref invocation: no payload"));
         let _ = tx.error(wick_packet::Error::component_error("no payload"));
         return;
       };
       let stream = from_wasmrs(incoming);
-      match cb(meta.reference, meta.operation, stream, None, None).await {
+      match cb(meta.reference, meta.operation, stream, None, None, &span).await {
         Ok(mut response) => {
           while let Some(p) = response.next().await {
             let _ = tx.send_result(p);
           }
         }
         Err(e) => {
-          error!("bad component ref invocation: {}", e);
+          span.in_scope(|| error!("bad component ref invocation: {}", e));
           let _ = tx.error(wick_packet::Error::component_error(e.to_string()));
         }
       }

--- a/crates/wick/wick-config/docs/v1.html
+++ b/crates/wick/wick-config/docs/v1.html
@@ -982,7 +982,7 @@
   <a name="fallback">fallback</a>
 </h3>
 
-<span class="description field-description">Fallback path (relative to `path`) for files to serve in case of a 404. Useful for SPA's. if path: /www and fallback: index.html, then a 404 will serve /www/index.html</span>
+<span class="description field-description">Fallback path (relative to volume `resource`) for files to serve in case of a 404. Useful for SPA's. if volume resource is: /www and fallback: index.html, then a 404 will serve /www/index.html</span>
 
 
 <ul class="field-notes">

--- a/crates/wick/wick-config/json-schema/manifest.json
+++ b/crates/wick/wick-config/json-schema/manifest.json
@@ -970,7 +970,7 @@
             "type": "string"
           },
           "fallback": {
-            "description": "Fallback path (relative to &#x60;path&#x60;) for files to serve in case of a 404. Useful for SPA&#x27;s. if path: /www and fallback: index.html, then a 404 will serve /www/index.html",
+            "description": "Fallback path (relative to volume &#x60;resource&#x60;) for files to serve in case of a 404. Useful for SPA&#x27;s. if volume resource is: /www and fallback: index.html, then a 404 will serve /www/index.html",
             "required": false,
             "type": "string"
           }

--- a/crates/wick/wick-config/json-schema/v1/manifest.json
+++ b/crates/wick/wick-config/json-schema/v1/manifest.json
@@ -613,7 +613,7 @@
           "type": "string"
         },
         "fallback": {
-          "description": "Fallback path (relative to &#x60;path&#x60;) for files to serve in case of a 404. Useful for SPA&#x27;s. if path: /www and fallback: index.html, then a 404 will serve /www/index.html",
+          "description": "Fallback path (relative to volume &#x60;resource&#x60;) for files to serve in case of a 404. Useful for SPA&#x27;s. if volume resource is: /www and fallback: index.html, then a 404 will serve /www/index.html",
           "required": false,
 
           "type": "string"

--- a/crates/wick/wick-config/src/import_cache.rs
+++ b/crates/wick/wick-config/src/import_cache.rs
@@ -4,7 +4,6 @@ use std::sync::Arc;
 use asset_container::Asset;
 use flow_component::BoxFuture;
 use parking_lot::RwLock;
-use tracing::trace;
 use wick_asset_reference::{AssetReference, FetchOptions};
 use wick_interface_types::TypeDefinition;
 
@@ -53,7 +52,6 @@ pub(crate) async fn setup_cache(
   mut init: Vec<TypeDefinition>,
   options: FetchOptions,
 ) -> Result<(), ManifestError> {
-  trace!("manifest:cache:setup");
   if cached_types.read().is_some() {
     return Ok(());
   }

--- a/crates/wick/wick-config/src/v1.rs
+++ b/crates/wick/wick-config/src/v1.rs
@@ -484,7 +484,7 @@ pub(crate) struct StaticRouter {
 
   #[serde(deserialize_with = "crate::helpers::with_expand_envs_string")]
   pub(crate) volume: String,
-  /// Fallback path (relative to &#x60;path&#x60;) for files to serve in case of a 404. Useful for SPA&#x27;s. if path: /www and fallback: index.html, then a 404 will serve /www/index.html
+  /// Fallback path (relative to volume &#x60;resource&#x60;) for files to serve in case of a 404. Useful for SPA&#x27;s. if volume resource is: /www and fallback: index.html, then a 404 will serve /www/index.html
 
   #[serde(default)]
   #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/wick/wick-host/Cargo.toml
+++ b/crates/wick/wick-host/Cargo.toml
@@ -29,6 +29,7 @@ parking_lot = { workspace = true }
 uuid = { workspace = true }
 futures = { workspace = true }
 option-utils = { workspace = true }
+derive_builder = { workspace = true }
 
 [dev-dependencies]
 wick-logger = { workspace = true }

--- a/crates/wick/wick-host/examples/basic-host.rs
+++ b/crates/wick/wick-host/examples/basic-host.rs
@@ -2,7 +2,7 @@ use wick_host::{ComponentHostBuilder, Error};
 
 #[tokio::main]
 async fn main() -> Result<(), Error> {
-  let mut host = ComponentHostBuilder::new().build();
+  let mut host = ComponentHostBuilder::new().build().unwrap();
   host.start(None).await?;
 
   println!("Host started, waiting for ctrl-c / SIGINT");

--- a/crates/wick/wick-host/src/app_host.rs
+++ b/crates/wick/wick-host/src/app_host.rs
@@ -1,20 +1,27 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use futures::future::join_all;
+use futures::future::{join_all, select};
+use futures::pin_mut;
 use tokio::task::{JoinError, JoinHandle};
-use wick_config::config::{AppConfiguration, WickConfiguration};
+use tracing::Span;
+use wick_config::config::AppConfiguration;
 use wick_runtime::error::RuntimeError;
 use wick_runtime::resources::Resource;
 use wick_runtime::Trigger;
 
 use crate::{Error, Result};
 
+#[derive(derive_builder::Builder)]
+#[builder(derive(Debug), setter(into))]
 /// A Wick Host wraps a Wick runtime with server functionality like persistence,.
 #[must_use]
 pub struct AppHost {
   manifest: AppConfiguration,
+  #[builder(setter(skip))]
   triggers: Option<TriggerState>,
+  #[builder(default = "tracing::Span::current()")]
+  span: Span,
 }
 
 impl std::fmt::Debug for AppHost {
@@ -25,7 +32,7 @@ impl std::fmt::Debug for AppHost {
 
 impl AppHost {
   pub fn start(&mut self, _seed: Option<u64>) -> Result<()> {
-    debug!("host starting");
+    self.span.in_scope(|| debug!("host starting"));
 
     let resources = self.init_resources()?;
     self.start_triggers(resources)?;
@@ -36,7 +43,7 @@ impl AppHost {
   /// Stops a running host.
   #[allow(clippy::unused_async)]
   pub async fn stop(self) {
-    debug!("host stopping");
+    self.span.in_scope(|| debug!("host stopping"));
   }
 
   fn init_resources(&mut self) -> Result<HashMap<String, Resource>> {
@@ -50,10 +57,12 @@ impl AppHost {
 
   fn start_triggers(&mut self, resources: HashMap<String, Resource>) -> Result<()> {
     assert!(self.triggers.is_none(), "triggers already started");
+
     let resources = Arc::new(resources);
     let mut triggers = TriggerState::new();
+
     for trigger_config in self.manifest.triggers() {
-      debug!(?trigger_config, "loading trigger");
+      self.span.in_scope(|| debug!(?trigger_config, "loading trigger"));
       let config = trigger_config.clone();
       let name = self.manifest.name().to_owned();
       let app_config = self.manifest.clone();
@@ -63,9 +72,14 @@ impl AppHost {
           let loader = loader()?;
           let inner = loader.clone();
           let resources = resources.clone();
+          let span = debug_span!("trigger", kind=%trigger_config.kind());
+
           let task = tokio::spawn(async move {
-            if let Err(e) = inner.run(name, app_config, config, resources).await {
-              error!("trigger failed to start: {}", e);
+            span.in_scope(|| trace!("initializing trigger"));
+            if let Err(e) = inner.run(name, app_config, config, resources, span.clone()).await {
+              span.in_scope(|| error!("trigger failed to start: {}", e));
+            } else {
+              span.in_scope(|| debug!("trigger initialized"));
             };
             Ok(())
           });
@@ -95,11 +109,23 @@ impl AppHost {
       .map(|(trigger, task)| (trigger, task.unwrap()))
       .unzip();
     join_all(start_tasks).await;
-    debug!("all triggers started");
+    self.span.in_scope(|| debug!("all triggers started"));
     for trigger in triggers.iter() {
-      trigger.wait_for_done().await;
+      let ctrl_c = async {
+        let _ = tokio::signal::ctrl_c().await;
+      };
+      pin_mut!(ctrl_c);
+      match select(ctrl_c, trigger.wait_for_done()).await {
+        futures::future::Either::Left(_) => {
+          self.span.in_scope(|| debug!("ctrl-c received, stopping triggers"));
+          break;
+        }
+        futures::future::Either::Right(_) => {
+          self.span.in_scope(|| debug!("trigger finished"));
+        }
+      }
     }
-    debug!("all triggers finished");
+    self.span.in_scope(|| debug!("all triggers finished"));
 
     Ok(())
   }
@@ -141,48 +167,11 @@ impl TriggerState {
   }
 }
 
-/// The HostBuilder builds the configuration for a Wick Host.
-#[must_use]
-#[derive(Debug, Clone)]
-pub struct AppHostBuilder {
-  manifest: AppConfiguration,
-}
-
-impl Default for AppHostBuilder {
-  fn default() -> Self {
-    Self::new()
-  }
-}
-
 impl AppHostBuilder {
   /// Creates a new host builder.
+  #[must_use]
   pub fn new() -> AppHostBuilder {
-    AppHostBuilder {
-      manifest: AppConfiguration::default(),
-    }
-  }
-
-  pub async fn from_manifest_url(location: &str, allow_latest: bool, insecure_registries: &[String]) -> Result<Self> {
-    let fetch_options = wick_config::config::FetchOptions::new()
-      .allow_latest(allow_latest)
-      .allow_insecure(insecure_registries);
-
-    let manifest = WickConfiguration::fetch(location, fetch_options)
-      .await?
-      .try_app_config()?;
-    Ok(Self::from_definition(manifest))
-  }
-
-  pub fn from_definition(definition: AppConfiguration) -> Self {
-    AppHostBuilder { manifest: definition }
-  }
-
-  /// Constructs an instance of a Wick host.
-  pub fn build(self) -> AppHost {
-    AppHost {
-      manifest: self.manifest,
-      triggers: None,
-    }
+    AppHostBuilder::default()
   }
 }
 

--- a/crates/wick/wick-host/src/component_host.rs
+++ b/crates/wick/wick-host/src/component_host.rs
@@ -6,11 +6,11 @@ use flow_component::SharedComponent;
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 use seeded_random::Seed;
+use tracing::Span;
 use uuid::Uuid;
 use wick_component_cli::options::{Options as HostOptions, ServerOptions};
 use wick_component_cli::ServerState;
 use wick_config::config::ComponentConfiguration;
-use wick_config::WickConfiguration;
 use wick_interface_types::ComponentSignature;
 use wick_packet::{Entity, InherentData, Invocation, OperationConfig, PacketStream};
 use wick_runtime::{EngineComponent, Runtime, RuntimeBuilder};
@@ -28,19 +28,26 @@ fn from_registry(id: Uuid) -> SharedComponent {
 
 /// A Wick Host wraps a Wick runtime with server functionality like persistence,.
 #[must_use]
-#[derive(Debug)]
+#[derive(Debug, derive_builder::Builder)]
+#[builder(derive(Debug), setter(into))]
 pub struct ComponentHost {
+  #[builder(default = "Uuid::new_v4().to_string()")]
   id: String,
+  #[builder(default)]
   runtime: Option<Runtime>,
+  #[builder(default)]
   manifest: ComponentConfiguration,
+  #[builder(default, setter(strip_option))]
   server_metadata: Option<ServerState>,
+  #[builder(default = "tracing::Span::current()")]
+  span: Span,
 }
 
 impl ComponentHost {
   /// Starts the host. This call is non-blocking, so it is up to the consumer
   /// to wait with a method like `host.wait_for_sigint()`.
   pub async fn start(&mut self, seed: Option<u64>) -> Result<()> {
-    debug!("host starting");
+    self.span.in_scope(|| debug!("host starting"));
 
     // self.mesh = self.get_mesh().await?;
     self.start_engine(seed.map(Seed::unsafe_new)).await?;
@@ -73,7 +80,7 @@ impl ComponentHost {
 
   /// Stops a running host.
   pub async fn stop(self) {
-    debug!("host stopping");
+    self.span.in_scope(|| debug!("host stopping"));
     if let Some(engine) = self.runtime {
       let _ = engine.shutdown().await;
     }
@@ -93,17 +100,17 @@ impl ComponentHost {
       crate::Error::InvalidHostState("Host already has a engine running".into())
     );
 
-    let mut engine_builder = RuntimeBuilder::from_definition(self.manifest.clone())?;
-    if let Some(seed) = seed {
-      engine_builder = engine_builder.with_seed(seed);
-    }
+    let mut engine_builder = RuntimeBuilder::from_definition(self.manifest.clone());
+    let span = debug_span!("host");
+    span.follows_from(&self.span);
+    engine_builder = engine_builder.span(span);
     engine_builder = engine_builder.namespace(self.get_host_id());
     engine_builder = engine_builder.allow_latest(self.manifest.allow_latest());
     if let Some(insecure) = self.manifest.insecure_registries() {
-      engine_builder = engine_builder.allow_insecure(insecure.to_vec());
+      engine_builder = engine_builder.allowed_insecure(insecure.to_vec());
     }
 
-    let engine = engine_builder.build().await?;
+    let engine = engine_builder.build(seed).await?;
 
     self.runtime = Some(engine);
     Ok(())
@@ -146,7 +153,12 @@ impl ComponentHost {
   ) -> Result<PacketStream> {
     match &self.runtime {
       Some(runtime) => {
-        let invocation = Invocation::new(Entity::server(&self.id), Entity::operation(&self.id, operation), data);
+        let invocation = Invocation::new(
+          Entity::server(&self.id),
+          Entity::operation(&self.id, operation),
+          data,
+          &self.span,
+        );
         Ok(runtime.invoke(invocation, stream, None).await?)
       }
       None => Err(crate::Error::InvalidHostState("No engine available".into())),
@@ -167,7 +179,7 @@ impl ComponentHost {
 
   pub async fn wait_for_sigint(&self) -> Result<()> {
     tokio::signal::ctrl_c().await.unwrap();
-    debug!("SIGINT received");
+    self.span.in_scope(|| debug!("SIGINT received"));
     Ok(())
   }
 
@@ -182,52 +194,11 @@ impl ComponentHost {
   }
 }
 
-/// The HostBuilder builds the configuration for a Wick Host.
-#[must_use]
-#[derive(Debug, Clone)]
-pub struct ComponentHostBuilder {
-  manifest: ComponentConfiguration,
-}
-
-impl Default for ComponentHostBuilder {
-  fn default() -> Self {
-    Self::new()
-  }
-}
-
 impl ComponentHostBuilder {
   /// Creates a new host builder.
+  #[must_use]
   pub fn new() -> ComponentHostBuilder {
-    ComponentHostBuilder {
-      manifest: ComponentConfiguration::default(),
-    }
-  }
-
-  pub async fn from_manifest_url(location: &str, allow_latest: bool, insecure_registries: &[String]) -> Result<Self> {
-    let fetch_options = wick_config::config::FetchOptions::new()
-      .allow_latest(allow_latest)
-      .allow_insecure(insecure_registries);
-
-    let manifest = WickConfiguration::fetch(location, fetch_options)
-      .await?
-      .try_component_config()?;
-    Ok(Self::from_definition(manifest))
-  }
-
-  pub fn from_definition(definition: ComponentConfiguration) -> Self {
-    ComponentHostBuilder { manifest: definition }
-  }
-
-  /// Constructs an instance of a Wick host.
-  pub fn build(self) -> ComponentHost {
-    let host_id = Uuid::new_v4().to_string();
-
-    ComponentHost {
-      id: host_id,
-      runtime: None,
-      manifest: self.manifest,
-      server_metadata: None,
-    }
+    ComponentHostBuilder::default()
   }
 }
 
@@ -241,6 +212,7 @@ mod test {
   use futures::StreamExt;
   use http::Uri;
   use wick_config::config::HttpConfigBuilder;
+  use wick_config::WickConfiguration;
   use wick_invocation_server::connect_rpc_client;
   use wick_packet::{packet_stream, packets, Entity, Packet};
 
@@ -254,7 +226,7 @@ mod test {
 
   #[test_logger::test(tokio::test)]
   async fn should_start_and_stop() -> Result<()> {
-    let mut host = ComponentHostBuilder::new().build();
+    let mut host = ComponentHostBuilder::new().build()?;
 
     host.start(None).await?;
     assert!(host.is_started());
@@ -267,7 +239,7 @@ mod test {
   async fn request_direct() -> Result<()> {
     let file = PathBuf::from("manifests/logger.yaml");
     let manifest = WickConfiguration::load_from_file(&file).await?.try_component_config()?;
-    let mut host = ComponentHostBuilder::from_definition(manifest).build();
+    let mut host = ComponentHostBuilder::default().manifest(manifest).build()?;
     host.start(None).await?;
     let passed_data = "logging output";
     let stream = packet_stream!(("input", passed_data));
@@ -296,7 +268,7 @@ mod test {
         .build()?,
     );
 
-    let mut host = ComponentHostBuilder::from_definition(def).build();
+    let mut host = ComponentHostBuilder::default().manifest(def).build()?;
     host.start(None).await?;
     let address = host.rpc_address().unwrap();
     println!("rpc server bound to : {}", address);
@@ -305,7 +277,7 @@ mod test {
     println!("connected to server");
     let passed_data = "logging output";
     let packets = packets![("input", passed_data)];
-    let invocation: wick_rpc::rpc::Invocation = Invocation::new(Entity::test("test"), Entity::local("logger"), None)
+    let invocation: wick_rpc::rpc::Invocation = Invocation::test("test", Entity::local("logger"), None)?
       .try_into()
       .unwrap();
 

--- a/crates/wick/wick-logger/Cargo.toml
+++ b/crates/wick/wick-logger/Cargo.toml
@@ -14,19 +14,15 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = [
   "env-filter",
   "fmt",
-  "json",
   "time",
+  "parking_lot"
 ] }
-tracing-bunyan-formatter = "0.3"
-tracing-appender = "0.2"
-time = { version = "0.3", features = ["formatting"] }
-ansi_term = "0.12"
-tokio = { workspace = true, features = ["rt"] }
+tracing-appender = { workspace = true }
+time = { workspace = true, features = ["formatting"] }
+ansi_term = { workspace = true }
+tokio = { workspace = true }
 thiserror = { workspace = true }
 tracing-opentelemetry = { workspace = true }
 opentelemetry = { workspace = true, features = ["rt-tokio"] }
-opentelemetry-jaeger = { workspace = true, features = [
-  "rt-tokio",
-  "hyper_collector_client",
-  "collector_client"
-] }
+opentelemetry-otlp = { workspace = true, features = ["tokio"] }
+tokio-stream = { workspace = true }

--- a/crates/wick/wick-logger/src/lib.rs
+++ b/crates/wick/wick-logger/src/lib.rs
@@ -98,7 +98,7 @@ pub use options::{LogLevel, LoggingOptions};
 /// The main Logger module.
 mod logger;
 
-pub use crate::logger::{init, init_defaults, init_test, LoggingGuard};
+pub use crate::logger::{init, init_test, with_default, LoggingGuard};
 
 #[macro_use]
 extern crate tracing;

--- a/crates/wick/wick-logger/src/logger/otel.rs
+++ b/crates/wick/wick-logger/src/logger/otel.rs
@@ -1,0 +1,46 @@
+use opentelemetry::sdk::trace::{self, Builder, Sampler};
+use opentelemetry::sdk::{self, Resource};
+use opentelemetry::trace::{TraceError, TracerProvider};
+use opentelemetry::KeyValue;
+use opentelemetry_otlp::{SpanExporter, SpanExporterBuilder, WithExportConfig};
+
+fn exporter_builder(endpoint: &str) -> SpanExporter {
+  SpanExporterBuilder::from(opentelemetry_otlp::new_exporter().tonic().with_endpoint(endpoint))
+    .build_span_exporter()
+    .unwrap()
+}
+
+fn trace_config() -> Option<trace::Config> {
+  Some(
+    trace::config()
+      .with_sampler(Sampler::AlwaysOn)
+      .with_resource(Resource::new(vec![KeyValue::new("service.name", "wick")])),
+  )
+}
+
+pub(super) fn build_batch(endpoint: &str) -> Result<(sdk::trace::Tracer, sdk::trace::TracerProvider), TraceError> {
+  Ok(build_with_exporter(
+    sdk::trace::TracerProvider::builder()
+      .with_batch_exporter(exporter_builder(endpoint), opentelemetry::runtime::Tokio),
+    trace_config(),
+  ))
+}
+
+pub(super) fn build_simple(endpoint: &str) -> Result<(sdk::trace::Tracer, sdk::trace::TracerProvider), TraceError> {
+  Ok(build_with_exporter(
+    sdk::trace::TracerProvider::builder().with_simple_exporter(exporter_builder(endpoint)),
+    trace_config(),
+  ))
+}
+
+pub(super) fn build_with_exporter(
+  mut provider_builder: Builder,
+  trace_config: Option<sdk::trace::Config>,
+) -> (sdk::trace::Tracer, sdk::trace::TracerProvider) {
+  if let Some(config) = trace_config {
+    provider_builder = provider_builder.with_config(config);
+  }
+  let provider = provider_builder.build();
+  let tracer = provider.versioned_tracer("opentelemetry-otlp", Some(env!("CARGO_PKG_VERSION")), None);
+  (tracer, provider)
+}

--- a/crates/wick/wick-logger/src/options.rs
+++ b/crates/wick/wick-logger/src/options.rs
@@ -19,10 +19,13 @@ pub struct LoggingOptions {
   pub log_dir: Option<PathBuf>,
 
   /// The endpoint to send jaeger-format traces.
-  pub jaeger_endpoint: Option<String>,
+  pub otlp_endpoint: Option<String>,
 
   /// The application doing the logging.
   pub app_name: String,
+
+  /// Whether to install the global logger.
+  pub global: bool,
 }
 
 impl LoggingOptions {

--- a/crates/wick/wick-packet/src/collection_link.rs
+++ b/crates/wick/wick-packet/src/collection_link.rs
@@ -18,10 +18,15 @@ impl ComponentReference {
 
   #[cfg(feature = "invocation")]
   /// Create an [crate::Invocation] for this component reference.
-  pub fn to_invocation(&self, operation: &str, inherent: Option<crate::InherentData>) -> crate::Invocation {
+  pub fn to_invocation(
+    &self,
+    operation: &str,
+    inherent: Option<crate::InherentData>,
+    follows_from: &tracing::Span,
+  ) -> crate::Invocation {
     let target = crate::Entity::operation(self.target.component_id(), operation);
 
-    crate::Invocation::new(self.origin.clone(), target, inherent)
+    crate::Invocation::new(self.origin.clone(), target, inherent, follows_from)
   }
 
   #[must_use]

--- a/crates/wick/wick-rpc/src/types/conversions.rs
+++ b/crates/wick/wick-rpc/src/types/conversions.rs
@@ -243,6 +243,7 @@ impl TryFrom<rpc::Invocation> for wick_packet::Invocation {
         seed: d.seed,
         timestamp: d.timestamp,
       }),
+      span: tracing::Span::current(),
     })
   }
 }

--- a/crates/wick/wick-runtime/Cargo.toml
+++ b/crates/wick/wick-runtime/Cargo.toml
@@ -52,6 +52,7 @@ url = { workspace = true }
 bytes = { workspace = true }
 hyper-staticfile = "0.9"
 hyper-reverse-proxy = "0.5"
+derive_builder = { workspace = true }
 
 [dev-dependencies]
 wick-invocation-server = { workspace = true }

--- a/crates/wick/wick-runtime/src/components/engine_component.rs
+++ b/crates/wick/wick-runtime/src/components/engine_component.rs
@@ -46,7 +46,7 @@ impl Component for EngineComponent {
       let engine = RuntimeService::for_id(&self.engine_id)
         .ok_or_else(|| flow_component::ComponentError::message(&format!("Engine '{}' not found", target_url)))?;
 
-      trace!(target = %target_url, "invoking");
+      invocation.trace(|| trace!(target = %target_url, "invoking"));
 
       let result: InvocationResponse = engine
         .invoke(invocation, stream, config)
@@ -83,7 +83,7 @@ mod tests {
   async fn request_log(component: &EngineComponent, data: &str) -> Result<String> {
     let stream = packet_stream!(("MAIN_IN", data));
 
-    let invocation = Invocation::new(Entity::test(file!()), Entity::local("simple"), None);
+    let invocation = Invocation::test(file!(), Entity::local("simple"), None)?;
     let outputs = component.handle(invocation, stream, None, panic_callback()).await?;
     let mut packets: Vec<_> = outputs.collect().await;
     println!("packets: {:#?}", packets);

--- a/crates/wick/wick-runtime/src/dispatch.rs
+++ b/crates/wick/wick-runtime/src/dispatch.rs
@@ -75,7 +75,7 @@ mod tests {
 
     let target = Entity::operation("self", "echo");
     let stream = packet_stream![("input", "hello")];
-    let invocation = Invocation::new(Entity::test(file!()), target, None);
+    let invocation = Invocation::test(file!(), target, None)?;
 
     let packets = engine_invoke_async(nuid, invocation, stream, None).await?;
     let mut packets: Vec<_> = packets.collect().await;
@@ -87,16 +87,4 @@ mod tests {
 
     Ok(())
   }
-
-  // fn sync_send<T>()
-  // where
-  //   T: Sync + Send,
-  // {
-  // }
-
-  // #[test_logger::test]
-  // fn test_sync_send() -> Result<()> {
-  //   sync_send::<InvocationResponse>();
-  //   Ok(())
-  // }
 }

--- a/crates/wick/wick-runtime/src/runtime.rs
+++ b/crates/wick/wick-runtime/src/runtime.rs
@@ -2,14 +2,16 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use seeded_random::Seed;
+use tracing::Span;
 use uuid::Uuid;
+use wick_config::config::{ComponentConfiguration, ComponentConfigurationBuilder};
 use wick_packet::{Entity, OperationConfig};
 
 use crate::dev::prelude::*;
 use crate::runtime_service::{ComponentFactory, ComponentRegistry, Initialize};
 
 type Result<T> = std::result::Result<T, RuntimeError>;
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[must_use]
 pub struct Runtime {
   pub uid: Uuid,
@@ -17,33 +19,31 @@ pub struct Runtime {
   timeout: Duration,
 }
 
-#[derive(Debug)]
+#[derive(Debug, derive_builder::Builder)]
+#[builder(pattern = "owned", name = "RuntimeBuilder", setter(into), build_fn(skip))]
 #[must_use]
 pub struct RuntimeInit {
-  definition: config::ComponentConfiguration,
-  allow_latest: bool,
-  allowed_insecure: Vec<String>,
-  timeout: Duration,
-  namespace: Option<String>,
-  rng_seed: Seed,
-  native_components: ComponentRegistry,
-  constraints: Vec<RuntimeConstraint>,
+  #[builder(default)]
+  pub(crate) manifest: ComponentConfiguration,
+  #[builder(default)]
+  pub(crate) allow_latest: bool,
+  #[builder(default)]
+  pub(crate) allowed_insecure: Vec<String>,
+  #[builder(default = "Duration::from_secs(5)")]
+  pub(crate) timeout: Duration,
+  #[builder(setter(strip_option))]
+  pub(crate) namespace: Option<String>,
+  #[builder(default)]
+  pub(crate) constraints: Vec<RuntimeConstraint>,
+  pub(crate) span: Span,
+  #[builder(setter(custom = true))]
+  pub(crate) native_components: ComponentRegistry,
 }
 
 impl Runtime {
-  pub async fn new(config: RuntimeInit) -> Result<Self> {
-    trace!(?config, "init");
-    let init = Initialize::new(
-      config.rng_seed,
-      config.definition,
-      config.allowed_insecure.clone(),
-      config.allow_latest,
-      config.timeout,
-      config.native_components,
-      config.namespace,
-      config.constraints,
-      debug_span!("runtime"),
-    );
+  pub async fn new(seed: Seed, config: RuntimeInit) -> Result<Self> {
+    let timeout = config.timeout;
+    let init = Initialize::new(seed, config);
 
     let service = RuntimeService::new(init)
       .await
@@ -51,7 +51,7 @@ impl Runtime {
     Ok(Self {
       uid: service.id,
       inner: service,
-      timeout: config.timeout,
+      timeout,
     })
   }
 
@@ -91,28 +91,13 @@ impl Runtime {
   }
 }
 
-/// The [RuntimeBuilder] builds the configuration for a Wick [Runtime].
-#[derive(Default)]
-#[must_use]
-pub struct RuntimeBuilder {
-  allow_latest: bool,
-  allowed_insecure: Vec<String>,
-  manifest_builder: config::ComponentConfigurationBuilder,
-  constraints: Vec<RuntimeConstraint>,
-  timeout: Duration,
-  rng_seed: Option<Seed>,
-  namespace: Option<String>,
-  native_components: ComponentRegistry,
-}
-
 impl std::fmt::Debug for RuntimeBuilder {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
     f.debug_struct("RuntimeBuilder")
       .field("allow_latest", &self.allow_latest)
       .field("allowed_insecure", &self.allowed_insecure)
-      .field("manifest_builder", &self.manifest_builder)
+      .field("manifest", &self.manifest)
       .field("timeout", &self.timeout)
-      .field("rng_seed", &self.rng_seed)
       .field("namespace", &self.namespace)
       .field("native_components", &self.native_components)
       .finish()
@@ -138,91 +123,70 @@ impl std::fmt::Display for RuntimeConstraint {
 }
 
 impl RuntimeBuilder {
+  #[must_use]
   pub fn new() -> Self {
-    Self {
-      timeout: Duration::from_secs(5),
-      ..Default::default()
-    }
+    Self::default()
   }
 
   /// Creates a new [RuntimeBuilder] from a [config::ComponentConfiguration]
-  pub fn from_definition(definition: config::ComponentConfiguration) -> Result<Self> {
-    Ok(Self {
-      allow_latest: definition.allow_latest(),
-      allowed_insecure: definition.insecure_registries().map(|v| v.to_vec()).unwrap_or_default(),
-      manifest_builder: config::ComponentConfigurationBuilder::from_base(definition),
-      timeout: Duration::from_secs(5),
-      native_components: ComponentRegistry::default(),
-      namespace: None,
-      rng_seed: None,
-      constraints: Vec::new(),
-    })
+  #[must_use]
+  pub fn from_definition(definition: ComponentConfiguration) -> Self {
+    let builder = Self::new();
+    builder
+      .allow_latest(definition.allow_latest())
+      .allowed_insecure(definition.insecure_registries().map(|v| v.to_vec()).unwrap_or_default())
+      .manifest(definition)
   }
 
   pub fn add_constraint(&mut self, constraint: RuntimeConstraint) -> &mut Self {
-    self.constraints.push(constraint);
+    let mut val = self.constraints.take().unwrap_or_default();
+    val.push(constraint);
+    self.constraints.replace(val);
     self
   }
 
   pub fn add_import(&mut self, component: config::ImportBinding) -> &mut Self {
-    self.manifest_builder.add_import(component);
+    let val = self.manifest.take().unwrap_or_default();
+    let mut val = ComponentConfigurationBuilder::from_base(val);
+    val.add_import(component);
+    self.manifest.replace(val.build().unwrap());
     self
   }
 
   pub fn add_resource(&mut self, resource: config::ResourceBinding) -> &mut Self {
-    self.manifest_builder.add_resource(resource);
+    let val = self.manifest.take().unwrap_or_default();
+    let mut val = ComponentConfigurationBuilder::from_base(val);
+    val.add_resource(resource);
+    self.manifest.replace(val.build().unwrap());
     self
   }
 
-  pub fn timeout(self, timeout: Duration) -> Self {
-    Self { timeout, ..self }
-  }
-
-  pub fn allow_latest(self, allow_latest: bool) -> Self {
-    Self { allow_latest, ..self }
-  }
-
-  pub fn allow_insecure(self, allowed_insecure: Vec<String>) -> Self {
-    Self {
-      allowed_insecure,
-      ..self
-    }
-  }
-
-  pub fn with_seed(self, seed: Seed) -> Self {
-    Self {
-      rng_seed: Some(seed),
-      ..self
-    }
-  }
-
-  pub fn namespace<T: AsRef<str>>(self, namespace: T) -> Self {
-    Self {
-      namespace: Some(namespace.as_ref().to_owned()),
-      ..self
-    }
-  }
-
-  pub fn native_component(&mut self, factory: Box<ComponentFactory>) {
-    self.native_components.add(factory);
+  pub fn add_native_component(&mut self, factory: Box<ComponentFactory>) -> &mut Self {
+    let mut val = self.native_components.take().unwrap_or_default();
+    val.add(factory);
+    self.native_components.replace(val);
+    self
   }
 
   /// Constructs an instance of a Wick [Runtime].
-  pub async fn build(self) -> Result<Runtime> {
-    let definition = self
-      .manifest_builder
-      .build()
-      .map_err(|e| RuntimeError::InitializationFailed(e.to_string()))?;
-    Runtime::new(RuntimeInit {
-      definition,
-      allow_latest: self.allow_latest,
-      allowed_insecure: self.allowed_insecure,
-      native_components: self.native_components,
-      timeout: self.timeout,
-      namespace: self.namespace,
-      rng_seed: self.rng_seed.unwrap_or_else(new_seed),
-      constraints: self.constraints,
-    })
+  pub async fn build(self, seed: Option<Seed>) -> Result<Runtime> {
+    let from_span = self.span.unwrap_or_else(tracing::Span::current);
+    let span = debug_span!("runtime");
+    span.follows_from(from_span);
+    let definition = self.manifest.unwrap_or_default();
+    Runtime::new(
+      seed.unwrap_or_else(new_seed),
+      RuntimeInit {
+        manifest: definition,
+        allow_latest: self.allow_latest.unwrap_or_default(),
+        allowed_insecure: self.allowed_insecure.unwrap_or_default(),
+        native_components: self.native_components.unwrap_or_default(),
+        timeout: self.timeout.unwrap_or_else(|| Duration::from_secs(5)),
+        namespace: self.namespace.unwrap_or_default(),
+        constraints: self.constraints.unwrap_or_default(),
+        span,
+      },
+    )
     .await
   }
 }

--- a/crates/wick/wick-runtime/src/runtime.rs
+++ b/crates/wick/wick-runtime/src/runtime.rs
@@ -31,7 +31,6 @@ pub struct RuntimeInit {
 }
 
 impl Runtime {
-  #[instrument(name = "runtime", skip_all)]
   pub async fn new(config: RuntimeInit) -> Result<Self> {
     trace!(?config, "init");
     let init = Initialize::new(
@@ -43,7 +42,7 @@ impl Runtime {
       config.native_components,
       config.namespace,
       config.constraints,
-      debug_span!("runtime:new"),
+      debug_span!("runtime"),
     );
 
     let service = RuntimeService::new(init)

--- a/crates/wick/wick-runtime/src/test.rs
+++ b/crates/wick/wick-runtime/src/test.rs
@@ -14,7 +14,7 @@ use crate::{Runtime, RuntimeBuilder};
 pub(crate) async fn init_engine_from_yaml(path: &str) -> Result<(Runtime, uuid::Uuid)> {
   let def = WickConfiguration::load_from_file(path).await?.try_component_config()?;
 
-  let engine = RuntimeBuilder::from_definition(def)?.build().await?;
+  let engine = RuntimeBuilder::from_definition(def).build(None).await?;
 
   let engine_id = engine.uid;
   trace!(engine_id = %engine_id, "engine uid");

--- a/crates/wick/wick-runtime/src/triggers/http/component_utils.rs
+++ b/crates/wick/wick-runtime/src/triggers/http/component_utils.rs
@@ -9,6 +9,7 @@ use hyper::http::{HeaderName, HeaderValue};
 use hyper::{Body, Request, Response, StatusCode};
 use serde_json::{Map, Value};
 use tokio_stream::StreamExt;
+use tracing::Span;
 use wick_config::config::components::Codec;
 use wick_packet::{packets, Entity, Invocation, Observer, Packet, PacketStream};
 
@@ -24,7 +25,7 @@ pub(super) async fn handle(
   req: Request<Body>,
 ) -> Result<PacketStream, HttpError> {
   let (tx, rx) = PacketStream::new_channels();
-  let invocation = Invocation::new(Entity::server("http_client"), target, None);
+  let invocation = Invocation::new(Entity::server("http_client"), target, None, &Span::current());
   let stream = engine
     .invoke(invocation, rx, None)
     .await

--- a/crates/wick/wick-runtime/src/triggers/http/rest_router/route.rs
+++ b/crates/wick/wick-runtime/src/triggers/http/rest_router/route.rs
@@ -15,6 +15,8 @@ pub(super) struct Route {
   query_params: Vec<Field>,
 }
 
+pub(super) type MatchedValues = (Vec<FieldValue>, Vec<FieldValue>);
+
 impl Route {
   pub(super) fn parse(path: &str) -> Result<Self, wick_interface_types::ParserError> {
     let (path, query) = path.find('?').map_or((path, ""), |idx| {
@@ -62,11 +64,7 @@ impl Route {
     })
   }
 
-  pub(super) fn compare(
-    &self,
-    path: &str,
-    query_string: Option<&str>,
-  ) -> Result<Option<(Vec<FieldValue>, Vec<FieldValue>)>, HttpError> {
+  pub(super) fn compare(&self, path: &str, query_string: Option<&str>) -> Result<Option<MatchedValues>, HttpError> {
     let mut path_params = Vec::new();
     let mut query_params = Vec::new();
 

--- a/crates/wick/wick-runtime/tests/utils/mod.rs
+++ b/crates/wick/wick-runtime/tests/utils/mod.rs
@@ -10,11 +10,11 @@ pub async fn init_engine_from_yaml(path: &str, timeout: Duration) -> anyhow::Res
   let host_def = WickConfiguration::load_from_file(path).await?.try_component_config()?;
   debug!("Manifest loaded");
 
-  let builder = RuntimeBuilder::from_definition(host_def)?
+  let builder = RuntimeBuilder::from_definition(host_def)
     .namespace("__TEST__")
     .timeout(timeout);
 
-  let engine = builder.build().await?;
+  let engine = builder.build(None).await?;
 
   let nuid = engine.uid;
   Ok((engine, nuid))
@@ -50,7 +50,7 @@ pub async fn base_test(
 
   let result = engine
     .invoke(
-      Invocation::new(Entity::test("simple schematic"), target, Some(inherent)),
+      Invocation::test("simple schematic", target, Some(inherent))?,
       stream,
       None,
     )

--- a/crates/wick/wick-settings/src/settings.rs
+++ b/crates/wick/wick-settings/src/settings.rs
@@ -13,20 +13,23 @@ use crate::error::Error;
 pub struct Settings {
   #[serde(default)]
   /// Logging configuration.
-  pub logging: Logging,
-  #[serde(default)]
+  pub trace: TraceSettings,
   /// Registry credentials.
+  #[serde(default, skip_serializing_if = "Vec::is_empty")]
   pub credentials: Vec<Credential>,
   #[serde(skip)]
   /// Where this configuration was loaded from.
   pub source: Option<PathBuf>,
 }
 
-#[derive(Debug, Default, Deserialize, Serialize, Clone, Copy)]
+#[derive(Debug, Default, Deserialize, Serialize, Clone)]
 #[serde(rename_all = "snake_case")]
 #[serde(deny_unknown_fields)]
 /// Logging configuration.
-pub struct Logging {
+pub struct TraceSettings {
+  /// Jaeger Telemetry endpoint.
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub jaeger: Option<String>,
   /// Logging level.
   #[serde(default)]
   pub level: LogLevel,

--- a/crates/wick/wick-test/src/runner.rs
+++ b/crates/wick/wick-test/src/runner.rs
@@ -48,12 +48,12 @@ async fn run_unit<'a>(
   let prefix = |msg: &str| format!("{}: {}", test_name, msg);
 
   trace!(i, %entity, "invoke");
-  let invocation = Invocation::new(Entity::test(&test_name), entity, inherent);
+  let invocation = Invocation::new(Entity::test(&test_name), entity, inherent, &tracing::Span::current());
   let fut = component.handle(
     invocation,
     stream,
     def.test.config().cloned(),
-    std::sync::Arc::new(|_, _, _, _, _| panic!()),
+    std::sync::Arc::new(|_, _, _, _, _, _| panic!()),
   );
   let fut = tokio::time::timeout(Duration::from_secs(5), fut);
   let result = fut

--- a/tests/integration/src/test.rs
+++ b/tests/integration/src/test.rs
@@ -102,7 +102,7 @@ mod tests {
     let input_stream = packet_stream!(("input", input));
 
     let entity = Entity::local("test-component");
-    let invocation = Invocation::new(Entity::test(file!()), entity, None);
+    let invocation = Invocation::test(file!(), entity, None)?;
 
     let outputs = collection
       .handle(invocation, input_stream, None, panic_callback())

--- a/tests/integration/src/test/wick_host_run.rs
+++ b/tests/integration/src/test/wick_host_run.rs
@@ -20,7 +20,7 @@ mod slow_test {
       .await?
       .try_app_config()?;
 
-    let mut host = AppHostBuilder::from_definition(app_config.clone()).build();
+    let mut host = AppHostBuilder::default().manifest(app_config.clone()).build()?;
     host.start(None)?;
     debug!("Waiting on triggers to finish or interrupt...");
     // host.wait_for_done().await?;


### PR DESCRIPTION
This PR:
- removes jaeger support in favor of OTLP
- improves the span/event relationships for many of the existing items. More improvements will be necessary.
- Adds a `span` to `Invocation`s so they can be linked together.
- adds an `otlp` setting to the settings file.

Closes #260 