### PR TITLE
Added pluck shorthand e.g. `op.output.field -> op.input`

### DIFF
--- a/crates/wick/flow-expression-parser/src/error.rs
+++ b/crates/wick/flow-expression-parser/src/error.rs
@@ -17,6 +17,10 @@ pub enum ParserError {
   #[error("Invalid connection definition syntax: '{0}'")]
   ConnectionDefinitionSyntax(String),
 
+  /// Whatever was passed in as an operation's port isn't valid.
+  #[error("Invalid input/output port syntax: '{0}'")]
+  PortSyntax(String),
+
   /// Ambiguous reference in connection shorthand.
   #[error("No suitable default found for port in : {0}")]
   NoDefaultPort(String),

--- a/crates/wick/flow-graph-interpreter/src/graph.rs
+++ b/crates/wick/flow-graph-interpreter/src/graph.rs
@@ -9,11 +9,22 @@ pub mod types {
   pub(crate) type Port<'a> = flow_graph::iterators::Port<'a, OperationConfig>;
 }
 
-use flow_expression_parser::ast::{FlowExpression, InstanceTarget};
+use std::collections::HashMap;
+
+use flow_expression_parser::ast::{
+  BlockExpression,
+  ConnectionExpression,
+  ConnectionTargetExpression,
+  FlowExpression,
+  InstancePort,
+  InstanceTarget,
+};
 use flow_expression_parser::parse::CORE_ID;
 use flow_graph::NodeReference;
+use serde_json::Value;
 use types::*;
 use wick_config::config::{ComponentImplementation, FlowOperation};
+use wick_packet::OperationConfig;
 
 use crate::constants::{INTERNAL_ID_INHERENT, NS_CORE, NS_INTERNAL, NS_NULL};
 
@@ -66,62 +77,166 @@ fn register_operation(
     );
   }
 
-  let mut drop_id = 0;
-
-  // inline instances
-  for expression in flow.expressions_mut() {
-    match expression {
-      FlowExpression::ConnectionExpression(expr) => {
-        if let InstanceTarget::Path(path, id) = expr.from().instance() {
-          let (component_id, op) = path.split_once("::").unwrap(); // unwrap OK if we come from a parsed config.
-          schematic.add_external(id, NodeReference::new(component_id, op), None);
-        }
-        match expr.to_mut().instance_mut() {
-          InstanceTarget::Path(path, id) => {
-            let (component_id, op) = path.split_once("::").unwrap(); // unwrap OK if we come from a parsed config.
-            schematic.add_external(id, NodeReference::new(component_id, op), None);
-          }
-          InstanceTarget::Null(id) => {
-            drop_id += 1;
-            let id_str = format!("drop_{}", drop_id);
-            id.replace(id_str.clone());
-            schematic.add_external(id_str, NodeReference::new(NS_NULL, "drop"), None);
-          }
-          _ => {}
-        }
-      }
-      FlowExpression::BlockExpression(_) => todo!(),
-    }
-  }
+  expand_expressions(&mut schematic, flow.expressions_mut())?;
 
   for expression in flow.expressions() {
-    match expression {
-      FlowExpression::ConnectionExpression(expr) => {
-        let from = expr.from();
-        let to = expr.to();
-        let to_port = schematic
-          .find_mut(to.instance().id().unwrap())
-          .map(|component| component.add_input(to.port()));
-
-        if to_port.is_none() {
-          error!("Missing downstream: instance {:?}", to);
-          return Err(flow_graph::error::Error::MissingDownstream(
-            to.instance().id().unwrap().to_owned(),
-          ));
-        }
-        let to_port = to_port.unwrap();
-
-        if let Some(component) = schematic.find_mut(from.instance().id().unwrap()) {
-          let from_port = component.add_output(from.port());
-          schematic.connect(from_port, to_port, None)?;
-        } else {
-          panic!("Can't find component {}", from.instance());
-        }
-      }
-      FlowExpression::BlockExpression(_) => todo!(),
-    }
+    process_flow_expression(&mut schematic, expression)?;
   }
   network.add_schematic(schematic);
