### PR TITLE
Invocation & PacketStream merge + debuggability

### DIFF
--- a/crates/bins/wick/src/commands/rpc/invoke.rs
+++ b/crates/bins/wick/src/commands/rpc/invoke.rs
@@ -109,9 +109,9 @@ pub(crate) async fn handle(
       tx.send(Packet::done(port))?;
     }
 
-    let invocation = Invocation::new(origin, target, inherent_data, &span);
+    let invocation = Invocation::new(origin, target, stream, inherent_data, &span);
     span.in_scope(|| trace!("issuing invocation"));
-    let stream = client.invoke(invocation, stream).await?;
+    let stream = client.invoke(invocation).await?;
     span.in_scope(|| trace!("server responsed"));
     utils::print_stream_json(stream, &opts.filter, opts.short, opts.raw).await?;
   }

--- a/crates/components/wick-azure-sql/src/component.rs
+++ b/crates/components/wick-azure-sql/src/component.rs
@@ -96,7 +96,7 @@ impl Component for AzureSqlComponent {
 
       let input_names: Vec<_> = opdef.inputs().iter().map(|i| i.name.clone()).collect();
       let mut input_streams = wick_packet::split_stream(invocation.eject_stream(), input_names);
-      let (tx, rx) = PacketStream::new_channels();
+      let (tx, rx) = invocation.make_response();
       tokio::spawn(async move {
         'outer: loop {
           let mut incoming_packets = Vec::new();

--- a/crates/components/wick-azure-sql/src/component.rs
+++ b/crates/components/wick-azure-sql/src/component.rs
@@ -71,8 +71,7 @@ impl AzureSqlComponent {
 impl Component for AzureSqlComponent {
   fn handle(
     &self,
-    invocation: Invocation,
-    stream: PacketStream,
+    mut invocation: Invocation,
     _data: Option<OperationConfig>,
     _callback: Arc<RuntimeCallback>,
   ) -> BoxFuture<Result<PacketStream, ComponentError>> {
@@ -96,7 +95,7 @@ impl Component for AzureSqlComponent {
       };
 
       let input_names: Vec<_> = opdef.inputs().iter().map(|i| i.name.clone()).collect();
-      let mut input_streams = wick_packet::split_stream(stream, input_names);
+      let mut input_streams = wick_packet::split_stream(invocation.eject_stream(), input_names);
       let (tx, rx) = PacketStream::new_channels();
       tokio::spawn(async move {
         'outer: loop {

--- a/crates/components/wick-azure-sql/src/mssql.rs
+++ b/crates/components/wick-azure-sql/src/mssql.rs
@@ -93,10 +93,10 @@ mod integration_test {
 
   #[test_logger::test(tokio::test)]
   async fn test_mssql_basic() -> Result<()> {
-    let pg = init_mssql_component().await?;
+    let db = init_mssql_component().await?;
     let input = packet_stream!(("input", 1_i32));
-    let inv = Invocation::test("postgres", "wick://__local__/test", None)?;
-    let response = pg.handle(inv, input, None, panic_callback()).await.unwrap();
+    let inv = Invocation::test("mssql", "wick://__local__/test", input, None)?;
+    let response = db.handle(inv, None, panic_callback()).await.unwrap();
     let packets: Vec<_> = response.collect().await;
 
     assert_eq!(

--- a/crates/components/wick-sqlx/src/component.rs
+++ b/crates/components/wick-sqlx/src/component.rs
@@ -141,8 +141,8 @@ impl Component for SqlXComponent {
       };
 
       let input_names: Vec<_> = opdef.inputs().iter().map(|i| i.name.clone()).collect();
+      let (tx, rx) = invocation.make_response();
       let mut input_streams = wick_packet::split_stream(invocation.packets, input_names);
-      let (tx, rx) = PacketStream::new_channels();
       tokio::spawn(async move {
         'outer: loop {
           let mut incoming_packets = Vec::new();

--- a/crates/components/wick-sqlx/src/component.rs
+++ b/crates/components/wick-sqlx/src/component.rs
@@ -118,7 +118,6 @@ impl Component for SqlXComponent {
   fn handle(
     &self,
     invocation: Invocation,
-    stream: PacketStream,
     _data: Option<OperationConfig>,
     _callback: Arc<RuntimeCallback>,
   ) -> BoxFuture<Result<PacketStream, ComponentError>> {
@@ -142,7 +141,7 @@ impl Component for SqlXComponent {
       };
 
       let input_names: Vec<_> = opdef.inputs().iter().map(|i| i.name.clone()).collect();
-      let mut input_streams = wick_packet::split_stream(stream, input_names);
+      let mut input_streams = wick_packet::split_stream(invocation.packets, input_names);
       let (tx, rx) = PacketStream::new_channels();
       tokio::spawn(async move {
         'outer: loop {

--- a/crates/components/wick-sqlx/src/mssql.rs
+++ b/crates/components/wick-sqlx/src/mssql.rs
@@ -76,8 +76,8 @@ mod integration_test {
   async fn test_mssql_basic() -> Result<()> {
     let pg = init_mssql_component().await?;
     let input = packet_stream!(("input", 1_i32));
-    let inv = Invocation::test("postgres", "wick://__local__/test", None)?;
-    let response = pg.handle(inv, input, None, panic_callback()).await.unwrap();
+    let inv = Invocation::test("postgres", "wick://__local__/test", input, None)?;
+    let response = pg.handle(inv, None, panic_callback()).await.unwrap();
     let packets: Vec<_> = response.collect().await;
 
     assert_eq!(

--- a/crates/components/wick-sqlx/src/postgres.rs
+++ b/crates/components/wick-sqlx/src/postgres.rs
@@ -76,8 +76,8 @@ mod integration_test {
   async fn test_pg_basic() -> Result<()> {
     let pg = init_pg_component().await?;
     let input = packet_stream!(("input", 1_u32));
-    let inv = Invocation::test("postgres", "wick://__local__/test", None)?;
-    let response = pg.handle(inv, input, None, panic_callback()).await.unwrap();
+    let inv = Invocation::test("postgres", "wick://__local__/test", input, None)?;
+    let response = pg.handle(inv, None, panic_callback()).await.unwrap();
     let packets: Vec<_> = response.collect().await;
 
     assert_eq!(

--- a/crates/wick/flow-component/src/traits.rs
+++ b/crates/wick/flow-component/src/traits.rs
@@ -35,7 +35,7 @@ pub trait Operation {
   fn handle(
     &self,
     invocation: Invocation,
-    payload: PacketStream,
+    stream: PacketStream,
     context: Context<Self::Config>,
   ) -> BoxFuture<Result<PacketStream, ComponentError>>;
 

--- a/crates/wick/flow-component/src/traits.rs
+++ b/crates/wick/flow-component/src/traits.rs
@@ -14,7 +14,6 @@ pub trait Component {
   fn handle(
     &self,
     invocation: Invocation,
-    stream: PacketStream,
     data: Option<OperationConfig>,
     callback: Arc<RuntimeCallback>,
   ) -> BoxFuture<Result<PacketStream, ComponentError>>;
@@ -35,7 +34,6 @@ pub trait Operation {
   fn handle(
     &self,
     invocation: Invocation,
-    stream: PacketStream,
     context: Context<Self::Config>,
   ) -> BoxFuture<Result<PacketStream, ComponentError>>;
 

--- a/crates/wick/flow-graph-interpreter/src/interpreter/components/component_component.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/components/component_component.rs
@@ -1,5 +1,5 @@
 use flow_component::{Component, ComponentError, RuntimeCallback};
-use wasmrs_rx::{FluxChannel, Observer};
+use wasmrs_rx::Observer;
 use wick_interface_types::{ComponentSignature, Field, OperationSignature};
 use wick_packet::{ComponentReference, Entity, Invocation, Packet, PacketStream};
 
@@ -58,16 +58,15 @@ impl Component for ComponentComponent {
           all_collections,
         )));
       }
-      let flux = FluxChannel::new();
+      let (tx, rx) = invocation.make_response();
 
-      flux
-        .send(Packet::encode(
-          port_name,
-          ComponentReference::new(invocation.origin.clone(), Entity::component(entity.component_id())),
-        ))
-        .map_err(ComponentError::new)?;
+      tx.send(Packet::encode(
+        port_name,
+        ComponentReference::new(invocation.origin.clone(), Entity::component(entity.component_id())),
+      ))
+      .map_err(ComponentError::new)?;
 
-      Ok(PacketStream::new(Box::new(flux)))
+      Ok(rx)
     })
   }
 

--- a/crates/wick/flow-graph-interpreter/src/interpreter/components/component_component.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/components/component_component.rs
@@ -37,7 +37,6 @@ impl Component for ComponentComponent {
   fn handle(
     &self,
     invocation: Invocation,
-    _stream: PacketStream,
     _config: Option<wick_packet::OperationConfig>,
     _callback: std::sync::Arc<RuntimeCallback>,
   ) -> BoxFuture<Result<PacketStream, ComponentError>> {

--- a/crates/wick/flow-graph-interpreter/src/interpreter/components/core_collection.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/components/core_collection.rs
@@ -115,11 +115,9 @@ impl CoreCollection {
 }
 
 macro_rules! core_op {
-  ($type:ty, $inv:expr, $name:expr, $stream:ident, $callback:expr, $data:ident, $seed:ident) => {{
+  ($type:ty, $inv:expr, $name:expr, $callback:expr, $data:ident, $seed:ident) => {{
     let config = <$type>::decode_config($data)?;
-    $name
-      .handle($inv, $stream, Context::new(config, $seed, $callback))
-      .await
+    $name.handle($inv, Context::new(config, $seed, $callback)).await
   }};
 }
 
@@ -127,7 +125,6 @@ impl Component for CoreCollection {
   fn handle(
     &self,
     invocation: Invocation,
-    stream: PacketStream,
     data: Option<wick_packet::OperationConfig>,
     callback: std::sync::Arc<RuntimeCallback>,
   ) -> BoxFuture<Result<PacketStream, ComponentError>> {
@@ -136,10 +133,10 @@ impl Component for CoreCollection {
 
     let task = async move {
       match invocation.target.operation_id() {
-        sender::Op::ID => core_op! {sender::Op, invocation, self.sender, stream, callback, data, seed},
-        pluck::Op::ID => core_op! {pluck::Op, invocation, self.pluck, stream, callback, data, seed},
-        merge::Op::ID => core_op! {merge::Op, invocation, self.merge, stream, callback, data, seed},
-        switch::Op::ID => core_op! {switch::Op, invocation, self.switch, stream, callback, data, seed},
+        sender::Op::ID => core_op! {sender::Op, invocation, self.sender, callback, data, seed},
+        pluck::Op::ID => core_op! {pluck::Op, invocation, self.pluck, callback, data, seed},
+        merge::Op::ID => core_op! {merge::Op, invocation, self.merge, callback, data, seed},
+        switch::Op::ID => core_op! {switch::Op, invocation, self.switch, callback, data, seed},
         _ => {
           panic!("Core operation {} not handled.", invocation.target.operation_id());
         }

--- a/crates/wick/flow-graph-interpreter/src/interpreter/components/core_collection/merge.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/components/core_collection/merge.rs
@@ -51,8 +51,8 @@ impl Operation for Op {
     invocation: Invocation,
     context: Context<Self::Config>,
   ) -> BoxFuture<Result<PacketStream, ComponentError>> {
+    let (tx, rx) = invocation.make_response();
     let mut map = StreamMap::from_stream(invocation.packets, self.input_names(&context.config));
-    let (tx, rx) = PacketStream::new_channels();
     tokio::spawn(async move {
       while let Ok(next) = map.next_set().await {
         if next.is_none() {

--- a/crates/wick/flow-graph-interpreter/src/interpreter/components/core_collection/pluck.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/components/core_collection/pluck.rs
@@ -39,11 +39,10 @@ impl Operation for Op {
   type Config = Config;
   fn handle(
     &self,
-    _invocation: Invocation,
-    stream: PacketStream,
+    invocation: Invocation,
     context: Context<Self::Config>,
   ) -> BoxFuture<Result<PacketStream, ComponentError>> {
-    let mut map = StreamMap::from_stream(stream, self.input_names(&context.config));
+    let mut map = StreamMap::from_stream(invocation.packets, self.input_names(&context.config));
     let mapped = map.take("input").map_err(ComponentError::new).map(|input| {
       input
         .map(move |next| {
@@ -108,9 +107,9 @@ mod test {
         "dont_pluck_this": "unused",
       })
     ));
-    let inv = Invocation::test(file!(), Entity::test("noop"), None)?;
+    let inv = Invocation::test(file!(), Entity::test("noop"), stream, None)?;
     let mut packets = op
-      .handle(inv, stream, Context::new(config, None, panic_callback()))
+      .handle(inv, Context::new(config, None, panic_callback()))
       .await?
       .collect::<Vec<_>>()
       .await;

--- a/crates/wick/flow-graph-interpreter/src/interpreter/components/core_collection/sender.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/components/core_collection/sender.rs
@@ -34,7 +34,6 @@ impl Operation for Op {
   fn handle(
     &self,
     _invocation: Invocation,
-    _payload: PacketStream,
     context: Context<Self::Config>,
   ) -> BoxFuture<Result<PacketStream, ComponentError>> {
     let config = context.config;

--- a/crates/wick/flow-graph-interpreter/src/interpreter/components/core_collection/switch.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/components/core_collection/switch.rs
@@ -112,7 +112,7 @@ impl Operation for Op {
     mut invocation: Invocation,
     context: Context<Self::Config>,
   ) -> BoxFuture<Result<PacketStream, ComponentError>> {
-    let (tx, rx) = PacketStream::new_channels();
+    let (tx, rx) = invocation.make_response();
 
     let default = context.config.default.clone();
     let callback = context.callback;
@@ -177,7 +177,7 @@ impl Operation for Op {
         let stream = router.entry(op.clone()).or_insert_with(|| {
           let target = path_to_entity(op).unwrap(); // unwrap ok because the config has been pre-validated.
           let op_id = target.operation_id().to_owned();
-          let (route_tx, route_rx) = PacketStream::new_channels();
+          let (route_tx, route_rx) = invocation.make_response();
           let link = ComponentReference::new(origin.clone(), target);
           let tx = tx.clone();
           let callback = callback.clone();

--- a/crates/wick/flow-graph-interpreter/src/interpreter/components/core_collection/switch.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/components/core_collection/switch.rs
@@ -109,8 +109,7 @@ impl Operation for Op {
   #[allow(clippy::too_many_lines)]
   fn handle(
     &self,
-    invocation: Invocation,
-    mut stream: PacketStream,
+    mut invocation: Invocation,
     context: Context<Self::Config>,
   ) -> BoxFuture<Result<PacketStream, ComponentError>> {
     let (tx, rx) = PacketStream::new_channels();
@@ -126,7 +125,7 @@ impl Operation for Op {
         let packet = if condition.is_some() {
           match held_packets.pop_front() {
             Some(p) => p,
-            None => match stream.next().await {
+            None => match invocation.packets.next().await {
               Some(Ok(p)) => p,
               Some(Err(e)) => {
                 let _ = tx.error(e);
@@ -138,7 +137,7 @@ impl Operation for Op {
             },
           }
         } else {
-          match stream.next().await {
+          match invocation.packets.next().await {
             Some(Ok(p)) => p,
             Some(Err(e)) => {
               let _ = tx.error(e);

--- a/crates/wick/flow-graph-interpreter/src/interpreter/components/internal_collection.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/components/internal_collection.rs
@@ -31,7 +31,6 @@ impl Component for InternalCollection {
   fn handle(
     &self,
     invocation: Invocation,
-    stream: PacketStream,
     _config: Option<wick_packet::OperationConfig>,
     _callback: std::sync::Arc<RuntimeCallback>,
   ) -> BoxFuture<Result<PacketStream, ComponentError>> {
@@ -43,7 +42,7 @@ impl Component for InternalCollection {
       if op == SCHEMATIC_OUTPUT {
         panic!("Output component should not be executed");
       } else if is_oneshot {
-        Ok(stream)
+        Ok(invocation.packets)
       } else {
         panic!("Internal component {} not handled.", op);
       }

--- a/crates/wick/flow-graph-interpreter/src/interpreter/components/null_component.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/components/null_component.rs
@@ -28,7 +28,6 @@ impl Component for NullComponent {
   fn handle(
     &self,
     invocation: Invocation,
-    _stream: PacketStream,
     _data: Option<wick_packet::OperationConfig>,
     _callback: std::sync::Arc<RuntimeCallback>,
   ) -> BoxFuture<Result<PacketStream, ComponentError>> {

--- a/crates/wick/flow-graph-interpreter/src/interpreter/components/schematic_component.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/components/schematic_component.rs
@@ -71,7 +71,6 @@ impl Component for SchematicComponent {
   fn handle(
     &self,
     invocation: Invocation,
-    stream: PacketStream,
     _config: Option<wick_packet::OperationConfig>,
     callback: Arc<RuntimeCallback>,
   ) -> BoxFuture<Result<PacketStream, ComponentError>> {
@@ -85,7 +84,6 @@ impl Component for SchematicComponent {
       .map(|s| {
         s.invoke(
           invocation,
-          stream,
           self.rng.seed(),
           self.components.clone(),
           self.clone_self_collection(),

--- a/crates/wick/flow-graph-interpreter/src/interpreter/executor.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/executor.rs
@@ -38,7 +38,6 @@ impl SchematicExecutor {
   pub(crate) async fn invoke(
     &self,
     invocation: Invocation,
-    stream: PacketStream,
     seed: Seed,
     components: Arc<HandlerMap>,
     self_component: Arc<dyn Component + Send + Sync>,
@@ -51,7 +50,6 @@ impl SchematicExecutor {
     let mut transaction = Transaction::new(
       self.schematic.clone(),
       invocation,
-      stream,
       self.channel.clone(),
       &components,
       &self_component,

--- a/crates/wick/flow-graph-interpreter/src/interpreter/executor/transaction.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/executor/transaction.rs
@@ -33,7 +33,6 @@ pub struct Transaction {
   output: FluxChannel<Packet, wick_packet::Error>,
   channel: InterpreterDispatchChannel,
   invocation: Invocation,
-  incoming: Option<PacketStream>,
   instances: Vec<Arc<InstanceHandler>>,
   id: Uuid,
   start_time: Instant,
@@ -56,7 +55,6 @@ impl Transaction {
   pub(crate) fn new(
     schematic: Arc<Schematic>,
     mut invocation: Invocation,
-    stream: PacketStream,
     channel: InterpreterDispatchChannel,
     collections: &Arc<HandlerMap>,
     self_collection: &Arc<dyn Component + Send + Sync>,
@@ -87,7 +85,6 @@ impl Transaction {
     Self {
       channel,
       invocation,
-      incoming: Some(stream),
       schematic,
       output: FluxChannel::new(),
       instances,
@@ -158,7 +155,7 @@ impl Transaction {
         .await?;
     }
 
-    let incoming = self.incoming.take().unwrap();
+    let incoming = self.invocation.eject_stream();
 
     self.prime_input_ports(self.schematic.input().index(), incoming)?;
 

--- a/crates/wick/flow-graph-interpreter/tests/core.rs
+++ b/crates/wick/flow-graph-interpreter/tests/core.rs
@@ -59,6 +59,47 @@ async fn test_merge() -> Result<()> {
 }
 
 #[test_logger::test(tokio::test)]
+// #[ignore]
+async fn test_sender_merge() -> Result<()> {
+  let (interpreter, mut outputs) =
+    test::common_setup("./tests/manifests/v1/core-sender-merge.yaml", "test", Vec::new()).await?;
+
+  assert_eq!(outputs.len(), 2);
+
+  let _ = outputs.pop();
+  let wrapper = outputs.pop().unwrap().unwrap();
+  let actual = wrapper.deserialize_generic()?;
+  let expected = json!({"a": true, "b": "Hello world", "c": 123456});
+  assert_eq!(actual, expected);
+  interpreter.shutdown().await?;
+
+  Ok(())
+}
+
+#[test_logger::test(tokio::test)]
+// #[ignore]
+async fn test_multi_sender() -> Result<()> {
+  let (interpreter, mut outputs) =
+    test::common_setup("./tests/manifests/v1/core-multi-sender.yaml", "test", Vec::new()).await?;
+
+  assert_eq!(outputs.len(), 6);
+
+  let _ = outputs.pop();
+  let actual = outputs.pop().unwrap().unwrap();
+
+  assert_eq!(actual, Packet::encode("c", 123456));
+  let _ = outputs.pop();
+  let actual = outputs.pop().unwrap().unwrap();
+  assert_eq!(actual, Packet::encode("b", "Hello world"));
+  let _ = outputs.pop();
+  let actual = outputs.pop().unwrap().unwrap();
+  assert_eq!(actual, Packet::encode("a", true));
+  interpreter.shutdown().await?;
+
+  Ok(())
+}
+
+#[test_logger::test(tokio::test)]
 async fn test_subflows() -> Result<()> {
   first_packet_test(
     "./tests/manifests/v1/private-flows.yaml",
@@ -132,6 +173,28 @@ async fn first_packet_test(file: &str, packets: Vec<Packet>, expected: &str) -> 
   Ok(())
 }
 
+// #[test_logger::test(tokio::test)]
+// async fn test_switch_err() -> Result<()> {
+//   error_test(
+//     "./tests/manifests/v1/core-switch.yaml",
+//     Packet::err("match", "Something bad"),
+//     "hello WORLD",
+//   )
+//   .await
+// }
+// async fn error_test(file: &str, packet: Packet, expected: &str) -> Result<()> {
+//   let (interpreter, mut outputs) = test::common_setup(file, "test", vec![packet]).await?;
+
+//   assert_eq!(outputs.len(), 2);
+
+//   let _ = outputs.pop();
+//   let wrapper = outputs.pop().unwrap().unwrap();
+//   let actual: String = wrapper.deserialize()?;
+//   assert_eq!(actual, expected);
+//   interpreter.shutdown().await?;
+
+//   Ok(())
+// }
 // #[test_logger::test(tokio::test)]
 // async fn test_merge() -> Result<()> {
 //   let manifest = load("./tests/manifests/v0/core/merge.yaml")?;

--- a/crates/wick/flow-graph-interpreter/tests/manifests/v1/core-multi-sender.yaml
+++ b/crates/wick/flow-graph-interpreter/tests/manifests/v1/core-multi-sender.yaml
@@ -1,0 +1,25 @@
+name: 'test'
+kind: wick/component@v1
+metadata:
+  version: '0.0.2'
+component:
+  kind: wick/component/composite@v1
+  operations:
+    - name: test
+      uses:
+        - name: BOOL
+          operation: core::sender
+          with:
+            output: true
+        - name: STRING
+          operation: core::sender
+          with:
+            output: 'Hello world'
+        - name: NUM
+          operation: core::sender
+          with:
+            output: 123456
+      flow:
+        - BOOL.output -> <>.a
+        - STRING.output -> <>.b
+        - NUM.output -> <>.c

--- a/crates/wick/flow-graph-interpreter/tests/manifests/v1/core-sender-merge.yaml
+++ b/crates/wick/flow-graph-interpreter/tests/manifests/v1/core-sender-merge.yaml
@@ -1,0 +1,38 @@
+name: 'test'
+kind: wick/component@v1
+metadata:
+  version: '0.0.2'
+component:
+  kind: wick/component/composite@v1
+  operations:
+    - name: test
+      uses:
+        - name: BOOL
+          operation: core::sender
+          with:
+            output: true
+        - name: STRING
+          operation: core::sender
+          with:
+            output: 'Hello world'
+        - name: NUM
+          operation: core::sender
+          with:
+            output: 123456
+        - name: m
+          operation: core::merge
+          with:
+            inputs:
+              - name: a
+                type: string
+              - name: b
+                type: i32
+              - name: c
+                type: list
+                element:
+                  type: string
+      flow:
+        - BOOL.output -> m.a
+        - STRING.output -> m.b
+        - NUM.output -> m.c
+        - m.output -> <>

--- a/crates/wick/flow-graph-interpreter/tests/manifests/v1/core-switch-2.yaml
+++ b/crates/wick/flow-graph-interpreter/tests/manifests/v1/core-switch-2.yaml
@@ -1,0 +1,44 @@
+---
+kind: wick/component@v1
+name: switch-bool
+component:
+  kind: wick/component/composite@v1
+  operations:
+    - name: test
+      uses:
+        - name: switch
+          operation: core::switch
+          with:
+            context:
+              - name: message
+                type: object
+            outputs:
+              - name: output
+                type: string
+            cases:
+              - case: false
+                do: self::test::on_false
+            default: self::test::on_true
+      flow:
+        - <>.input -> switch.match
+        - <>.message -> switch.message
+        - switch.output -> <>
+      operations:
+        - name: on_false
+          uses:
+            - name: STATUS
+              operation: core::sender
+              with:
+                output: 'on_false'
+          flow:
+            - <>.message -> drop
+            - STATUS.output -> <>.output
+        - name: on_true
+          uses:
+            - name: STATUS
+              operation: core::sender
+              with:
+                output: 'on_true'
+          flow:
+            - <>.message -> drop
+            - STATUS.output -> <>.output

--- a/crates/wick/flow-graph-interpreter/tests/test/mod.rs
+++ b/crates/wick/flow-graph-interpreter/tests/test/mod.rs
@@ -44,7 +44,6 @@ pub(crate) async fn base_setup(
     Box::new(test::TestComponent::new()),
   )])
   .unwrap();
-  let invocation = Invocation::test("test", entity, None)?;
 
   let mut interpreter = Interpreter::new(
     Some(Seed::unsafe_new(1)),
@@ -56,7 +55,8 @@ pub(crate) async fn base_setup(
   )?;
   interpreter.start(options, None).await;
   let stream = wick_packet::PacketStream::new(Box::new(futures::stream::iter(packets.into_iter().map(Ok))));
-  let stream = interpreter.invoke(invocation, stream, config).await?;
+  let invocation = Invocation::test("test", entity, stream, None)?;
+  let stream = interpreter.invoke(invocation, config).await?;
   let outputs: Vec<_> = stream.collect().await;
   println!("{:#?}", outputs);
   Ok((interpreter, outputs))

--- a/crates/wick/flow-graph-interpreter/tests/test/test_component.rs
+++ b/crates/wick/flow-graph-interpreter/tests/test/test_component.rs
@@ -167,13 +167,12 @@ impl Component for TestComponent {
   fn handle(
     &self,
     invocation: Invocation,
-    stream: PacketStream,
     _config: Option<wick_packet::OperationConfig>,
     callback: Arc<RuntimeCallback>,
   ) -> BoxFuture<Result<PacketStream, ComponentError>> {
     let operation = invocation.target.operation_id();
     println!("got op {} in echo test collection", operation);
-    Box::pin(async move { Ok(handler(invocation, stream, callback)?) })
+    Box::pin(async move { Ok(handler(invocation, callback)?) })
   }
 
   fn list(&self) -> &ComponentSignature {
@@ -181,11 +180,8 @@ impl Component for TestComponent {
   }
 }
 
-fn handler(
-  invocation: Invocation,
-  mut payload_stream: PacketStream,
-  callback: Arc<RuntimeCallback>,
-) -> anyhow::Result<PacketStream> {
+fn handler(mut invocation: Invocation, callback: Arc<RuntimeCallback>) -> anyhow::Result<PacketStream> {
+  let mut payload_stream = invocation.packets;
   let operation = invocation.target.operation_id();
   match operation {
     "echo" => {

--- a/crates/wick/flow-graph-interpreter/tests/validation.rs
+++ b/crates/wick/flow-graph-interpreter/tests/validation.rs
@@ -21,7 +21,6 @@ impl Component for SignatureTestCollection {
   fn handle(
     &self,
     _invocation: Invocation,
-    _stream: PacketStream,
     _config: Option<wick_packet::OperationConfig>,
     _callback: std::sync::Arc<flow_component::RuntimeCallback>,
   ) -> BoxFuture<Result<PacketStream, ComponentError>> {

--- a/crates/wick/wick-component-wasm/src/wasm_host.rs
+++ b/crates/wick/wick-component-wasm/src/wasm_host.rs
@@ -149,12 +149,7 @@ impl WasmHost {
   }
 
   #[allow(clippy::needless_pass_by_value)]
-  pub fn call(
-    &self,
-    invocation: Invocation,
-    stream: PacketStream,
-    config: Option<wick_packet::OperationConfig>,
-  ) -> Result<PacketStream> {
+  pub fn call(&self, invocation: Invocation, config: Option<wick_packet::OperationConfig>) -> Result<PacketStream> {
     let _span = self.span.enter();
     let component_name = invocation.target.operation_id();
     debug!(component = component_name, "wasm invoke");
@@ -165,10 +160,10 @@ impl WasmHost {
       .get_export("wick", component_name)
       .map_err(|_| crate::Error::OperationNotFound(component_name.to_owned(), ctx.get_exports()))?;
     if let Some(config) = config {
-      stream.set_context(config, seed);
+      invocation.packets.set_context(config, seed);
     }
 
-    let s = into_wasmrs(index, stream);
+    let s = into_wasmrs(index, invocation.packets);
     let out = ctx.request_channel(Box::pin(s));
     trace!(
       component = component_name,

--- a/crates/wick/wick-host/src/collection.rs
+++ b/crates/wick/wick-host/src/collection.rs
@@ -46,11 +46,10 @@ impl Component for HostComponent {
   fn handle(
     &self,
     invocation: Invocation,
-    stream: PacketStream,
     data: Option<wick_packet::OperationConfig>,
     _callback: Arc<RuntimeCallback>,
   ) -> flow_component::BoxFuture<Result<PacketStream, ComponentError>> {
-    let fut = self.host.invoke(invocation, stream, data);
+    let fut = self.host.invoke(invocation, data);
 
     Box::pin(async move {
       let outputs = fut.await.map_err(ComponentError::new)?;
@@ -93,10 +92,8 @@ mod tests {
 
     let job_payload = packet_stream![("input", input)];
 
-    let invocation = Invocation::test(file!(), Entity::local("logger"), None)?;
-    let mut outputs = collection
-      .handle(invocation, job_payload, None, panic_callback())
-      .await?;
+    let invocation = Invocation::test(file!(), Entity::local("logger"), job_payload, None)?;
+    let mut outputs = collection.handle(invocation, None, panic_callback()).await?;
     let output = outputs.next().await.unwrap().unwrap();
 
     println!("output: {:?}", output);

--- a/crates/wick/wick-host/src/component_host.rs
+++ b/crates/wick/wick-host/src/component_host.rs
@@ -156,23 +156,19 @@ impl ComponentHost {
         let invocation = Invocation::new(
           Entity::server(&self.id),
           Entity::operation(&self.id, operation),
+          stream,
           data,
           &self.span,
         );
-        Ok(runtime.invoke(invocation, stream, None).await?)
+        Ok(runtime.invoke(invocation, None).await?)
       }
       None => Err(crate::Error::InvalidHostState("No engine available".into())),
     }
   }
 
-  pub async fn invoke(
-    &self,
-    invocation: Invocation,
-    stream: PacketStream,
-    data: Option<OperationConfig>,
-  ) -> Result<PacketStream> {
+  pub async fn invoke(&self, invocation: Invocation, data: Option<OperationConfig>) -> Result<PacketStream> {
     match &self.runtime {
-      Some(runtime) => Ok(runtime.invoke(invocation, stream, data).await?),
+      Some(runtime) => Ok(runtime.invoke(invocation, data).await?),
       None => Err(crate::Error::InvalidHostState("No engine available".into())),
     }
   }
@@ -277,7 +273,7 @@ mod test {
     println!("connected to server");
     let passed_data = "logging output";
     let packets = packets![("input", passed_data)];
-    let invocation: wick_rpc::rpc::Invocation = Invocation::test("test", Entity::local("logger"), None)?
+    let invocation: wick_rpc::rpc::Invocation = Invocation::test("test", Entity::local("logger"), Vec::new(), None)?
       .try_into()
       .unwrap();
 

--- a/crates/wick/wick-invocation-server/src/invocation_server.rs
+++ b/crates/wick/wick-invocation-server/src/invocation_server.rs
@@ -117,7 +117,7 @@ impl InvocationService for InvocationServer {
     let (tx, rx) = mpsc::channel(4);
     let mut stream = request.into_inner();
     let first = stream.next().await;
-    let invocation: wick_packet::Invocation = if let Some(Ok(inv)) = first {
+    let mut invocation: wick_packet::Invocation = if let Some(Ok(inv)) = first {
       if let Some(rpc::invocation_request::Data::Invocation(inv)) = inv.data {
         inv
           .try_into()
@@ -130,13 +130,11 @@ impl InvocationService for InvocationServer {
     };
     let stream = convert_invocation_stream(stream);
     let packet_stream = PacketStream::new(Box::new(stream));
+    invocation.attach_stream(packet_stream);
 
     let op_id = invocation.target.operation_id().to_owned();
 
-    let result = self
-      .collection
-      .handle(invocation, packet_stream, None, panic_callback())
-      .await;
+    let result = self.collection.handle(invocation, None, panic_callback()).await;
     if let Err(e) = result {
       let message = e.to_string();
       error!("Invocation failed: {}", message);

--- a/crates/wick/wick-packet/src/collection_link.rs
+++ b/crates/wick/wick-packet/src/collection_link.rs
@@ -21,12 +21,13 @@ impl ComponentReference {
   pub fn to_invocation(
     &self,
     operation: &str,
+    packets: impl Into<PacketStream>,
     inherent: Option<crate::InherentData>,
     follows_from: &tracing::Span,
   ) -> crate::Invocation {
     let target = crate::Entity::operation(self.target.component_id(), operation);
 
-    crate::Invocation::new(self.origin.clone(), target, inherent, follows_from)
+    crate::Invocation::new(self.origin.clone(), target, packets, inherent, follows_from)
   }
 
   #[must_use]

--- a/crates/wick/wick-packet/src/macros.rs
+++ b/crates/wick/wick-packet/src/macros.rs
@@ -26,8 +26,8 @@ macro_rules! packets {
 
 #[macro_export]
 macro_rules! fan_out {
-    ($stream:expr, $($port:expr),*) => {
-      {
+  ($stream:expr, $($port:expr),*) => {
+  {
         use $crate::wasmrs_rx::Observer;
         let mut streams = wick_packet::StreamMap::default();
         let mut senders = std::collections::HashMap::new();

--- a/crates/wick/wick-rpc/src/client.rs
+++ b/crates/wick/wick-rpc/src/client.rs
@@ -140,12 +140,9 @@ impl RpcClient {
   }
 
   /// Send an invoke RPC command with an [Invocation] object.
-  pub async fn invoke(
-    &mut self,
-    invocation: Invocation,
-    mut stream: PacketStream,
-  ) -> Result<PacketStream, RpcClientError> {
+  pub async fn invoke(&mut self, mut invocation: Invocation) -> Result<PacketStream, RpcClientError> {
     let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+    let mut stream = invocation.eject_stream();
     tx.send(InvocationRequest {
       data: Some(generated::wick::invocation_request::Data::Invocation(invocation.into())),
     })

--- a/crates/wick/wick-rpc/src/lib.rs
+++ b/crates/wick/wick-rpc/src/lib.rs
@@ -138,10 +138,10 @@ pub fn convert_tonic_streaming(mut streaming: tonic::Streaming<rpc::Packet>) -> 
 
 #[macro_export]
 macro_rules! dispatch {
-  ($inv:expr, $stream:expr, {$($name:expr => $handler:path),*,}) => {
+  ($inv:expr, {$($name:expr => $handler:path),*,}) => {
     {
       match $inv.target.operation_id() {
-        $($name => $handler($stream).await?,)*
+        $($name => $handler($inv).await?,)*
         _ => {
           unreachable!()
         }

--- a/crates/wick/wick-rpc/src/types/conversions.rs
+++ b/crates/wick/wick-rpc/src/types/conversions.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use wick_interface_types as wick;
-use wick_packet::{Entity, InherentData, Metadata, Packet, WickMetadata};
+use wick_packet::{Entity, InherentData, Metadata, Packet, PacketStream, WickMetadata};
 
 use crate::error::RpcError;
 use crate::{rpc, DurationStatistics};
@@ -244,6 +244,7 @@ impl TryFrom<rpc::Invocation> for wick_packet::Invocation {
         timestamp: d.timestamp,
       }),
       span: tracing::Span::current(),
+      packets: PacketStream::empty(),
     })
   }
 }

--- a/crates/wick/wick-runtime/src/components/component_service.rs
+++ b/crates/wick/wick-runtime/src/components/component_service.rs
@@ -28,13 +28,12 @@ impl Component for NativeComponentService {
   fn handle(
     &self,
     invocation: Invocation,
-    stream: PacketStream,
     config: Option<OperationConfig>,
     callback: std::sync::Arc<RuntimeCallback>,
   ) -> flow_component::BoxFuture<std::result::Result<PacketStream, flow_component::ComponentError>> {
     let component = self.component.clone();
 
-    let task = async move { component.handle(invocation, stream, config, callback).await };
+    let task = async move { component.handle(invocation, config, callback).await };
     Box::pin(task)
   }
 }
@@ -47,12 +46,11 @@ impl InvocationHandler for NativeComponentService {
   fn invoke(
     &self,
     invocation: Invocation,
-    stream: PacketStream,
     config: Option<OperationConfig>,
   ) -> Result<BoxFuture<Result<InvocationResponse>>> {
     let tx_id = invocation.tx_id;
     let span = debug_span!("invoke", target =  %invocation.target);
-    let fut = self.handle(invocation, stream, config, panic_callback());
+    let fut = self.handle(invocation, config, panic_callback());
 
     let task = async move {
       Ok(crate::dispatch::InvocationResponse::Stream {

--- a/crates/wick/wick-runtime/src/components/engine_component.rs
+++ b/crates/wick/wick-runtime/src/components/engine_component.rs
@@ -30,7 +30,6 @@ impl Component for EngineComponent {
   fn handle(
     &self,
     invocation: Invocation,
-    stream: PacketStream,
     config: Option<wick_packet::OperationConfig>,
     _callback: std::sync::Arc<RuntimeCallback>,
   ) -> flow_component::BoxFuture<Result<PacketStream, flow_component::ComponentError>> {
@@ -49,7 +48,7 @@ impl Component for EngineComponent {
       invocation.trace(|| trace!(target = %target_url, "invoking"));
 
       let result: InvocationResponse = engine
-        .invoke(invocation, stream, config)
+        .invoke(invocation, config)
         .map_err(flow_component::ComponentError::new)?
         .instrument(span)
         .await
@@ -83,8 +82,8 @@ mod tests {
   async fn request_log(component: &EngineComponent, data: &str) -> Result<String> {
     let stream = packet_stream!(("MAIN_IN", data));
 
-    let invocation = Invocation::test(file!(), Entity::local("simple"), None)?;
-    let outputs = component.handle(invocation, stream, None, panic_callback()).await?;
+    let invocation = Invocation::test(file!(), Entity::local("simple"), stream, None)?;
+    let outputs = component.handle(invocation, None, panic_callback()).await?;
     let mut packets: Vec<_> = outputs.collect().await;
     println!("packets: {:#?}", packets);
     let _ = packets.pop();

--- a/crates/wick/wick-runtime/src/runtime.rs
+++ b/crates/wick/wick-runtime/src/runtime.rs
@@ -55,16 +55,11 @@ impl Runtime {
     })
   }
 
-  pub async fn invoke(
-    &self,
-    invocation: Invocation,
-    stream: PacketStream,
-    config: Option<OperationConfig>,
-  ) -> Result<PacketStream> {
+  pub async fn invoke(&self, invocation: Invocation, config: Option<OperationConfig>) -> Result<PacketStream> {
     let time = std::time::SystemTime::now();
     trace!(start_time=%time.duration_since(std::time::UNIX_EPOCH).unwrap().as_millis() ,"invocation start");
 
-    let response = tokio::time::timeout(self.timeout, self.inner.invoke(invocation, stream, config)?)
+    let response = tokio::time::timeout(self.timeout, self.inner.invoke(invocation, config)?)
       .await
       .map_err(|_| RuntimeError::Timeout)??;
     trace!(duration_ms=%time.elapsed().unwrap().as_millis(),"invocation complete");

--- a/crates/wick/wick-runtime/src/runtime_service.rs
+++ b/crates/wick/wick-runtime/src/runtime_service.rs
@@ -276,12 +276,11 @@ impl InvocationHandler for RuntimeService {
   fn invoke(
     &self,
     invocation: Invocation,
-    stream: PacketStream,
     config: Option<OperationConfig>,
   ) -> std::result::Result<BoxFuture<std::result::Result<InvocationResponse, ComponentError>>, ComponentError> {
     let tx_id = invocation.tx_id;
 
-    let fut = self.interpreter.invoke(invocation, stream, config);
+    let fut = self.interpreter.invoke(invocation, config);
     let task = async move {
       match fut.await {
         Ok(response) => Ok(InvocationResponse::Stream { tx_id, rx: response }),
@@ -388,7 +387,6 @@ mod test {
     fn handle(
       &self,
       _invocation: Invocation,
-      _stream: PacketStream,
       _data: Option<OperationConfig>,
       _callback: Arc<flow_component::RuntimeCallback>,
     ) -> flow_component::BoxFuture<std::result::Result<PacketStream, flow_component::ComponentError>> {

--- a/crates/wick/wick-runtime/src/triggers/http/component_utils.rs
+++ b/crates/wick/wick-runtime/src/triggers/http/component_utils.rs
@@ -26,6 +26,7 @@ pub(super) async fn handle(
 ) -> Result<PacketStream, HttpError> {
   let (tx, rx) = PacketStream::new_channels();
   let invocation = Invocation::new(Entity::server("http_client"), target, rx, None, &Span::current());
+
   let stream = engine
     .invoke(invocation, None)
     .await

--- a/crates/wick/wick-runtime/src/triggers/http/component_utils.rs
+++ b/crates/wick/wick-runtime/src/triggers/http/component_utils.rs
@@ -25,9 +25,9 @@ pub(super) async fn handle(
   req: Request<Body>,
 ) -> Result<PacketStream, HttpError> {
   let (tx, rx) = PacketStream::new_channels();
-  let invocation = Invocation::new(Entity::server("http_client"), target, None, &Span::current());
+  let invocation = Invocation::new(Entity::server("http_client"), target, rx, None, &Span::current());
   let stream = engine
-    .invoke(invocation, rx, None)
+    .invoke(invocation, None)
     .await
     .map_err(|e| HttpError::OperationError(e.to_string()));
   match request_to_wick(req) {

--- a/crates/wick/wick-runtime/src/triggers/http/rest_router.rs
+++ b/crates/wick/wick-runtime/src/triggers/http/rest_router.rs
@@ -131,12 +131,13 @@ impl RestHandler {
       let invocation = Invocation::new(
         Entity::server("http_client"),
         Entity::operation(route.component.id(), route.operation.operation()),
+        packets,
         None,
         &span,
       );
 
       let stream = runtime
-        .invoke(invocation, packets.into(), None)
+        .invoke(invocation, None)
         .instrument(span)
         .await
         .map_err(|e| HttpError::OperationError(e.to_string()))?;

--- a/crates/wick/wick-runtime/src/triggers/time.rs
+++ b/crates/wick/wick-runtime/src/triggers/time.rs
@@ -30,16 +30,15 @@ async fn invoke_operation(
     .map(|packet| Packet::encode(packet.name(), packet.value()))
     .collect();
 
-  let packetstream: PacketStream = packets.into();
-
   let invocation = Invocation::new(
     Entity::server("schedule_client"),
     Entity::operation("0", operation.as_str()),
+    packets,
     None,
     &Span::current(),
   );
 
-  let mut response = runtime.invoke(invocation, packetstream, None).await?;
+  let mut response = runtime.invoke(invocation, None).await?;
   while let Some(packet) = response.next().await {
     trace!(?packet, "trigger:time:response");
   }

--- a/crates/wick/wick-runtime/tests/utils/mod.rs
+++ b/crates/wick/wick-runtime/tests/utils/mod.rs
@@ -50,8 +50,7 @@ pub async fn base_test(
 
   let result = engine
     .invoke(
-      Invocation::test("simple schematic", target, Some(inherent))?,
-      stream,
+      Invocation::test("simple schematic", target, stream, Some(inherent))?,
       None,
     )
     .await?;

--- a/crates/wick/wick-stdlib/src/lib.rs
+++ b/crates/wick/wick-stdlib/src/lib.rs
@@ -160,7 +160,6 @@ impl Component for Collection {
   fn handle(
     &self,
     invocation: Invocation,
-    stream: PacketStream,
     _data: Option<wick_packet::OperationConfig>,
     _callback: std::sync::Arc<RuntimeCallback>,
   ) -> flow_component::BoxFuture<Result<PacketStream, flow_component::ComponentError>> {
@@ -168,7 +167,7 @@ impl Component for Collection {
     trace!("stdlib invoke: {}", target);
 
     Box::pin(async move {
-      let stream = dispatch!(invocation, stream, {
+      let stream = dispatch!(invocation, {
             "core::error" => operations::core::error::job,
             "core::log" => operations::core::log::job,
             "core::panic" => operations::core::panic::job,

--- a/crates/wick/wick-stdlib/src/macros.rs
+++ b/crates/wick/wick-stdlib/src/macros.rs
@@ -4,9 +4,9 @@ macro_rules! request_response {
     inputs: {$($ikey:ident => $ity:ty),* $(,)?},
     output: $okey:expr,
   }) => {
-    pub(crate) async fn $name(mut stream: PacketStream) -> Result<PacketStream, Box<dyn std::error::Error + Send + Sync>> {
+    pub(crate) async fn $name(mut invocation: wick_packet::Invocation) -> Result<PacketStream, Box<dyn std::error::Error + Send + Sync>> {
       #[allow(unused_parens)]
-      let ($(mut $ikey),*) = fan_out!(stream, $(stringify!($ikey)),*);
+      let ($(mut $ikey),*) = fan_out!(invocation.packets, $(stringify!($ikey)),*);
       let (tx, rx) = PacketStream::new_channels();
       tokio::spawn(async move {
         let error = loop {

--- a/crates/wick/wick-test/src/runner.rs
+++ b/crates/wick/wick-test/src/runner.rs
@@ -48,10 +48,15 @@ async fn run_unit<'a>(
   let prefix = |msg: &str| format!("{}: {}", test_name, msg);
 
   trace!(i, %entity, "invoke");
-  let invocation = Invocation::new(Entity::test(&test_name), entity, inherent, &tracing::Span::current());
+  let invocation = Invocation::new(
+    Entity::test(&test_name),
+    entity,
+    stream,
+    inherent,
+    &tracing::Span::current(),
+  );
   let fut = component.handle(
     invocation,
-    stream,
     def.test.config().cloned(),
     std::sync::Arc::new(|_, _, _, _, _, _| panic!()),
   );

--- a/tests/integration/src/test.rs
+++ b/tests/integration/src/test.rs
@@ -71,7 +71,7 @@ async fn error(_input: Invocation) -> Result<PacketStream, ComponentError> {
 }
 
 async fn test_component(mut input: Invocation) -> Result<PacketStream, ComponentError> {
-  let (tx, stream) = PacketStream::new_channels();
+  let (tx, stream) = input.make_response();
   tokio::spawn(async move {
     let mut input = fan_out!(input.packets, "input");
     while let Some(Ok(input)) = input.next().await {


### PR DESCRIPTION
This PR circles back around to the wasmrs migration and brings packets closer to an `Invocation` struct. This allows for better correlation and centers invocations around a central configuration.

This PR also adds JSON-ification of packets in the debug output when running debug builds.