### PR TITLE
Fixed source having an empty filename in error messages

### DIFF
--- a/crates/wick/flow-graph-interpreter/tests/test/test_component.rs
+++ b/crates/wick/flow-graph-interpreter/tests/test/test_component.rs
@@ -180,7 +180,7 @@ impl Component for TestComponent {
   }
 }
 
-fn handler(mut invocation: Invocation, callback: Arc<RuntimeCallback>) -> anyhow::Result<PacketStream> {
+fn handler(invocation: Invocation, callback: Arc<RuntimeCallback>) -> anyhow::Result<PacketStream> {
   let mut payload_stream = invocation.packets;
   let operation = invocation.target.operation_id();
   match operation {

--- a/crates/wick/wick-config/src/config/app_config.rs
+++ b/crates/wick/wick-config/src/config/app_config.rs
@@ -106,18 +106,13 @@ impl AppConfiguration {
 
   /// Set the source location of the configuration.
   pub fn set_source(&mut self, source: &Path) {
-    // Source is a file, so our baseurl needs to be the parent directory.
-    // Remove the trailing filename from source.
-    if source.is_dir() {
-      self.set_baseurl(source);
-      self.source = Some(source.to_path_buf());
-    } else {
-      let mut s = source.to_path_buf();
-      s.pop();
-
-      self.set_baseurl(&s);
-      self.source = Some(s);
+    let mut source = source.to_path_buf();
+    self.source = Some(source.clone());
+    // Source is (should be) a file, so pop the filename before setting the baseurl.
+    if !source.is_dir() {
+      source.pop();
     }
+    self.set_baseurl(&source);
   }
 
   /// Return the version of the application.

--- a/crates/wick/wick-config/src/config/component_config.rs
+++ b/crates/wick/wick-config/src/config/component_config.rs
@@ -114,18 +114,13 @@ impl ComponentConfiguration {
 
   /// Set the source location of the configuration.
   pub fn set_source(&mut self, source: &Path) {
-    // Source is a file, so our baseurl needs to be the parent directory.
-    // Remove the trailing filename from source.
-    if source.is_dir() {
-      self.set_baseurl(source);
-      self.source = Some(source.to_path_buf());
-    } else {
-      let mut s = source.to_path_buf();
-      s.pop();
-
-      self.set_baseurl(&s);
-      self.source = Some(s);
+    let mut source = source.to_path_buf();
+    self.source = Some(source.clone());
+    // Source is (should be) a file, so pop the filename before setting the baseurl.
+    if !source.is_dir() {
+      source.pop();
     }
+    self.set_baseurl(&source);
   }
 
   /// Returns a function that resolves a binding to a configuration item.

--- a/crates/wick/wick-config/src/config/test_config.rs
+++ b/crates/wick/wick-config/src/config/test_config.rs
@@ -19,17 +19,12 @@ pub struct TestConfiguration {
 impl TestConfiguration {
   /// Set the source location of the configuration.
   pub fn set_source(&mut self, source: &Path) {
-    // Source is a file, so our baseurl needs to be the parent directory.
-    // Remove the trailing filename from source.
-    if source.is_dir() {
-      self.set_baseurl(source);
-      self.source = Some(source.to_path_buf());
-    } else {
-      let mut s = source.to_path_buf();
-      s.pop();
-
-      self.set_baseurl(&s);
-      self.source = Some(s);
+    let mut source = source.to_path_buf();
+    self.source = Some(source.clone());
+    // Source is (should be) a file, so pop the filename before setting the baseurl.
+    if !source.is_dir() {
+      source.pop();
     }
+    self.set_baseurl(&source);
   }
 }

--- a/crates/wick/wick-config/src/config/types_config.rs
+++ b/crates/wick/wick-config/src/config/types_config.rs
@@ -47,17 +47,12 @@ impl TypesConfiguration {
 
   /// Set the source location of the configuration.
   pub fn set_source(&mut self, source: &Path) {
-    // Source is a file, so our baseurl needs to be the parent directory.
-    // Remove the trailing filename from source.
-    if source.is_dir() {
-      self.set_baseurl(source);
-      self.source = Some(source.to_path_buf());
-    } else {
-      let mut s = source.to_path_buf();
-      s.pop();
-
-      self.set_baseurl(&s);
-      self.source = Some(s);
+    let mut source = source.to_path_buf();
+    self.source = Some(source.clone());
+    // Source is (should be) a file, so pop the filename before setting the baseurl.
+    if !source.is_dir() {
+      source.pop();
     }
+    self.set_baseurl(&source);
   }
 }


### PR DESCRIPTION
This PR fixes the reported `source` of configuration files so errors are more helpful.

Closes #267
