### PR TITLE
wick-component QoL: Reduced exposure of wasmrs* deps, added common imports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5589,9 +5589,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-msgpack"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ee7e61cbba6505b736aff4ae10e1d477a1688817a1eb1f7a329ef6366f9aab"
+checksum = "c566f7770882bb305d56f393e411f4a15b3b3e8404be914d183cc3cd35c3f733"
 dependencies = [
  "byteorder",
  "heapless",
@@ -6197,8 +6197,10 @@ dependencies = [
  "serde_json",
  "tokio",
  "tokio-stream",
+ "wasm-msgpack",
  "wasmrs",
  "wasmrs-codec",
+ "wasmrs-guest",
  "wasmrs-runtime",
  "wasmrs-rx",
  "wick-packet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,7 @@ wasmrs-host = { version = "0.12" }
 wasmrs-runtime = { version = "0.12" }
 wasmrs-rx = { version = "0.12" }
 wasmrs-wasmtime = { version = "0.12" }
+wasm-msgpack = { version = "~0.6.2" }
 #
 # Other
 #

--- a/crates/integration/test-baseline-component/Cargo.toml
+++ b/crates/integration/test-baseline-component/Cargo.toml
@@ -20,8 +20,6 @@ localgen = []
 crate-type = ["cdylib"]
 
 [dependencies]
-wasmrs-guest = { version="0.12", features = [
-] }
 wick-component = { path = "../../wick/wick-component" }
 serde = { version = "1", features = ["derive"] }
 async-trait = "0.1"

--- a/crates/integration/test-baseline-component/src/lib.rs
+++ b/crates/integration/test-baseline-component/src/lib.rs
@@ -9,7 +9,6 @@ mod wick {
   #![allow(unused_imports, missing_debug_implementations, clippy::needless_pass_by_value)]
   wick_component::wick_import!();
 }
-use wasmrs_guest::StreamExt;
 use wick::*;
 
 #[cfg_attr(target_family = "wasm",async_trait::async_trait(?Send))]

--- a/crates/integration/test-cli-trigger-component/Cargo.toml
+++ b/crates/integration/test-cli-trigger-component/Cargo.toml
@@ -20,8 +20,6 @@ localgen = []
 crate-type = ["cdylib"]
 
 [dependencies]
-wasmrs-guest = { version="0.12", features = [
-] }
 wick-component = { path = "../../wick/wick-component" }
 serde = { version = "1", features = ["derive"] }
 async-trait = "0.1"

--- a/crates/integration/test-cli-trigger-component/src/lib.rs
+++ b/crates/integration/test-cli-trigger-component/src/lib.rs
@@ -1,6 +1,5 @@
 use std::io::{self, BufRead, BufReader};
 
-use wasmrs_guest::StreamExt;
 #[cfg(feature = "localgen")]
 mod generated;
 #[cfg(feature = "localgen")]
@@ -11,7 +10,6 @@ mod wick {
   wick_component::wick_import!();
 }
 use wick::*;
-use wick_component::once;
 
 #[cfg_attr(target_family = "wasm",async_trait::async_trait(?Send))]
 #[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]

--- a/crates/integration/test-cli-with-db/Cargo.toml
+++ b/crates/integration/test-cli-with-db/Cargo.toml
@@ -20,8 +20,6 @@ localgen = []
 crate-type = ["cdylib"]
 
 [dependencies]
-wasmrs-guest = { version="0.12", features = [
-] }
 wick-component = { path = "../../wick/wick-component" }
 serde = { version = "1", features = ["derive"] }
 async-trait = "0.1"

--- a/crates/integration/test-cli-with-db/src/lib.rs
+++ b/crates/integration/test-cli-with-db/src/lib.rs
@@ -1,6 +1,5 @@
 use console::set_colors_enabled;
-use wasmrs_guest::StreamExt;
-use wick_component::once;
+
 #[cfg(feature = "localgen")]
 mod generated;
 #[cfg(feature = "localgen")]

--- a/crates/integration/test-http-trigger-component/Cargo.toml
+++ b/crates/integration/test-http-trigger-component/Cargo.toml
@@ -20,8 +20,6 @@ localgen = []
 crate-type = ["cdylib"]
 
 [dependencies]
-wasmrs-guest = { version="0.12", features = [
-] }
 wick-component = { path = "../../wick/wick-component" }
 serde = { version = "1", features = ["derive"] }
 async-trait = "0.1"

--- a/crates/integration/test-http-trigger-component/src/lib.rs
+++ b/crates/integration/test-http-trigger-component/src/lib.rs
@@ -1,5 +1,5 @@
 use futures::TryStreamExt;
-use wasmrs_guest::StreamExt;
+
 #[cfg(feature = "localgen")]
 mod generated;
 #[cfg(feature = "localgen")]

--- a/crates/wick/wick-component-codegen/src/generate/dependency.rs
+++ b/crates/wick/wick-component-codegen/src/generate/dependency.rs
@@ -40,7 +40,7 @@ impl ToTokens for Dependency {
       Dependency::WickPacket => tokens.extend(quote! { pub use wick_component::packet as wick_packet; }),
       Dependency::SerdeJson => tokens.extend(quote! {
         #[cfg(target_family="wasm")]
-        pub use wasmrs_guest::Value;
+        pub use wick_component::wasmrs_guest::Value;
         #[cfg(not(target_family="wasm"))]
         pub use serde_json::Value;
       }),
@@ -48,6 +48,7 @@ impl ToTokens for Dependency {
       Dependency::AsyncTrait => tokens.extend(quote! { pub use async_trait::async_trait; }),
       Dependency::WickComponent => tokens.extend(quote! {
         pub use wick_component;
+        pub use wick_component::StreamExt;
       }),
     }
   }

--- a/crates/wick/wick-component-codegen/src/generate/expand_type.rs
+++ b/crates/wick/wick-component-codegen/src/generate/expand_type.rs
@@ -66,11 +66,6 @@ pub(super) fn expand_type(
       config.add_dep(Dependency::Chrono);
       quote! {chrono::NaiveDateTime}
     }
-    // wick_interface_types::TypeSignature::Stream { ty } => {
-    //   let ty = expand_type(config, dir, imported, ty);
-    //   config.add_dep(Dependency::WasmRsRx);
-    //   quote! { WickStream<#ty> }
-    // }
     wick_interface_types::Type::Object => {
       config.add_dep(Dependency::SerdeJson);
       quote! { Value }
@@ -91,7 +86,7 @@ pub(crate) fn expand_input_fields(
       let name = id(&snake(input.name()));
       let ty = expand_type(config, direction, raw, &input.ty);
       quote! {
-        #name: impl wasmrs_guest::Stream<Item = Result<#ty, wick_component::BoxError>> + 'static
+        #name: impl wick_component::Stream<Item = Result<#ty, wick_component::BoxError>> + 'static
       }
     })
     .collect_vec()

--- a/crates/wick/wick-component-codegen/src/generate/templates/component_impl.rs
+++ b/crates/wick/wick-component-codegen/src/generate/templates/component_impl.rs
@@ -26,8 +26,8 @@ pub(crate) fn gen_component_impls<'a>(
     #[no_mangle]
     #[cfg(target_family = "wasm")]
     extern "C" fn __wasmrs_init(guest_buffer_size: u32, host_buffer_size: u32, max_host_frame_len: u32) {
-      wasmrs_guest::init(guest_buffer_size, host_buffer_size, max_host_frame_len);
-      wasmrs_guest::register_request_response("wick", "__setup", Box::new(__setup));
+      wick_component::wasmrs_guest::init(guest_buffer_size, host_buffer_size, max_host_frame_len);
+      wick_component::wasmrs_guest::register_request_response("wick", "__setup", Box::new(__setup));
       #(#register_operations)*
     }
 
@@ -47,7 +47,7 @@ fn register_operations<'a>(
     let string = op.name();
 
     quote! {
-      wasmrs_guest::register_request_channel("wick", #string, Box::new(#component::#name));
+      wick_component::wasmrs_guest::register_request_channel("wick", #string, Box::new(#component::#name));
     }
   })
   .collect()

--- a/crates/wick/wick-component-codegen/src/generate/templates/type_def.rs
+++ b/crates/wick/wick-component-codegen/src/generate/templates/type_def.rs
@@ -160,7 +160,11 @@ pub(crate) fn gen_struct<'a>(
 
   let name = id(item_part);
 
-  let fields = ty.fields.iter().map(f::field_pair(config, imported)).collect_vec();
+  let fields = ty
+    .fields
+    .iter()
+    .map(f::field_pair(config, imported, true))
+    .collect_vec();
 
   let (derive, default_impl) = if ty.fields.is_empty() {
     (

--- a/crates/wick/wick-component/Cargo.toml
+++ b/crates/wick/wick-component/Cargo.toml
@@ -26,6 +26,10 @@ wasmrs-runtime = { workspace = true }
 tokio-stream = { workspace = true }
 paste = { workspace = true }
 serde_json = { workspace = true }
+wasm-msgpack = { workspace = true, features = ["std"] }
+
+[target.'cfg(target_family = "wasm")'.dependencies]
+wasmrs-guest = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/wick/wick-component/src/lib.rs
+++ b/crates/wick/wick-component/src/lib.rs
@@ -89,16 +89,24 @@
 
 pub mod macros;
 pub use serde_json::to_value;
-pub use tokio_stream::{empty, iter as iter_raw, once as once_raw, StreamExt};
+pub use tokio_stream::{empty, iter as iter_raw, once as once_raw, Stream, StreamExt};
+#[cfg(target_family = "wasm")]
+pub use wasmrs_guest;
 pub use {flow_component, paste, wasmrs, wasmrs_codec, wasmrs_runtime as runtime, wasmrs_rx, wick_packet as packet};
 
 pub type BoxError = Box<dyn std::error::Error + Send + Sync + 'static>;
 
-pub fn once<T>(value: T) -> impl tokio_stream::Stream<Item = Result<T, BoxError>> {
+pub fn once<T>(value: T) -> impl Stream<Item = Result<T, BoxError>> {
   tokio_stream::once(Ok(value))
 }
 
-pub fn iter<I, O>(i: I) -> impl tokio_stream::Stream<Item = Result<O, BoxError>>
+pub mod prelude {
+  pub use serde_json::Value;
+
+  pub use crate::{iter, once, propagate_if_error, BoxError, Stream, StreamExt};
+}
+
+pub fn iter<I, O>(i: I) -> impl Stream<Item = Result<O, BoxError>>
 where
   I: IntoIterator<Item = O>,
 {

--- a/crates/wick/wick-component/src/macros.rs
+++ b/crates/wick/wick-component/src/macros.rs
@@ -1,6 +1,7 @@
 #[macro_export]
 macro_rules! wick_import {
   () => {
+    pub use wick_component::prelude::*;
     include!(concat!(env!("OUT_DIR"), "/mod.rs"));
   };
 }

--- a/examples/http/middleware/request/Cargo.lock
+++ b/examples/http/middleware/request/Cargo.lock
@@ -1322,7 +1322,6 @@ dependencies = [
  "anyhow",
  "async-trait",
  "serde",
- "wasmrs-guest",
  "wick-component",
  "wick-component-codegen",
 ]
@@ -2066,9 +2065,9 @@ checksum = "ed9d5b4305409d1fc9482fee2d7f9bcbf24b3972bf59817ef757e23982242a93"
 
 [[package]]
 name = "wasm-msgpack"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ee7e61cbba6505b736aff4ae10e1d477a1688817a1eb1f7a329ef6366f9aab"
+checksum = "c566f7770882bb305d56f393e411f4a15b3b3e8404be914d183cc3cd35c3f733"
 dependencies = [
  "byteorder",
  "heapless",
@@ -2246,8 +2245,10 @@ dependencies = [
  "paste",
  "serde_json",
  "tokio-stream",
+ "wasm-msgpack",
  "wasmrs",
  "wasmrs-codec",
+ "wasmrs-guest",
  "wasmrs-runtime",
  "wasmrs-rx",
  "wick-packet",

--- a/examples/http/middleware/request/Cargo.toml
+++ b/examples/http/middleware/request/Cargo.toml
@@ -17,7 +17,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 wick-component = { path = "../../../../crates/wick/wick-component" }
-wasmrs-guest = { version = "0.12", features = [] }
 serde = { version = "1", features = ["derive"] }
 async-trait = "0.1"
 anyhow = { version = "1" }

--- a/examples/http/middleware/request/src/lib.rs
+++ b/examples/http/middleware/request/src/lib.rs
@@ -1,11 +1,9 @@
 use std::collections::HashMap;
 
-use wasmrs_guest::*;
 mod wick {
   wick_component::wick_import!();
 }
 use wick::*;
-use wick_component::propagate_if_error;
 
 use self::wick::types::http;
 

--- a/templates/rust/Cargo.toml
+++ b/templates/rust/Cargo.toml
@@ -17,7 +17,6 @@ crate-type = ["cdylib"]
 
 [dependencies]
 wick-component = { git = "https://github.com/candlecorp/wick.git" }
-wasmrs-guest = { version = "0.12", features = [] }
 serde = { version = "1", features = ["derive"] }
 async-trait = "0.1"
 anyhow = { version = "1" }

--- a/templates/rust/src/lib.rs
+++ b/templates/rust/src/lib.rs
@@ -1,4 +1,3 @@
-use wasmrs_guest::*;
 mod wick {
   wick_component::wick_import!();
 }

--- a/tests/codegen-tests/Justfile
+++ b/tests/codegen-tests/Justfile
@@ -3,3 +3,4 @@ codegen:
 
 test:
   cargo test
+  cargo run --manifest-path ../../crates/bins/wick/Cargo.toml -- test tests/testdata/import-types.wick

--- a/tests/codegen-tests/src/import_types/mod.rs
+++ b/tests/codegen-tests/src/import_types/mod.rs
@@ -9,9 +9,9 @@ pub use wick_component::flow_component::Context;
 #[no_mangle]
 #[cfg(target_family = "wasm")]
 extern "C" fn __wasmrs_init(guest_buffer_size: u32, host_buffer_size: u32, max_host_frame_len: u32) {
-  wasmrs_guest::init(guest_buffer_size, host_buffer_size, max_host_frame_len);
-  wasmrs_guest::register_request_response("wick", "__setup", Box::new(__setup));
-  wasmrs_guest::register_request_channel("wick", "testop", Box::new(Component::testop_wrapper));
+  wick_component::wasmrs_guest::init(guest_buffer_size, host_buffer_size, max_host_frame_len);
+  wick_component::wasmrs_guest::register_request_response("wick", "__setup", Box::new(__setup));
+  wick_component::wasmrs_guest::register_request_channel("wick", "testop", Box::new(Component::testop_wrapper));
 }
 #[cfg(target_family = "wasm")]
 thread_local! { static __CONFIG : std :: cell :: UnsafeCell < Option < SetupPayload >> = std :: cell :: UnsafeCell :: new (None) ; }

--- a/tests/codegen-tests/src/import_types/mod.rs
+++ b/tests/codegen-tests/src/import_types/mod.rs
@@ -1,5 +1,4 @@
 pub use async_trait::async_trait;
-pub use bytes::Bytes;
 #[allow(unused)]
 pub(crate) use wick_component::wasmrs_rx::{Observable, Observer};
 pub use wick_component::{packet as wick_packet, runtime, wasmrs, wasmrs_codec, wasmrs_rx};
@@ -11,6 +10,7 @@ pub use wick_component::flow_component::Context;
 extern "C" fn __wasmrs_init(guest_buffer_size: u32, host_buffer_size: u32, max_host_frame_len: u32) {
   wick_component::wasmrs_guest::init(guest_buffer_size, host_buffer_size, max_host_frame_len);
   wick_component::wasmrs_guest::register_request_response("wick", "__setup", Box::new(__setup));
+  wick_component::wasmrs_guest::register_request_channel("wick", "echo", Box::new(Component::echo_wrapper));
   wick_component::wasmrs_guest::register_request_channel("wick", "testop", Box::new(Component::testop_wrapper));
 }
 #[cfg(target_family = "wasm")]
@@ -96,6 +96,98 @@ pub mod types {
     #[allow(unused)]
     use super::aaa;
     #[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize, PartialEq)]
+    #[doc = "HTTP method enum"]
+    pub enum HttpMethod {
+      #[doc = "HTTP GET method"]
+      Get,
+      #[doc = "HTTP POST method"]
+      Post,
+      #[doc = "HTTP PUT method"]
+      Put,
+      #[doc = "HTTP DELETE method"]
+      Delete,
+      #[doc = "HTTP PATCH method"]
+      Patch,
+      #[doc = "HTTP HEAD method"]
+      Head,
+      #[doc = "HTTP OPTIONS method"]
+      Options,
+      #[doc = "HTTP TRACE method"]
+      Trace,
+    }
+    impl HttpMethod {
+      #[allow(unused)]
+      #[doc = "Returns the value of the enum variant as a string."]
+      #[must_use]
+      pub fn value(&self) -> Option<&'static str> {
+        #[allow(clippy::match_single_binding)]
+        match self {
+          Self::Get => None,
+          Self::Post => None,
+          Self::Put => None,
+          Self::Delete => None,
+          Self::Patch => None,
+          Self::Head => None,
+          Self::Options => None,
+          Self::Trace => None,
+        }
+      }
+    }
+    impl TryFrom<u32> for HttpMethod {
+      type Error = u32;
+      fn try_from(i: u32) -> Result<Self, Self::Error> {
+        #[allow(clippy::match_single_binding)]
+        match i {
+          _ => Err(i),
+        }
+      }
+    }
+    impl std::str::FromStr for HttpMethod {
+      type Err = String;
+      fn from_str(s: &str) -> Result<Self, Self::Err> {
+        #[allow(clippy::match_single_binding)]
+        match s {
+          _ => Err(s.to_owned()),
+        }
+      }
+    }
+    impl std::fmt::Display for HttpMethod {
+      fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        #[allow(clippy::match_single_binding)]
+        match self {
+          Self::Get => f.write_str("GET"),
+          Self::Post => f.write_str("POST"),
+          Self::Put => f.write_str("PUT"),
+          Self::Delete => f.write_str("DELETE"),
+          Self::Patch => f.write_str("PATCH"),
+          Self::Head => f.write_str("HEAD"),
+          Self::Options => f.write_str("OPTIONS"),
+          Self::Trace => f.write_str("TRACE"),
+        }
+      }
+    }
+    #[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize, PartialEq)]
+    #[doc = "HTTP request"]
+    pub struct HttpRequest {
+      #[doc = "method from request line enum"]
+      pub method: HttpMethod,
+      #[doc = "scheme from request line enum"]
+      pub scheme: HttpScheme,
+      #[doc = "domain/port and any authentication from request line. optional"]
+      pub authority: String,
+      #[doc = "query parameters from request line. optional"]
+      pub query_parameters: std::collections::HashMap<String, Vec<String>>,
+      #[doc = "path from request line (not including query parameters)"]
+      pub path: String,
+      #[doc = "full URI from request line"]
+      pub uri: String,
+      #[doc = "HTTP version enum"]
+      pub version: HttpVersion,
+      #[doc = "All request headers. Duplicates are comma separated."]
+      pub headers: std::collections::HashMap<String, Vec<String>>,
+    }
+    #[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize, PartialEq)]
+    #[doc = "HTTP response"]
     pub struct HttpResponse {
       #[doc = "HTTP version enum"]
       pub version: HttpVersion,
@@ -103,13 +195,62 @@ pub mod types {
       pub status: StatusCode,
       #[doc = "All response headers. Supports duplicates."]
       pub headers: std::collections::HashMap<String, Vec<String>>,
-      #[doc = "Response body in bytes. optional."]
-      pub body: bytes::Bytes,
     }
     #[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize, PartialEq)]
+    #[doc = "HTTP scheme"]
+    pub enum HttpScheme {
+      #[doc = "HTTP scheme"]
+      Http,
+      #[doc = "HTTPS scheme"]
+      Https,
+    }
+    impl HttpScheme {
+      #[allow(unused)]
+      #[doc = "Returns the value of the enum variant as a string."]
+      #[must_use]
+      pub fn value(&self) -> Option<&'static str> {
+        #[allow(clippy::match_single_binding)]
+        match self {
+          Self::Http => None,
+          Self::Https => None,
+        }
+      }
+    }
+    impl TryFrom<u32> for HttpScheme {
+      type Error = u32;
+      fn try_from(i: u32) -> Result<Self, Self::Error> {
+        #[allow(clippy::match_single_binding)]
+        match i {
+          _ => Err(i),
+        }
+      }
+    }
+    impl std::str::FromStr for HttpScheme {
+      type Err = String;
+      fn from_str(s: &str) -> Result<Self, Self::Err> {
+        #[allow(clippy::match_single_binding)]
+        match s {
+          _ => Err(s.to_owned()),
+        }
+      }
+    }
+    impl std::fmt::Display for HttpScheme {
+      fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        #[allow(clippy::match_single_binding)]
+        match self {
+          Self::Http => f.write_str("HTTP"),
+          Self::Https => f.write_str("HTTPS"),
+        }
+      }
+    }
+    #[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize, PartialEq)]
+    #[doc = "HTTP version"]
     pub enum HttpVersion {
+      #[doc = "HTTP 1.0 version"]
       Http10,
+      #[doc = "HTTP 1.1 version"]
       Http11,
+      #[doc = "HTTP 2.0 version"]
       Http20,
     }
     impl HttpVersion {
@@ -157,9 +298,100 @@ pub mod types {
       }
     }
     #[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize, PartialEq)]
+    #[doc = "HTTP status code"]
     pub enum StatusCode {
+      #[doc = "Continue status code"]
+      Continue,
+      #[doc = "SwitchingProtocols status code"]
+      SwitchingProtocols,
+      #[doc = "HTTP OK status code"]
       Ok,
+      #[doc = "Created status code"]
       Created,
+      #[doc = "Accepted status code"]
+      Accepted,
+      #[doc = "NonAuthoritativeInformation status code"]
+      NonAuthoritativeInformation,
+      #[doc = "NoContent status code"]
+      NoContent,
+      #[doc = "ResetContent status code"]
+      ResetContent,
+      #[doc = "PartialContent status code"]
+      PartialContent,
+      #[doc = "MultipleChoices status code"]
+      MultipleChoices,
+      #[doc = "MovedPermanently status code"]
+      MovedPermanently,
+      #[doc = "Found status code"]
+      Found,
+      #[doc = "SeeOther status code"]
+      SeeOther,
+      #[doc = "NotModified status code"]
+      NotModified,
+      #[doc = "TemporaryRedirect status code"]
+      TemporaryRedirect,
+      #[doc = "PermanentRedirect status code"]
+      PermanentRedirect,
+      #[doc = "BadRequest status code"]
+      BadRequest,
+      #[doc = "Unauthorized status code"]
+      Unauthorized,
+      #[doc = "PaymentRequired status code"]
+      PaymentRequired,
+      #[doc = "Forbidden status code"]
+      Forbidden,
+      #[doc = "NotFound status code"]
+      NotFound,
+      #[doc = "MethodNotAllowed status code"]
+      MethodNotAllowed,
+      #[doc = "NotAcceptable status code"]
+      NotAcceptable,
+      #[doc = "ProxyAuthenticationRequired status code"]
+      ProxyAuthenticationRequired,
+      #[doc = "RequestTimeout status code"]
+      RequestTimeout,
+      #[doc = "Conflict status code"]
+      Conflict,
+      #[doc = "Gone status code"]
+      Gone,
+      #[doc = "LengthRequired status code"]
+      LengthRequired,
+      #[doc = "PreconditionFailed status code"]
+      PreconditionFailed,
+      #[doc = "PayloadTooLarge status code"]
+      PayloadTooLarge,
+      #[doc = "URITooLong status code"]
+      UriTooLong,
+      #[doc = "UnsupportedMediaType status code"]
+      UnsupportedMediaType,
+      #[doc = "RangeNotSatisfiable status code"]
+      RangeNotSatisfiable,
+      #[doc = "ExpectationFailed status code"]
+      ExpectationFailed,
+      #[doc = "ImATeapot status code"]
+      ImATeapot,
+      #[doc = "UnprocessableEntity status code"]
+      UnprocessableEntity,
+      #[doc = "Locked status code"]
+      Locked,
+      #[doc = "FailedDependency status code"]
+      FailedDependency,
+      #[doc = "TooManyRequests status code"]
+      TooManyRequests,
+      #[doc = "InternalServerError status code"]
+      InternalServerError,
+      #[doc = "NotImplemented status code"]
+      NotImplemented,
+      #[doc = "BadGateway status code"]
+      BadGateway,
+      #[doc = "ServiceUnavailable status code"]
+      ServiceUnavailable,
+      #[doc = "GatewayTimeout status code"]
+      GatewayTimeout,
+      #[doc = "HTTPVersionNotSupported status code"]
+      HttpVersionNotSupported,
+      #[doc = "Indicates an unknown status code"]
+      Unknown,
     }
     impl StatusCode {
       #[allow(unused)]
@@ -168,8 +400,52 @@ pub mod types {
       pub fn value(&self) -> Option<&'static str> {
         #[allow(clippy::match_single_binding)]
         match self {
+          Self::Continue => Some("100"),
+          Self::SwitchingProtocols => Some("101"),
           Self::Ok => Some("200"),
           Self::Created => Some("201"),
+          Self::Accepted => Some("202"),
+          Self::NonAuthoritativeInformation => Some("203"),
+          Self::NoContent => Some("204"),
+          Self::ResetContent => Some("205"),
+          Self::PartialContent => Some("206"),
+          Self::MultipleChoices => Some("300"),
+          Self::MovedPermanently => Some("301"),
+          Self::Found => Some("302"),
+          Self::SeeOther => Some("303"),
+          Self::NotModified => Some("304"),
+          Self::TemporaryRedirect => Some("307"),
+          Self::PermanentRedirect => Some("308"),
+          Self::BadRequest => Some("400"),
+          Self::Unauthorized => Some("401"),
+          Self::PaymentRequired => Some("402"),
+          Self::Forbidden => Some("403"),
+          Self::NotFound => Some("404"),
+          Self::MethodNotAllowed => Some("405"),
+          Self::NotAcceptable => Some("406"),
+          Self::ProxyAuthenticationRequired => Some("407"),
+          Self::RequestTimeout => Some("408"),
+          Self::Conflict => Some("409"),
+          Self::Gone => Some("410"),
+          Self::LengthRequired => Some("411"),
+          Self::PreconditionFailed => Some("412"),
+          Self::PayloadTooLarge => Some("413"),
+          Self::UriTooLong => Some("414"),
+          Self::UnsupportedMediaType => Some("415"),
+          Self::RangeNotSatisfiable => Some("416"),
+          Self::ExpectationFailed => Some("417"),
+          Self::ImATeapot => Some("418"),
+          Self::UnprocessableEntity => Some("422"),
+          Self::Locked => Some("423"),
+          Self::FailedDependency => Some("424"),
+          Self::TooManyRequests => Some("429"),
+          Self::InternalServerError => Some("500"),
+          Self::NotImplemented => Some("501"),
+          Self::BadGateway => Some("502"),
+          Self::ServiceUnavailable => Some("503"),
+          Self::GatewayTimeout => Some("504"),
+          Self::HttpVersionNotSupported => Some("505"),
+          Self::Unknown => Some("-1"),
         }
       }
     }
@@ -187,8 +463,52 @@ pub mod types {
       fn from_str(s: &str) -> Result<Self, Self::Err> {
         #[allow(clippy::match_single_binding)]
         match s {
+          "100" => Ok(Self::Continue),
+          "101" => Ok(Self::SwitchingProtocols),
           "200" => Ok(Self::Ok),
           "201" => Ok(Self::Created),
+          "202" => Ok(Self::Accepted),
+          "203" => Ok(Self::NonAuthoritativeInformation),
+          "204" => Ok(Self::NoContent),
+          "205" => Ok(Self::ResetContent),
+          "206" => Ok(Self::PartialContent),
+          "300" => Ok(Self::MultipleChoices),
+          "301" => Ok(Self::MovedPermanently),
+          "302" => Ok(Self::Found),
+          "303" => Ok(Self::SeeOther),
+          "304" => Ok(Self::NotModified),
+          "307" => Ok(Self::TemporaryRedirect),
+          "308" => Ok(Self::PermanentRedirect),
+          "400" => Ok(Self::BadRequest),
+          "401" => Ok(Self::Unauthorized),
+          "402" => Ok(Self::PaymentRequired),
+          "403" => Ok(Self::Forbidden),
+          "404" => Ok(Self::NotFound),
+          "405" => Ok(Self::MethodNotAllowed),
+          "406" => Ok(Self::NotAcceptable),
+          "407" => Ok(Self::ProxyAuthenticationRequired),
+          "408" => Ok(Self::RequestTimeout),
+          "409" => Ok(Self::Conflict),
+          "410" => Ok(Self::Gone),
+          "411" => Ok(Self::LengthRequired),
+          "412" => Ok(Self::PreconditionFailed),
+          "413" => Ok(Self::PayloadTooLarge),
+          "414" => Ok(Self::UriTooLong),
+          "415" => Ok(Self::UnsupportedMediaType),
+          "416" => Ok(Self::RangeNotSatisfiable),
+          "417" => Ok(Self::ExpectationFailed),
+          "418" => Ok(Self::ImATeapot),
+          "422" => Ok(Self::UnprocessableEntity),
+          "423" => Ok(Self::Locked),
+          "424" => Ok(Self::FailedDependency),
+          "429" => Ok(Self::TooManyRequests),
+          "500" => Ok(Self::InternalServerError),
+          "501" => Ok(Self::NotImplemented),
+          "502" => Ok(Self::BadGateway),
+          "503" => Ok(Self::ServiceUnavailable),
+          "504" => Ok(Self::GatewayTimeout),
+          "505" => Ok(Self::HttpVersionNotSupported),
+          "-1" => Ok(Self::Unknown),
           _ => Err(s.to_owned()),
         }
       }
@@ -197,8 +517,52 @@ pub mod types {
       fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         #[allow(clippy::match_single_binding)]
         match self {
+          Self::Continue => f.write_str("Continue"),
+          Self::SwitchingProtocols => f.write_str("SwitchingProtocols"),
           Self::Ok => f.write_str("OK"),
           Self::Created => f.write_str("Created"),
+          Self::Accepted => f.write_str("Accepted"),
+          Self::NonAuthoritativeInformation => f.write_str("NonAuthoritativeInformation"),
+          Self::NoContent => f.write_str("NoContent"),
+          Self::ResetContent => f.write_str("ResetContent"),
+          Self::PartialContent => f.write_str("PartialContent"),
+          Self::MultipleChoices => f.write_str("MultipleChoices"),
+          Self::MovedPermanently => f.write_str("MovedPermanently"),
+          Self::Found => f.write_str("Found"),
+          Self::SeeOther => f.write_str("SeeOther"),
+          Self::NotModified => f.write_str("NotModified"),
+          Self::TemporaryRedirect => f.write_str("TemporaryRedirect"),
+          Self::PermanentRedirect => f.write_str("PermanentRedirect"),
+          Self::BadRequest => f.write_str("BadRequest"),
+          Self::Unauthorized => f.write_str("Unauthorized"),
+          Self::PaymentRequired => f.write_str("PaymentRequired"),
+          Self::Forbidden => f.write_str("Forbidden"),
+          Self::NotFound => f.write_str("NotFound"),
+          Self::MethodNotAllowed => f.write_str("MethodNotAllowed"),
+          Self::NotAcceptable => f.write_str("NotAcceptable"),
+          Self::ProxyAuthenticationRequired => f.write_str("ProxyAuthenticationRequired"),
+          Self::RequestTimeout => f.write_str("RequestTimeout"),
+          Self::Conflict => f.write_str("Conflict"),
+          Self::Gone => f.write_str("Gone"),
+          Self::LengthRequired => f.write_str("LengthRequired"),
+          Self::PreconditionFailed => f.write_str("PreconditionFailed"),
+          Self::PayloadTooLarge => f.write_str("PayloadTooLarge"),
+          Self::UriTooLong => f.write_str("URITooLong"),
+          Self::UnsupportedMediaType => f.write_str("UnsupportedMediaType"),
+          Self::RangeNotSatisfiable => f.write_str("RangeNotSatisfiable"),
+          Self::ExpectationFailed => f.write_str("ExpectationFailed"),
+          Self::ImATeapot => f.write_str("ImATeapot"),
+          Self::UnprocessableEntity => f.write_str("UnprocessableEntity"),
+          Self::Locked => f.write_str("Locked"),
+          Self::FailedDependency => f.write_str("FailedDependency"),
+          Self::TooManyRequests => f.write_str("TooManyRequests"),
+          Self::InternalServerError => f.write_str("InternalServerError"),
+          Self::NotImplemented => f.write_str("NotImplemented"),
+          Self::BadGateway => f.write_str("BadGateway"),
+          Self::ServiceUnavailable => f.write_str("ServiceUnavailable"),
+          Self::GatewayTimeout => f.write_str("GatewayTimeout"),
+          Self::HttpVersionNotSupported => f.write_str("HTTPVersionNotSupported"),
+          Self::Unknown => f.write_str("Unknown"),
         }
       }
     }
@@ -207,6 +571,98 @@ pub mod types {
     #[allow(unused)]
     use super::zzz;
     #[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize, PartialEq)]
+    #[doc = "HTTP method enum"]
+    pub enum HttpMethod {
+      #[doc = "HTTP GET method"]
+      Get,
+      #[doc = "HTTP POST method"]
+      Post,
+      #[doc = "HTTP PUT method"]
+      Put,
+      #[doc = "HTTP DELETE method"]
+      Delete,
+      #[doc = "HTTP PATCH method"]
+      Patch,
+      #[doc = "HTTP HEAD method"]
+      Head,
+      #[doc = "HTTP OPTIONS method"]
+      Options,
+      #[doc = "HTTP TRACE method"]
+      Trace,
+    }
+    impl HttpMethod {
+      #[allow(unused)]
+      #[doc = "Returns the value of the enum variant as a string."]
+      #[must_use]
+      pub fn value(&self) -> Option<&'static str> {
+        #[allow(clippy::match_single_binding)]
+        match self {
+          Self::Get => None,
+          Self::Post => None,
+          Self::Put => None,
+          Self::Delete => None,
+          Self::Patch => None,
+          Self::Head => None,
+          Self::Options => None,
+          Self::Trace => None,
+        }
+      }
+    }
+    impl TryFrom<u32> for HttpMethod {
+      type Error = u32;
+      fn try_from(i: u32) -> Result<Self, Self::Error> {
+        #[allow(clippy::match_single_binding)]
+        match i {
+          _ => Err(i),
+        }
+      }
+    }
+    impl std::str::FromStr for HttpMethod {
+      type Err = String;
+      fn from_str(s: &str) -> Result<Self, Self::Err> {
+        #[allow(clippy::match_single_binding)]
+        match s {
+          _ => Err(s.to_owned()),
+        }
+      }
+    }
+    impl std::fmt::Display for HttpMethod {
+      fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        #[allow(clippy::match_single_binding)]
+        match self {
+          Self::Get => f.write_str("GET"),
+          Self::Post => f.write_str("POST"),
+          Self::Put => f.write_str("PUT"),
+          Self::Delete => f.write_str("DELETE"),
+          Self::Patch => f.write_str("PATCH"),
+          Self::Head => f.write_str("HEAD"),
+          Self::Options => f.write_str("OPTIONS"),
+          Self::Trace => f.write_str("TRACE"),
+        }
+      }
+    }
+    #[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize, PartialEq)]
+    #[doc = "HTTP request"]
+    pub struct HttpRequest {
+      #[doc = "method from request line enum"]
+      pub method: HttpMethod,
+      #[doc = "scheme from request line enum"]
+      pub scheme: HttpScheme,
+      #[doc = "domain/port and any authentication from request line. optional"]
+      pub authority: String,
+      #[doc = "query parameters from request line. optional"]
+      pub query_parameters: std::collections::HashMap<String, Vec<String>>,
+      #[doc = "path from request line (not including query parameters)"]
+      pub path: String,
+      #[doc = "full URI from request line"]
+      pub uri: String,
+      #[doc = "HTTP version enum"]
+      pub version: HttpVersion,
+      #[doc = "All request headers. Duplicates are comma separated."]
+      pub headers: std::collections::HashMap<String, Vec<String>>,
+    }
+    #[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize, PartialEq)]
+    #[doc = "HTTP response"]
     pub struct HttpResponse {
       #[doc = "HTTP version enum"]
       pub version: HttpVersion,
@@ -214,13 +670,62 @@ pub mod types {
       pub status: StatusCode,
       #[doc = "All response headers. Supports duplicates."]
       pub headers: std::collections::HashMap<String, Vec<String>>,
-      #[doc = "Response body in bytes. optional."]
-      pub body: bytes::Bytes,
     }
     #[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize, PartialEq)]
+    #[doc = "HTTP scheme"]
+    pub enum HttpScheme {
+      #[doc = "HTTP scheme"]
+      Http,
+      #[doc = "HTTPS scheme"]
+      Https,
+    }
+    impl HttpScheme {
+      #[allow(unused)]
+      #[doc = "Returns the value of the enum variant as a string."]
+      #[must_use]
+      pub fn value(&self) -> Option<&'static str> {
+        #[allow(clippy::match_single_binding)]
+        match self {
+          Self::Http => None,
+          Self::Https => None,
+        }
+      }
+    }
+    impl TryFrom<u32> for HttpScheme {
+      type Error = u32;
+      fn try_from(i: u32) -> Result<Self, Self::Error> {
+        #[allow(clippy::match_single_binding)]
+        match i {
+          _ => Err(i),
+        }
+      }
+    }
+    impl std::str::FromStr for HttpScheme {
+      type Err = String;
+      fn from_str(s: &str) -> Result<Self, Self::Err> {
+        #[allow(clippy::match_single_binding)]
+        match s {
+          _ => Err(s.to_owned()),
+        }
+      }
+    }
+    impl std::fmt::Display for HttpScheme {
+      fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        #[allow(clippy::match_single_binding)]
+        match self {
+          Self::Http => f.write_str("HTTP"),
+          Self::Https => f.write_str("HTTPS"),
+        }
+      }
+    }
+    #[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize, PartialEq)]
+    #[doc = "HTTP version"]
     pub enum HttpVersion {
+      #[doc = "HTTP 1.0 version"]
       Http10,
+      #[doc = "HTTP 1.1 version"]
       Http11,
+      #[doc = "HTTP 2.0 version"]
       Http20,
     }
     impl HttpVersion {
@@ -268,9 +773,100 @@ pub mod types {
       }
     }
     #[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize, PartialEq)]
+    #[doc = "HTTP status code"]
     pub enum StatusCode {
+      #[doc = "Continue status code"]
+      Continue,
+      #[doc = "SwitchingProtocols status code"]
+      SwitchingProtocols,
+      #[doc = "HTTP OK status code"]
       Ok,
+      #[doc = "Created status code"]
       Created,
+      #[doc = "Accepted status code"]
+      Accepted,
+      #[doc = "NonAuthoritativeInformation status code"]
+      NonAuthoritativeInformation,
+      #[doc = "NoContent status code"]
+      NoContent,
+      #[doc = "ResetContent status code"]
+      ResetContent,
+      #[doc = "PartialContent status code"]
+      PartialContent,
+      #[doc = "MultipleChoices status code"]
+      MultipleChoices,
+      #[doc = "MovedPermanently status code"]
+      MovedPermanently,
+      #[doc = "Found status code"]
+      Found,
+      #[doc = "SeeOther status code"]
+      SeeOther,
+      #[doc = "NotModified status code"]
+      NotModified,
+      #[doc = "TemporaryRedirect status code"]
+      TemporaryRedirect,
+      #[doc = "PermanentRedirect status code"]
+      PermanentRedirect,
+      #[doc = "BadRequest status code"]
+      BadRequest,
+      #[doc = "Unauthorized status code"]
+      Unauthorized,
+      #[doc = "PaymentRequired status code"]
+      PaymentRequired,
+      #[doc = "Forbidden status code"]
+      Forbidden,
+      #[doc = "NotFound status code"]
+      NotFound,
+      #[doc = "MethodNotAllowed status code"]
+      MethodNotAllowed,
+      #[doc = "NotAcceptable status code"]
+      NotAcceptable,
+      #[doc = "ProxyAuthenticationRequired status code"]
+      ProxyAuthenticationRequired,
+      #[doc = "RequestTimeout status code"]
+      RequestTimeout,
+      #[doc = "Conflict status code"]
+      Conflict,
+      #[doc = "Gone status code"]
+      Gone,
+      #[doc = "LengthRequired status code"]
+      LengthRequired,
+      #[doc = "PreconditionFailed status code"]
+      PreconditionFailed,
+      #[doc = "PayloadTooLarge status code"]
+      PayloadTooLarge,
+      #[doc = "URITooLong status code"]
+      UriTooLong,
+      #[doc = "UnsupportedMediaType status code"]
+      UnsupportedMediaType,
+      #[doc = "RangeNotSatisfiable status code"]
+      RangeNotSatisfiable,
+      #[doc = "ExpectationFailed status code"]
+      ExpectationFailed,
+      #[doc = "ImATeapot status code"]
+      ImATeapot,
+      #[doc = "UnprocessableEntity status code"]
+      UnprocessableEntity,
+      #[doc = "Locked status code"]
+      Locked,
+      #[doc = "FailedDependency status code"]
+      FailedDependency,
+      #[doc = "TooManyRequests status code"]
+      TooManyRequests,
+      #[doc = "InternalServerError status code"]
+      InternalServerError,
+      #[doc = "NotImplemented status code"]
+      NotImplemented,
+      #[doc = "BadGateway status code"]
+      BadGateway,
+      #[doc = "ServiceUnavailable status code"]
+      ServiceUnavailable,
+      #[doc = "GatewayTimeout status code"]
+      GatewayTimeout,
+      #[doc = "HTTPVersionNotSupported status code"]
+      HttpVersionNotSupported,
+      #[doc = "Indicates an unknown status code"]
+      Unknown,
     }
     impl StatusCode {
       #[allow(unused)]
@@ -279,8 +875,52 @@ pub mod types {
       pub fn value(&self) -> Option<&'static str> {
         #[allow(clippy::match_single_binding)]
         match self {
+          Self::Continue => Some("100"),
+          Self::SwitchingProtocols => Some("101"),
           Self::Ok => Some("200"),
           Self::Created => Some("201"),
+          Self::Accepted => Some("202"),
+          Self::NonAuthoritativeInformation => Some("203"),
+          Self::NoContent => Some("204"),
+          Self::ResetContent => Some("205"),
+          Self::PartialContent => Some("206"),
+          Self::MultipleChoices => Some("300"),
+          Self::MovedPermanently => Some("301"),
+          Self::Found => Some("302"),
+          Self::SeeOther => Some("303"),
+          Self::NotModified => Some("304"),
+          Self::TemporaryRedirect => Some("307"),
+          Self::PermanentRedirect => Some("308"),
+          Self::BadRequest => Some("400"),
+          Self::Unauthorized => Some("401"),
+          Self::PaymentRequired => Some("402"),
+          Self::Forbidden => Some("403"),
+          Self::NotFound => Some("404"),
+          Self::MethodNotAllowed => Some("405"),
+          Self::NotAcceptable => Some("406"),
+          Self::ProxyAuthenticationRequired => Some("407"),
+          Self::RequestTimeout => Some("408"),
+          Self::Conflict => Some("409"),
+          Self::Gone => Some("410"),
+          Self::LengthRequired => Some("411"),
+          Self::PreconditionFailed => Some("412"),
+          Self::PayloadTooLarge => Some("413"),
+          Self::UriTooLong => Some("414"),
+          Self::UnsupportedMediaType => Some("415"),
+          Self::RangeNotSatisfiable => Some("416"),
+          Self::ExpectationFailed => Some("417"),
+          Self::ImATeapot => Some("418"),
+          Self::UnprocessableEntity => Some("422"),
+          Self::Locked => Some("423"),
+          Self::FailedDependency => Some("424"),
+          Self::TooManyRequests => Some("429"),
+          Self::InternalServerError => Some("500"),
+          Self::NotImplemented => Some("501"),
+          Self::BadGateway => Some("502"),
+          Self::ServiceUnavailable => Some("503"),
+          Self::GatewayTimeout => Some("504"),
+          Self::HttpVersionNotSupported => Some("505"),
+          Self::Unknown => Some("-1"),
         }
       }
     }
@@ -298,8 +938,52 @@ pub mod types {
       fn from_str(s: &str) -> Result<Self, Self::Err> {
         #[allow(clippy::match_single_binding)]
         match s {
+          "100" => Ok(Self::Continue),
+          "101" => Ok(Self::SwitchingProtocols),
           "200" => Ok(Self::Ok),
           "201" => Ok(Self::Created),
+          "202" => Ok(Self::Accepted),
+          "203" => Ok(Self::NonAuthoritativeInformation),
+          "204" => Ok(Self::NoContent),
+          "205" => Ok(Self::ResetContent),
+          "206" => Ok(Self::PartialContent),
+          "300" => Ok(Self::MultipleChoices),
+          "301" => Ok(Self::MovedPermanently),
+          "302" => Ok(Self::Found),
+          "303" => Ok(Self::SeeOther),
+          "304" => Ok(Self::NotModified),
+          "307" => Ok(Self::TemporaryRedirect),
+          "308" => Ok(Self::PermanentRedirect),
+          "400" => Ok(Self::BadRequest),
+          "401" => Ok(Self::Unauthorized),
+          "402" => Ok(Self::PaymentRequired),
+          "403" => Ok(Self::Forbidden),
+          "404" => Ok(Self::NotFound),
+          "405" => Ok(Self::MethodNotAllowed),
+          "406" => Ok(Self::NotAcceptable),
+          "407" => Ok(Self::ProxyAuthenticationRequired),
+          "408" => Ok(Self::RequestTimeout),
+          "409" => Ok(Self::Conflict),
+          "410" => Ok(Self::Gone),
+          "411" => Ok(Self::LengthRequired),
+          "412" => Ok(Self::PreconditionFailed),
+          "413" => Ok(Self::PayloadTooLarge),
+          "414" => Ok(Self::UriTooLong),
+          "415" => Ok(Self::UnsupportedMediaType),
+          "416" => Ok(Self::RangeNotSatisfiable),
+          "417" => Ok(Self::ExpectationFailed),
+          "418" => Ok(Self::ImATeapot),
+          "422" => Ok(Self::UnprocessableEntity),
+          "423" => Ok(Self::Locked),
+          "424" => Ok(Self::FailedDependency),
+          "429" => Ok(Self::TooManyRequests),
+          "500" => Ok(Self::InternalServerError),
+          "501" => Ok(Self::NotImplemented),
+          "502" => Ok(Self::BadGateway),
+          "503" => Ok(Self::ServiceUnavailable),
+          "504" => Ok(Self::GatewayTimeout),
+          "505" => Ok(Self::HttpVersionNotSupported),
+          "-1" => Ok(Self::Unknown),
           _ => Err(s.to_owned()),
         }
       }
@@ -308,8 +992,52 @@ pub mod types {
       fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         #[allow(clippy::match_single_binding)]
         match self {
+          Self::Continue => f.write_str("Continue"),
+          Self::SwitchingProtocols => f.write_str("SwitchingProtocols"),
           Self::Ok => f.write_str("OK"),
           Self::Created => f.write_str("Created"),
+          Self::Accepted => f.write_str("Accepted"),
+          Self::NonAuthoritativeInformation => f.write_str("NonAuthoritativeInformation"),
+          Self::NoContent => f.write_str("NoContent"),
+          Self::ResetContent => f.write_str("ResetContent"),
+          Self::PartialContent => f.write_str("PartialContent"),
+          Self::MultipleChoices => f.write_str("MultipleChoices"),
+          Self::MovedPermanently => f.write_str("MovedPermanently"),
+          Self::Found => f.write_str("Found"),
+          Self::SeeOther => f.write_str("SeeOther"),
+          Self::NotModified => f.write_str("NotModified"),
+          Self::TemporaryRedirect => f.write_str("TemporaryRedirect"),
+          Self::PermanentRedirect => f.write_str("PermanentRedirect"),
+          Self::BadRequest => f.write_str("BadRequest"),
+          Self::Unauthorized => f.write_str("Unauthorized"),
+          Self::PaymentRequired => f.write_str("PaymentRequired"),
+          Self::Forbidden => f.write_str("Forbidden"),
+          Self::NotFound => f.write_str("NotFound"),
+          Self::MethodNotAllowed => f.write_str("MethodNotAllowed"),
+          Self::NotAcceptable => f.write_str("NotAcceptable"),
+          Self::ProxyAuthenticationRequired => f.write_str("ProxyAuthenticationRequired"),
+          Self::RequestTimeout => f.write_str("RequestTimeout"),
+          Self::Conflict => f.write_str("Conflict"),
+          Self::Gone => f.write_str("Gone"),
+          Self::LengthRequired => f.write_str("LengthRequired"),
+          Self::PreconditionFailed => f.write_str("PreconditionFailed"),
+          Self::PayloadTooLarge => f.write_str("PayloadTooLarge"),
+          Self::UriTooLong => f.write_str("URITooLong"),
+          Self::UnsupportedMediaType => f.write_str("UnsupportedMediaType"),
+          Self::RangeNotSatisfiable => f.write_str("RangeNotSatisfiable"),
+          Self::ExpectationFailed => f.write_str("ExpectationFailed"),
+          Self::ImATeapot => f.write_str("ImATeapot"),
+          Self::UnprocessableEntity => f.write_str("UnprocessableEntity"),
+          Self::Locked => f.write_str("Locked"),
+          Self::FailedDependency => f.write_str("FailedDependency"),
+          Self::TooManyRequests => f.write_str("TooManyRequests"),
+          Self::InternalServerError => f.write_str("InternalServerError"),
+          Self::NotImplemented => f.write_str("NotImplemented"),
+          Self::BadGateway => f.write_str("BadGateway"),
+          Self::ServiceUnavailable => f.write_str("ServiceUnavailable"),
+          Self::GatewayTimeout => f.write_str("GatewayTimeout"),
+          Self::HttpVersionNotSupported => f.write_str("HTTPVersionNotSupported"),
+          Self::Unknown => f.write_str("Unknown"),
         }
       }
     }
@@ -318,6 +1046,98 @@ pub mod types {
     #[allow(unused)]
     use super::http;
     #[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize, PartialEq)]
+    #[doc = "HTTP method enum"]
+    pub enum HttpMethod {
+      #[doc = "HTTP GET method"]
+      Get,
+      #[doc = "HTTP POST method"]
+      Post,
+      #[doc = "HTTP PUT method"]
+      Put,
+      #[doc = "HTTP DELETE method"]
+      Delete,
+      #[doc = "HTTP PATCH method"]
+      Patch,
+      #[doc = "HTTP HEAD method"]
+      Head,
+      #[doc = "HTTP OPTIONS method"]
+      Options,
+      #[doc = "HTTP TRACE method"]
+      Trace,
+    }
+    impl HttpMethod {
+      #[allow(unused)]
+      #[doc = "Returns the value of the enum variant as a string."]
+      #[must_use]
+      pub fn value(&self) -> Option<&'static str> {
+        #[allow(clippy::match_single_binding)]
+        match self {
+          Self::Get => None,
+          Self::Post => None,
+          Self::Put => None,
+          Self::Delete => None,
+          Self::Patch => None,
+          Self::Head => None,
+          Self::Options => None,
+          Self::Trace => None,
+        }
+      }
+    }
+    impl TryFrom<u32> for HttpMethod {
+      type Error = u32;
+      fn try_from(i: u32) -> Result<Self, Self::Error> {
+        #[allow(clippy::match_single_binding)]
+        match i {
+          _ => Err(i),
+        }
+      }
+    }
+    impl std::str::FromStr for HttpMethod {
+      type Err = String;
+      fn from_str(s: &str) -> Result<Self, Self::Err> {
+        #[allow(clippy::match_single_binding)]
+        match s {
+          _ => Err(s.to_owned()),
+        }
+      }
+    }
+    impl std::fmt::Display for HttpMethod {
+      fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        #[allow(clippy::match_single_binding)]
+        match self {
+          Self::Get => f.write_str("GET"),
+          Self::Post => f.write_str("POST"),
+          Self::Put => f.write_str("PUT"),
+          Self::Delete => f.write_str("DELETE"),
+          Self::Patch => f.write_str("PATCH"),
+          Self::Head => f.write_str("HEAD"),
+          Self::Options => f.write_str("OPTIONS"),
+          Self::Trace => f.write_str("TRACE"),
+        }
+      }
+    }
+    #[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize, PartialEq)]
+    #[doc = "HTTP request"]
+    pub struct HttpRequest {
+      #[doc = "method from request line enum"]
+      pub method: HttpMethod,
+      #[doc = "scheme from request line enum"]
+      pub scheme: HttpScheme,
+      #[doc = "domain/port and any authentication from request line. optional"]
+      pub authority: String,
+      #[doc = "query parameters from request line. optional"]
+      pub query_parameters: std::collections::HashMap<String, Vec<String>>,
+      #[doc = "path from request line (not including query parameters)"]
+      pub path: String,
+      #[doc = "full URI from request line"]
+      pub uri: String,
+      #[doc = "HTTP version enum"]
+      pub version: HttpVersion,
+      #[doc = "All request headers. Duplicates are comma separated."]
+      pub headers: std::collections::HashMap<String, Vec<String>>,
+    }
+    #[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize, PartialEq)]
+    #[doc = "HTTP response"]
     pub struct HttpResponse {
       #[doc = "HTTP version enum"]
       pub version: HttpVersion,
@@ -325,13 +1145,62 @@ pub mod types {
       pub status: StatusCode,
       #[doc = "All response headers. Supports duplicates."]
       pub headers: std::collections::HashMap<String, Vec<String>>,
-      #[doc = "Response body in bytes. optional."]
-      pub body: bytes::Bytes,
     }
     #[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize, PartialEq)]
+    #[doc = "HTTP scheme"]
+    pub enum HttpScheme {
+      #[doc = "HTTP scheme"]
+      Http,
+      #[doc = "HTTPS scheme"]
+      Https,
+    }
+    impl HttpScheme {
+      #[allow(unused)]
+      #[doc = "Returns the value of the enum variant as a string."]
+      #[must_use]
+      pub fn value(&self) -> Option<&'static str> {
+        #[allow(clippy::match_single_binding)]
+        match self {
+          Self::Http => None,
+          Self::Https => None,
+        }
+      }
+    }
+    impl TryFrom<u32> for HttpScheme {
+      type Error = u32;
+      fn try_from(i: u32) -> Result<Self, Self::Error> {
+        #[allow(clippy::match_single_binding)]
+        match i {
+          _ => Err(i),
+        }
+      }
+    }
+    impl std::str::FromStr for HttpScheme {
+      type Err = String;
+      fn from_str(s: &str) -> Result<Self, Self::Err> {
+        #[allow(clippy::match_single_binding)]
+        match s {
+          _ => Err(s.to_owned()),
+        }
+      }
+    }
+    impl std::fmt::Display for HttpScheme {
+      fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        #[allow(clippy::match_single_binding)]
+        match self {
+          Self::Http => f.write_str("HTTP"),
+          Self::Https => f.write_str("HTTPS"),
+        }
+      }
+    }
+    #[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize, PartialEq)]
+    #[doc = "HTTP version"]
     pub enum HttpVersion {
+      #[doc = "HTTP 1.0 version"]
       Http10,
+      #[doc = "HTTP 1.1 version"]
       Http11,
+      #[doc = "HTTP 2.0 version"]
       Http20,
     }
     impl HttpVersion {
@@ -379,9 +1248,100 @@ pub mod types {
       }
     }
     #[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize, PartialEq)]
+    #[doc = "HTTP status code"]
     pub enum StatusCode {
+      #[doc = "Continue status code"]
+      Continue,
+      #[doc = "SwitchingProtocols status code"]
+      SwitchingProtocols,
+      #[doc = "HTTP OK status code"]
       Ok,
+      #[doc = "Created status code"]
       Created,
+      #[doc = "Accepted status code"]
+      Accepted,
+      #[doc = "NonAuthoritativeInformation status code"]
+      NonAuthoritativeInformation,
+      #[doc = "NoContent status code"]
+      NoContent,
+      #[doc = "ResetContent status code"]
+      ResetContent,
+      #[doc = "PartialContent status code"]
+      PartialContent,
+      #[doc = "MultipleChoices status code"]
+      MultipleChoices,
+      #[doc = "MovedPermanently status code"]
+      MovedPermanently,
+      #[doc = "Found status code"]
+      Found,
+      #[doc = "SeeOther status code"]
+      SeeOther,
+      #[doc = "NotModified status code"]
+      NotModified,
+      #[doc = "TemporaryRedirect status code"]
+      TemporaryRedirect,
+      #[doc = "PermanentRedirect status code"]
+      PermanentRedirect,
+      #[doc = "BadRequest status code"]
+      BadRequest,
+      #[doc = "Unauthorized status code"]
+      Unauthorized,
+      #[doc = "PaymentRequired status code"]
+      PaymentRequired,
+      #[doc = "Forbidden status code"]
+      Forbidden,
+      #[doc = "NotFound status code"]
+      NotFound,
+      #[doc = "MethodNotAllowed status code"]
+      MethodNotAllowed,
+      #[doc = "NotAcceptable status code"]
+      NotAcceptable,
+      #[doc = "ProxyAuthenticationRequired status code"]
+      ProxyAuthenticationRequired,
+      #[doc = "RequestTimeout status code"]
+      RequestTimeout,
+      #[doc = "Conflict status code"]
+      Conflict,
+      #[doc = "Gone status code"]
+      Gone,
+      #[doc = "LengthRequired status code"]
+      LengthRequired,
+      #[doc = "PreconditionFailed status code"]
+      PreconditionFailed,
+      #[doc = "PayloadTooLarge status code"]
+      PayloadTooLarge,
+      #[doc = "URITooLong status code"]
+      UriTooLong,
+      #[doc = "UnsupportedMediaType status code"]
+      UnsupportedMediaType,
+      #[doc = "RangeNotSatisfiable status code"]
+      RangeNotSatisfiable,
+      #[doc = "ExpectationFailed status code"]
+      ExpectationFailed,
+      #[doc = "ImATeapot status code"]
+      ImATeapot,
+      #[doc = "UnprocessableEntity status code"]
+      UnprocessableEntity,
+      #[doc = "Locked status code"]
+      Locked,
+      #[doc = "FailedDependency status code"]
+      FailedDependency,
+      #[doc = "TooManyRequests status code"]
+      TooManyRequests,
+      #[doc = "InternalServerError status code"]
+      InternalServerError,
+      #[doc = "NotImplemented status code"]
+      NotImplemented,
+      #[doc = "BadGateway status code"]
+      BadGateway,
+      #[doc = "ServiceUnavailable status code"]
+      ServiceUnavailable,
+      #[doc = "GatewayTimeout status code"]
+      GatewayTimeout,
+      #[doc = "HTTPVersionNotSupported status code"]
+      HttpVersionNotSupported,
+      #[doc = "Indicates an unknown status code"]
+      Unknown,
     }
     impl StatusCode {
       #[allow(unused)]
@@ -390,8 +1350,52 @@ pub mod types {
       pub fn value(&self) -> Option<&'static str> {
         #[allow(clippy::match_single_binding)]
         match self {
+          Self::Continue => Some("100"),
+          Self::SwitchingProtocols => Some("101"),
           Self::Ok => Some("200"),
           Self::Created => Some("201"),
+          Self::Accepted => Some("202"),
+          Self::NonAuthoritativeInformation => Some("203"),
+          Self::NoContent => Some("204"),
+          Self::ResetContent => Some("205"),
+          Self::PartialContent => Some("206"),
+          Self::MultipleChoices => Some("300"),
+          Self::MovedPermanently => Some("301"),
+          Self::Found => Some("302"),
+          Self::SeeOther => Some("303"),
+          Self::NotModified => Some("304"),
+          Self::TemporaryRedirect => Some("307"),
+          Self::PermanentRedirect => Some("308"),
+          Self::BadRequest => Some("400"),
+          Self::Unauthorized => Some("401"),
+          Self::PaymentRequired => Some("402"),
+          Self::Forbidden => Some("403"),
+          Self::NotFound => Some("404"),
+          Self::MethodNotAllowed => Some("405"),
+          Self::NotAcceptable => Some("406"),
+          Self::ProxyAuthenticationRequired => Some("407"),
+          Self::RequestTimeout => Some("408"),
+          Self::Conflict => Some("409"),
+          Self::Gone => Some("410"),
+          Self::LengthRequired => Some("411"),
+          Self::PreconditionFailed => Some("412"),
+          Self::PayloadTooLarge => Some("413"),
+          Self::UriTooLong => Some("414"),
+          Self::UnsupportedMediaType => Some("415"),
+          Self::RangeNotSatisfiable => Some("416"),
+          Self::ExpectationFailed => Some("417"),
+          Self::ImATeapot => Some("418"),
+          Self::UnprocessableEntity => Some("422"),
+          Self::Locked => Some("423"),
+          Self::FailedDependency => Some("424"),
+          Self::TooManyRequests => Some("429"),
+          Self::InternalServerError => Some("500"),
+          Self::NotImplemented => Some("501"),
+          Self::BadGateway => Some("502"),
+          Self::ServiceUnavailable => Some("503"),
+          Self::GatewayTimeout => Some("504"),
+          Self::HttpVersionNotSupported => Some("505"),
+          Self::Unknown => Some("-1"),
         }
       }
     }
@@ -409,8 +1413,52 @@ pub mod types {
       fn from_str(s: &str) -> Result<Self, Self::Err> {
         #[allow(clippy::match_single_binding)]
         match s {
+          "100" => Ok(Self::Continue),
+          "101" => Ok(Self::SwitchingProtocols),
           "200" => Ok(Self::Ok),
           "201" => Ok(Self::Created),
+          "202" => Ok(Self::Accepted),
+          "203" => Ok(Self::NonAuthoritativeInformation),
+          "204" => Ok(Self::NoContent),
+          "205" => Ok(Self::ResetContent),
+          "206" => Ok(Self::PartialContent),
+          "300" => Ok(Self::MultipleChoices),
+          "301" => Ok(Self::MovedPermanently),
+          "302" => Ok(Self::Found),
+          "303" => Ok(Self::SeeOther),
+          "304" => Ok(Self::NotModified),
+          "307" => Ok(Self::TemporaryRedirect),
+          "308" => Ok(Self::PermanentRedirect),
+          "400" => Ok(Self::BadRequest),
+          "401" => Ok(Self::Unauthorized),
+          "402" => Ok(Self::PaymentRequired),
+          "403" => Ok(Self::Forbidden),
+          "404" => Ok(Self::NotFound),
+          "405" => Ok(Self::MethodNotAllowed),
+          "406" => Ok(Self::NotAcceptable),
+          "407" => Ok(Self::ProxyAuthenticationRequired),
+          "408" => Ok(Self::RequestTimeout),
+          "409" => Ok(Self::Conflict),
+          "410" => Ok(Self::Gone),
+          "411" => Ok(Self::LengthRequired),
+          "412" => Ok(Self::PreconditionFailed),
+          "413" => Ok(Self::PayloadTooLarge),
+          "414" => Ok(Self::UriTooLong),
+          "415" => Ok(Self::UnsupportedMediaType),
+          "416" => Ok(Self::RangeNotSatisfiable),
+          "417" => Ok(Self::ExpectationFailed),
+          "418" => Ok(Self::ImATeapot),
+          "422" => Ok(Self::UnprocessableEntity),
+          "423" => Ok(Self::Locked),
+          "424" => Ok(Self::FailedDependency),
+          "429" => Ok(Self::TooManyRequests),
+          "500" => Ok(Self::InternalServerError),
+          "501" => Ok(Self::NotImplemented),
+          "502" => Ok(Self::BadGateway),
+          "503" => Ok(Self::ServiceUnavailable),
+          "504" => Ok(Self::GatewayTimeout),
+          "505" => Ok(Self::HttpVersionNotSupported),
+          "-1" => Ok(Self::Unknown),
           _ => Err(s.to_owned()),
         }
       }
@@ -419,12 +1467,103 @@ pub mod types {
       fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         #[allow(clippy::match_single_binding)]
         match self {
+          Self::Continue => f.write_str("Continue"),
+          Self::SwitchingProtocols => f.write_str("SwitchingProtocols"),
           Self::Ok => f.write_str("OK"),
           Self::Created => f.write_str("Created"),
+          Self::Accepted => f.write_str("Accepted"),
+          Self::NonAuthoritativeInformation => f.write_str("NonAuthoritativeInformation"),
+          Self::NoContent => f.write_str("NoContent"),
+          Self::ResetContent => f.write_str("ResetContent"),
+          Self::PartialContent => f.write_str("PartialContent"),
+          Self::MultipleChoices => f.write_str("MultipleChoices"),
+          Self::MovedPermanently => f.write_str("MovedPermanently"),
+          Self::Found => f.write_str("Found"),
+          Self::SeeOther => f.write_str("SeeOther"),
+          Self::NotModified => f.write_str("NotModified"),
+          Self::TemporaryRedirect => f.write_str("TemporaryRedirect"),
+          Self::PermanentRedirect => f.write_str("PermanentRedirect"),
+          Self::BadRequest => f.write_str("BadRequest"),
+          Self::Unauthorized => f.write_str("Unauthorized"),
+          Self::PaymentRequired => f.write_str("PaymentRequired"),
+          Self::Forbidden => f.write_str("Forbidden"),
+          Self::NotFound => f.write_str("NotFound"),
+          Self::MethodNotAllowed => f.write_str("MethodNotAllowed"),
+          Self::NotAcceptable => f.write_str("NotAcceptable"),
+          Self::ProxyAuthenticationRequired => f.write_str("ProxyAuthenticationRequired"),
+          Self::RequestTimeout => f.write_str("RequestTimeout"),
+          Self::Conflict => f.write_str("Conflict"),
+          Self::Gone => f.write_str("Gone"),
+          Self::LengthRequired => f.write_str("LengthRequired"),
+          Self::PreconditionFailed => f.write_str("PreconditionFailed"),
+          Self::PayloadTooLarge => f.write_str("PayloadTooLarge"),
+          Self::UriTooLong => f.write_str("URITooLong"),
+          Self::UnsupportedMediaType => f.write_str("UnsupportedMediaType"),
+          Self::RangeNotSatisfiable => f.write_str("RangeNotSatisfiable"),
+          Self::ExpectationFailed => f.write_str("ExpectationFailed"),
+          Self::ImATeapot => f.write_str("ImATeapot"),
+          Self::UnprocessableEntity => f.write_str("UnprocessableEntity"),
+          Self::Locked => f.write_str("Locked"),
+          Self::FailedDependency => f.write_str("FailedDependency"),
+          Self::TooManyRequests => f.write_str("TooManyRequests"),
+          Self::InternalServerError => f.write_str("InternalServerError"),
+          Self::NotImplemented => f.write_str("NotImplemented"),
+          Self::BadGateway => f.write_str("BadGateway"),
+          Self::ServiceUnavailable => f.write_str("ServiceUnavailable"),
+          Self::GatewayTimeout => f.write_str("GatewayTimeout"),
+          Self::HttpVersionNotSupported => f.write_str("HTTPVersionNotSupported"),
+          Self::Unknown => f.write_str("Unknown"),
         }
       }
     }
   }
+}
+#[doc = "Types associated with the `echo` operation"]
+pub mod echo {
+  use super::*;
+  #[derive(Debug, Clone, Default, serde :: Serialize, serde :: Deserialize, PartialEq)]
+  pub struct Config {}
+  pub struct Outputs {
+    #[allow(unused)]
+    pub(crate) output: wick_packet::Output<types::http::HttpRequest>,
+  }
+  impl Outputs {
+    pub fn new(channel: wasmrs_rx::FluxChannel<wasmrs::RawPayload, wasmrs::PayloadError>) -> Self {
+      Self {
+        output: wick_packet::Output::new("output", channel.clone()),
+      }
+    }
+    #[allow(unused)]
+    pub fn broadcast_err(&mut self, err: impl AsRef<str>) {
+      self.output.error(&err);
+    }
+  }
+}
+# [async_trait :: async_trait (? Send)]
+#[cfg(target_family = "wasm")]
+pub trait EchoOperation {
+  type Error: std::fmt::Display;
+  type Outputs;
+  type Config: std::fmt::Debug;
+  #[allow(unused)]
+  async fn echo(
+    input: WickStream<types::http::HttpRequest>,
+    outputs: Self::Outputs,
+    ctx: wick_component::flow_component::Context<Self::Config>,
+  ) -> std::result::Result<(), Self::Error>;
+}
+#[async_trait::async_trait]
+#[cfg(not(target_family = "wasm"))]
+pub trait EchoOperation {
+  type Error: std::fmt::Display + Send;
+  type Outputs: Send;
+  type Config: std::fmt::Debug + Send;
+  #[allow(unused)]
+  async fn echo(
+    input: WickStream<types::http::HttpRequest>,
+    outputs: Self::Outputs,
+    ctx: wick_component::flow_component::Context<Self::Config>,
+  ) -> std::result::Result<(), Self::Error>;
 }
 #[doc = "Types associated with the `testop` operation"]
 pub mod testop {
@@ -488,6 +1627,29 @@ pub trait TestopOperation {
 #[doc = "The struct that the component implementation hinges around"]
 pub struct Component;
 impl Component {
+  fn echo_wrapper(
+    mut input: wasmrs_rx::BoxFlux<wasmrs::Payload, wasmrs::PayloadError>,
+  ) -> std::result::Result<
+    wasmrs_rx::BoxFlux<wasmrs::RawPayload, wasmrs::PayloadError>,
+    Box<dyn std::error::Error + Send + Sync>,
+  > {
+    let (channel, rx) = wasmrs_rx::FluxChannel::<wasmrs::RawPayload, wasmrs::PayloadError>::new_parts();
+    let outputs = echo::Outputs::new(channel.clone());
+    runtime::spawn("echo_wrapper", async move {
+      let (config, input) = wick_component :: payload_fan_out ! (input , raw : false , Box < dyn std :: error :: Error + Send + Sync > , echo :: Config , [("input" , types :: http :: HttpRequest) ,]);
+      let config = match config.await {
+        Ok(Ok(config)) => config,
+        _ => {
+          let _ = channel.send_result(wick_packet::Packet::component_error("Component sent invalid context").into());
+          return;
+        }
+      };
+      if let Err(e) = Component::echo(Box::pin(input), outputs, config).await {
+        let _ = channel.send_result(wick_packet::Packet::component_error(e.to_string()).into());
+      }
+    });
+    Ok(Box::pin(rx))
+  }
   fn testop_wrapper(
     mut input: wasmrs_rx::BoxFlux<wasmrs::Payload, wasmrs::PayloadError>,
   ) -> std::result::Result<

--- a/tests/codegen-tests/src/lib.rs
+++ b/tests/codegen-tests/src/lib.rs
@@ -18,6 +18,24 @@ mod test1 {
       Ok(())
     }
   }
+
+  # [cfg_attr (target_family = "wasm" , async_trait :: async_trait (? Send))]
+  #[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
+  impl EchoOperation for Component {
+    type Error = anyhow::Error;
+    type Outputs = echo::Outputs;
+    type Config = echo::Config;
+
+    #[allow(unused)]
+    async fn echo(
+      message: WickStream<types::http::HttpRequest>,
+      outputs: Self::Outputs,
+      ctx: Context<Self::Config>,
+    ) -> Result<(), Self::Error> {
+      Ok(())
+    }
+  }
+
   #[cfg(test)]
   mod test {
 
@@ -45,7 +63,6 @@ mod test1 {
         version: http::HttpVersion::Http11,
         status: http::StatusCode::Ok,
         headers: Default::default(),
-        body: Default::default(),
       };
       let packets = tokio_stream::iter(vec![Ok(response)]).boxed();
       let tx = FluxChannel::new();

--- a/tests/codegen-tests/tests/testdata/import-types.wick
+++ b/tests/codegen-tests/tests/testdata/import-types.wick
@@ -5,15 +5,15 @@ import:
   - name: http
     component:
       kind: wick/component/types@v1
-      ref: ./types-config.wick
+      ref: ../../../../crates/interfaces/wick-interface-http/component.yaml
   - name: AAA
     component:
       kind: wick/component/types@v1
-      ref: ./types-config.wick
+      ref: ../../../../crates/interfaces/wick-interface-http/component.yaml
   - name: ZZZ
     component:
       kind: wick/component/types@v1
-      ref: ./types-config.wick
+      ref: ../../../../crates/interfaces/wick-interface-http/component.yaml
 types:
   - name: LocalStruct
     kind: wick/type/struct@v1
@@ -34,6 +34,15 @@ types:
 component:
   kind: wick/component/composite@v1
   operations:
+    - name: echo
+      inputs:
+        - name: input
+          type: http::HttpRequest
+      outputs:
+        - name: output
+          type: http::HttpRequest
+      flow:
+        - <>.input -> <>.output
     - name: testop
       with:
         - name: A
@@ -47,5 +56,23 @@ component:
         - name: output
           type: string
       flow:
-        - <> -> test::whatever[A].input
-        - A.output -> <>
+        - <>.message -> <>.output
+tests:
+  - name: type_test
+    cases:
+      - name: codegenned-defaults
+        operation: echo
+        input:
+          - name: input
+            value:
+              method: Get
+              scheme: Http
+              path: '/'
+              uri: 'http://localhost:8080/'
+        output:
+          - name: output
+            value:
+              method: Get
+              scheme: Http
+              path: '/'
+              uri: 'http://localhost:8080/'


### PR DESCRIPTION
This PR:
- hides wasmrs-guest behind wick-component since wick/wasmrs are tied tightly together. Components no longer need to depend on `wasmrs-guest` explicitly.
- enables the "std" feature in wasm-msgpack to alleviate multiple issues, including those involving large errors.
- adds `serde` configuration to generated types in `wick-component-codegen` for defaults, renaming, et al
- added a `wick_component::prelude` to consolidate common imports.
- had `wick_import` import `wick_component::prelude::*` so importing `*` from the generated code will get most of what component devs need.