+  Ok(())
+}
+
+fn process_flow_expression(schematic: &mut Schematic, expr: &FlowExpression) -> Result<(), flow_graph::error::Error> {
+  match expr {
+    FlowExpression::ConnectionExpression(expr) => process_connection_expression(schematic, expr)?,
+    FlowExpression::BlockExpression(expr) => {
+      for expr in expr.iter() {
+        process_flow_expression(schematic, expr)?;
+      }
+    }
+  }
+  Ok(())
+}
+
+fn process_connection_expression(
+  schematic: &mut Schematic,
+  expr: &ConnectionExpression,
+) -> Result<(), flow_graph::error::Error> {
+  let from = expr.from();
+  let to = expr.to();
+  let to_port = schematic
+    .find_mut(to.instance().id().unwrap())
+    .map(|component| component.add_input(to.port().name()));
+
+  if to_port.is_none() {
+    error!("Missing downstream: instance {:?}", to);
+    return Err(flow_graph::error::Error::MissingDownstream(
+      to.instance().id().unwrap().to_owned(),
+    ));
+  }
+  let to_port = to_port.unwrap();
+
+  if let Some(component) = schematic.find_mut(from.instance().id().unwrap()) {
+    let from_port = component.add_output(from.port().name());
+    schematic.connect(from_port, to_port, None)?;
+  } else {
+    panic!("Can't find component {}", from.instance());
+  }
+  Ok(())
+}
+
+#[allow(clippy::option_if_let_else)]
+fn expand_expressions(
+  schematic: &mut Schematic,
+  expressions: &mut [FlowExpression],
+) -> Result<(), flow_graph::error::Error> {
+  expand_port_paths(schematic, expressions)?;
+  expand_inline_operations(schematic, expressions)?;
+
+  Ok(())
+}
+
+#[allow(clippy::option_if_let_else)]
+fn expand_port_paths(
+  schematic: &mut Schematic,
+  expressions: &mut [FlowExpression],
+) -> Result<(), flow_graph::error::Error> {
+  for expression in expressions.iter_mut() {
+    if let FlowExpression::ConnectionExpression(expr) = expression {
+      let (from, to) = expr.clone().into_parts();
+      let (from_inst, from_port, _) = from.into_parts();
+      let (to_inst, to_port, _) = to.into_parts();
+      if let InstancePort::Path(name, parts) = from_port {
+        let id = format!("{}_pluck_{}_{}", schematic.name(), name, parts.join(","));
+        let config = OperationConfig::from(HashMap::from([("field".to_owned(), Value::String(parts.join(",")))]));
+        schematic.add_external(&id, NodeReference::new("core", "pluck"), Some(config));
+        *expression = FlowExpression::block(BlockExpression::new(vec![
+          FlowExpression::connection(ConnectionExpression::new(
+            ConnectionTargetExpression::new(from_inst, InstancePort::named(&name)),
+            ConnectionTargetExpression::new(InstanceTarget::named(&id), InstancePort::named("input")),
+          )),
+          FlowExpression::connection(ConnectionExpression::new(
+            ConnectionTargetExpression::new(InstanceTarget::named(&id), InstancePort::named("output")),
+            ConnectionTargetExpression::new(to_inst, to_port),
+          )),
+        ]));
+      }
+    }
+  }
+  Ok(())
+}
+
+#[allow(clippy::option_if_let_else)]
+fn expand_inline_operations(
+  schematic: &mut Schematic,
+  expressions: &mut [FlowExpression],
+) -> Result<(), flow_graph::error::Error> {
+  let mut inline_id = 0;
+  let mut anonymous_path_ids: HashMap<String, (Vec<String>, String)> = HashMap::new();
+  for expression in expressions.iter_mut() {
+    expand_flow_expression(schematic, expression, &mut inline_id, &mut anonymous_path_ids)?;
+  }
+  Ok(())
+}
+
+fn expand_flow_expression(
+  schematic: &mut Schematic,
+  expression: &mut FlowExpression,
+  inline_id: &mut usize,
+  anonymous_path_ids: &mut HashMap<String, (Vec<String>, String)>,
+) -> Result<(), flow_graph::error::Error> {
+  match expression {
+    FlowExpression::ConnectionExpression(expr) => {
+      expand_operation(schematic, expr, inline_id, anonymous_path_ids)?;
+    }
+    FlowExpression::BlockExpression(block) => {
+      for expr in block.iter_mut() {
+        expand_flow_expression(schematic, expr, inline_id, anonymous_path_ids)?;
+      }
+    }
+  }
+  Ok(())
+}
+
+fn expand_operation(
+  schematic: &mut Schematic,
+  expr: &mut Box<ConnectionExpression>,
+  inline_id: &mut usize,
+  anonymous_path_ids: &mut HashMap<String, (Vec<String>, String)>,
+) -> Result<(), flow_graph::error::Error> {
+  if let InstanceTarget::Path(path, id) = expr.from().instance() {
+    let id = id.as_ref().or(anonymous_path_ids.get(path).map(|(_, id)| id));
+    #[allow(clippy::option_if_let_else)]
+    if let Some(id) = id {
+      let (component_id, op) = path.split_once("::").unwrap(); // unwrap OK if we come from a parsed config.
+      schematic.add_external(id, NodeReference::new(component_id, op), None);
+    } else {
+      todo!()
+    }
+  }
+  let to_port = expr.to().port().clone();
+  let instance = expr.to_mut().instance_mut();
+  match instance {
+    InstanceTarget::Path(path, id) => {
+      if let Some(id) = id {
+        let (component_id, op) = path.split_once("::").unwrap(); // unwrap OK if we come from a parsed config.
+        schematic.add_external(id, NodeReference::new(component_id, op), None);
+      } else if let Some((ports, generated_id)) = anonymous_path_ids.get_mut(path) {
+        if ports.contains(to_port.name()) {
+          return Err(flow_graph::error::Error::AmbiguousOperation(path.clone()));
+        }
+        ports.push(to_port.name().clone());
+        id.replace(generated_id.clone());
+      }
+    }
+    InstanceTarget::Null(id) => {
+      *inline_id += 1;
+      let id_str = format!("drop_{}", inline_id);
+      id.replace(id_str.clone());
+      schematic.add_external(id_str, NodeReference::new(NS_NULL, "drop"), None);
+    }
+    _ => {}
+  }
   Ok(())
 }
 

