### PR TITLE
Removed errant comma when codegenning multiple required components

### DIFF
--- a/crates/wick/wick-component-codegen/src/generate/templates/imported_components.rs
+++ b/crates/wick/wick-component-codegen/src/generate/templates/imported_components.rs
@@ -14,7 +14,7 @@ use crate::generate::{f, Direction};
 use crate::*;
 
 pub(crate) fn imported_components(config: &mut Config, required: Vec<BoundInterface>) -> TokenStream {
-  let fields = required
+  let components = required
     .into_iter()
     .map(|v| {
       let name = id(&format!("{}Component", &pascal(v.id())));
@@ -41,7 +41,7 @@ pub(crate) fn imported_components(config: &mut Config, required: Vec<BoundInterf
     })
     .collect_vec();
   quote! {
-      #(#fields),*
+      #(#components)*
 
   }
 }


### PR DESCRIPTION
This PR removes a comma that interferes when code-generating a config with multiple `required` components.