### PR TITLE
Fix handling of fatal component errors in wasm calls

### DIFF
--- a/crates/components/wick-sqlx/src/component.rs
+++ b/crates/components/wick-sqlx/src/component.rs
@@ -290,7 +290,11 @@ async fn exec(
 
   let mut bound_args = Vec::new();
   for arg in def.arguments() {
-    let (ty, packet) = args.iter().find(|(_, p)| p.port() == arg).cloned().unwrap();
+    let (ty, packet) = args
+      .iter()
+      .find(|(_, p)| p.port() == arg)
+      .cloned()
+      .ok_or_else(|| Error::MissingArgument(arg.clone()))?;
     let wrapper = match packet
       .deserialize_into(ty.clone())
       .map_err(|e| Error::Prepare(e.to_string()))

--- a/crates/components/wick-sqlx/src/error.rs
+++ b/crates/components/wick-sqlx/src/error.rs
@@ -11,6 +11,9 @@ pub enum Error {
   #[error("Failed to fetch result of query: {0}")]
   Fetch(String),
 
+  #[error("Missing argument: {0}")]
+  MissingArgument(String),
+
   #[error("Unknown database scheme '{0}'")]
   InvalidScheme(String),
 

--- a/crates/wick/wick-component/src/macros.rs
+++ b/crates/wick/wick-component/src/macros.rs
@@ -83,6 +83,14 @@ macro_rules! payload_fan_out {
                   $crate::handle_port!(raw: $raw, packet, tx, $port, $($ty)*)
                 },
               )*
+              $crate::packet::Packet::FATAL_ERROR => {
+                let error = packet.unwrap_err();
+                $crate::paste::paste! {
+                  $(
+                    [<$port:snake _tx>].send_result(Err($crate::anyhow::Error::msg(error.msg().to_owned()))).unwrap();
+                  )*
+                }
+              }
               _ => panic!("Unexpected port: {}", packet.port())
             }
           } else {
@@ -127,6 +135,15 @@ macro_rules! payload_fan_out {
                     $crate::handle_port!(raw: $raw, packet, tx, $port, $($ty)*)
                   },
                 )*
+                $crate::packet::Packet::FATAL_ERROR => {
+                  use $crate::wasmrs_rx::Observer;
+                  let error = packet.unwrap_err();
+                  $crate::paste::paste! {
+                    $(
+                      [<$port:snake _tx>].send_result(Err($crate::anyhow::Error::msg(error.msg().to_owned()))).unwrap();
+                    )*
+                  }
+                }
                 _ => panic!("Unexpected port: {}", packet.port())
               }
             } else {


### PR DESCRIPTION
The WebAssembly-oriented component-to-component call handling needed to be made more resilient to prevent unnecessary panics. This PR removes some unwraps and adds some better error handling.