--- a/crates/wick/flow-graph-interpreter/src/graph.rs
+++ b/crates/wick/flow-graph-interpreter/src/graph.rs
@@ -148,7 +148,7 @@ fn expand_port_paths(
       let (to_inst, to_port, _) = to.into_parts();
       if let InstancePort::Path(name, parts) = from_port {
         let id = format!("{}_pluck_{}_{}", schematic.name(), name, parts.join(","));
-        let config = OperationConfig::from(HashMap::from([("field".to_owned(), Value::String(parts.join(",")))]));
+        let config = OperationConfig::from(HashMap::from([("field".to_owned(), Value::String(parts.join(".")))]));
         schematic.add_external(&id, NodeReference::new("core", "pluck"), Some(config));
         *expression = FlowExpression::block(BlockExpression::new(vec![
           FlowExpression::connection(ConnectionExpression::new(

--- a/crates/wick/flow-graph-interpreter/tests/core.rs
+++ b/crates/wick/flow-graph-interpreter/tests/core.rs
@@ -23,6 +23,16 @@ async fn test_pluck() -> Result<()> {
 }
 
 #[test_logger::test(tokio::test)]
+async fn test_pluck_shorthand() -> Result<()> {
+  first_packet_test(
+    "./tests/manifests/v1/core-pluck-shorthand.yaml",
+    packets!(("input", json!({ "to_pluck" :"Hello world!", "to_ignore": "ignore me" }))),
+    "Hello world!",
+  )
+  .await
+}
+
+#[test_logger::test(tokio::test)]
 async fn test_drop() -> Result<()> {
   first_packet_test(
     "./tests/manifests/v1/core-drop.yaml",

--- a/crates/wick/flow-graph-interpreter/tests/core.rs
+++ b/crates/wick/flow-graph-interpreter/tests/core.rs
@@ -26,7 +26,7 @@ async fn test_pluck() -> Result<()> {
 async fn test_pluck_shorthand() -> Result<()> {
   first_packet_test(
     "./tests/manifests/v1/core-pluck-shorthand.yaml",
-    packets!(("input", json!({ "to_pluck" :"Hello world!", "to_ignore": "ignore me" }))),
+    packets!(("request", json!({ "headers" : {"cookie": ["Hello world!"]}}))),
     "Hello world!",
   )
   .await

--- a/crates/wick/flow-graph-interpreter/tests/manifests/v1/core-pluck-shorthand.yaml
+++ b/crates/wick/flow-graph-interpreter/tests/manifests/v1/core-pluck-shorthand.yaml
@@ -1,0 +1,11 @@
+---
+name: 'test'
+kind: wick/component@v1
+metadata:
+  version: '0.0.2'
+component:
+  kind: wick/component/composite@v1
+  operations:
+    - name: test
+      flow:
+        - <>.input.to_pluck -> <>.output

--- a/crates/wick/flow-graph-interpreter/tests/manifests/v1/core-pluck-shorthand.yaml
+++ b/crates/wick/flow-graph-interpreter/tests/manifests/v1/core-pluck-shorthand.yaml
@@ -8,4 +8,4 @@ component:
   operations:
     - name: test
       flow:
-        - <>.input.to_pluck -> <>.output
+        - <>.request.headers.cookie.0 -> <>.output

--- a/crates/wick/flow-graph/src/error.rs
+++ b/crates/wick/flow-graph/src/error.rs
@@ -8,4 +8,6 @@ pub enum Error {
   MultipleInputConnections(String),
   #[error("Missing downstream '{0}'")]
   MissingDownstream(String),
+  #[error("Usage of inline operation '{0}' can not be discerned, it's inputs are used by multiple connections. Use the inline ID syntax to disambiguate, e.g. component::op[A] to give the operation an id of 'A'")]
+  AmbiguousOperation(String),
 }

--- a/crates/wick/flow-graph/tests/test/mod.rs
+++ b/crates/wick/flow-graph/tests/test/mod.rs
@@ -98,13 +98,13 @@ pub fn from_manifest(network_def: &wick_config::config::ComponentConfiguration) 
         let to = connection.to();
         let to_port = if let Some(node) = schematic.find_mut(to.instance().id().unwrap()) {
           println!("{:?}", node);
-          node.add_input(to.port())
+          node.add_input(to.port().name())
         } else {
           panic!();
         };
         if let Some(node) = schematic.find_mut(from.instance().id().unwrap()) {
           println!("{:?}", node);
-          let from_port = node.add_output(from.port());
+          let from_port = node.add_output(from.port().name());
           schematic.connect(from_port, to_port, None)?;
         } else {
           // panic!();

--- a/crates/wick/wick-config/src/v0/conversions.rs
+++ b/crates/wick/wick-config/src/v0/conversions.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::str::FromStr;
 use std::time::Duration;
 
-use flow_expression_parser::ast::{self, InstanceTarget};
+use flow_expression_parser::ast::{self, InstancePort, InstanceTarget};
 use flow_expression_parser::parse_id;
 use option_utils::OptionUtils;
 use serde_json::Value;
@@ -110,7 +110,7 @@ impl TryFrom<crate::v0::SchematicManifest> for config::FlowOperation {
     let connections: Result<Vec<ast::FlowExpression>> = manifest
       .connections
       .into_iter()
-      .map(|def| Ok(ast::FlowExpression::ConnectionExpression(Box::new(def.try_into()?))))
+      .map(|def| Ok(ast::FlowExpression::connection(def.try_into()?)))
       .collect();
     Ok(Self {
       name: manifest.name.clone(),
@@ -151,9 +151,9 @@ impl TryFrom<crate::v0::ConnectionTargetDefinition> for ast::ConnectionTargetExp
   type Error = ManifestError;
 
   fn try_from(def: crate::v0::ConnectionTargetDefinition) -> Result<Self> {
-    Ok(ast::ConnectionTargetExpression::new(
+    Ok(ast::ConnectionTargetExpression::new_default(
       InstanceTarget::from_str(&def.instance)?,
-      def.port,
+      InstancePort::named(def.port),
       def.data,
     ))
   }

--- a/crates/wick/wick-config/src/v1/conversions.rs
+++ b/crates/wick/wick-config/src/v1/conversions.rs
@@ -3,7 +3,7 @@ use std::str::FromStr;
 use std::time::Duration;
 mod types;
 
-use flow_expression_parser::ast::{self, InstanceTarget};
+use flow_expression_parser::ast::{self, InstancePort, InstanceTarget};
 use option_utils::OptionUtils;
 
 // use flow_expression_parser::parse_id;
@@ -752,8 +752,8 @@ impl TryFrom<v1::FlowExpression> for ast::FlowExpression {
 
   fn try_from(expr: v1::FlowExpression) -> Result<Self> {
     Ok(match expr {
-      v1::FlowExpression::ConnectionDefinition(v) => ast::FlowExpression::ConnectionExpression(Box::new(v.try_into()?)),
-      v1::FlowExpression::BlockExpression(v) => ast::FlowExpression::BlockExpression(v.try_into()?),
+      v1::FlowExpression::ConnectionDefinition(v) => ast::FlowExpression::connection(v.try_into()?),
+      v1::FlowExpression::BlockExpression(v) => ast::FlowExpression::block(v.try_into()?),
     })
   }
 }
@@ -1013,7 +1013,7 @@ impl TryFrom<ast::ConnectionTargetExpression> for v1::ConnectionTargetDefinition
     Ok(Self {
       data,
       instance: instance.to_string(),
-      port,
+      port: port.to_string(),
     })
   }
 }
@@ -1146,9 +1146,9 @@ impl TryFrom<crate::v1::ConnectionTargetDefinition> for ast::ConnectionTargetExp
   type Error = ManifestError;
 
   fn try_from(def: crate::v1::ConnectionTargetDefinition) -> Result<Self> {
-    Ok(ast::ConnectionTargetExpression::new(
+    Ok(ast::ConnectionTargetExpression::new_default(
       InstanceTarget::from_str(&def.instance)?,
-      def.port,
+      InstancePort::from_str(&def.port)?,
       def.data,
     ))
   }

--- a/crates/wick/wick-config/src/v1/parse.rs
+++ b/crates/wick/wick-config/src/v1/parse.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::str::FromStr;
 
-use flow_expression_parser::ast;
+use flow_expression_parser::ast::{self, InstancePort};
 use serde::Deserialize;
 use serde_json::Value;
 
@@ -13,7 +13,7 @@ type Result<T> = std::result::Result<T, Error>;
 /// The reserved identifier representing an as-of-yet-undetermined default value.
 const DEFAULT_ID: &str = "<>";
 
-pub(crate) fn parse_target(s: &str) -> Result<(String, Option<&str>)> {
+pub(crate) fn parse_target(s: &str) -> Result<(String, Option<InstancePort>)> {
   Ok(flow_expression_parser::parse::v1::parse_target(s)?)
 }
 
@@ -21,7 +21,7 @@ pub(crate) fn parse_connection_target(s: &str) -> Result<v1::ConnectionTargetDef
   let (t_ref, t_port) = parse_target(s)?;
   Ok(v1::ConnectionTargetDefinition {
     instance: t_ref,
-    port: t_port.unwrap_or(DEFAULT_ID).to_owned(),
+    port: t_port.map_or(DEFAULT_ID.to_owned(), |v| v.to_string()),
     data: Default::default(),
   })
 }
@@ -32,12 +32,12 @@ pub(crate) fn parse_connection(s: &str) -> Result<v1::ConnectionDefinition> {
   Ok(v1::ConnectionDefinition {
     from: v1::ConnectionTargetDefinition {
       instance: from.0.to_string(),
-      port: from.1,
+      port: from.1.to_string(),
       data: from.2,
     },
     to: v1::ConnectionTargetDefinition {
       instance: to.0.to_string(),
-      port: to.1,
+      port: to.1.to_string(),
       data: to.2,
     },
   })

--- a/crates/wick/wick-config/tests/v0_load_from_file.rs
+++ b/crates/wick/wick-config/tests/v0_load_from_file.rs
@@ -1,7 +1,13 @@
 use std::env;
 use std::path::PathBuf;
 
-use flow_expression_parser::ast::{ConnectionExpression, ConnectionTargetExpression, FlowExpression, InstanceTarget};
+use flow_expression_parser::ast::{
+  ConnectionExpression,
+  ConnectionTargetExpression,
+  FlowExpression,
+  InstancePort,
+  InstanceTarget,
+};
 use tracing::debug;
 use wick_config::component_config::CompositeComponentImplementation;
 use wick_config::error::ManifestError;
@@ -74,10 +80,10 @@ async fn load_shortform_yaml() -> Result<(), ManifestError> {
 
   assert_eq!(
     expr,
-    &FlowExpression::ConnectionExpression(Box::new(ConnectionExpression::new(
-      ConnectionTargetExpression::new(InstanceTarget::Input, "input", Default::default()),
-      ConnectionTargetExpression::new(InstanceTarget::named("logger"), "input", Default::default())
-    )))
+    &FlowExpression::connection(ConnectionExpression::new(
+      ConnectionTargetExpression::new(InstanceTarget::Input, InstancePort::named("input")),
+      ConnectionTargetExpression::new(InstanceTarget::named("logger"), InstancePort::named("input"))
+    ))
   );
 
   Ok(())


### PR DESCRIPTION
This PR adds shorthand to automatically generate `pluck` operation definitions and associated expressions from shorthand.

i.e.

This:

```yaml
  operations:
    - name: test
      uses:
        - name: p
          operation: core::pluck
          with:
            field: 'some_field'
      flow:
        - <>.data -> p.input
        - p.output -> <>
```

can be shortened to this:

```yaml
operations:
    - name: test
      flow:
        - <>.data.some_field -> <>.output
```