### PR TITLE
Made inherent data required vs optional/missing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,7 +24,8 @@
   "rust-analyzer.cargo.features": [
     "wick-rpc/client",
     "wick-packet/datetime",
-    "wick-packet/invocation"
+    "wick-packet/invocation",
+    "wick-packet/std"
   ],
   "rust-analyzer.rustfmt.overrideCommand": [
     "rustup",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1569,6 +1569,7 @@ version = "0.5.0"
 dependencies = [
  "anyhow",
  "futures",
+ "seeded-random",
  "serde",
  "serde_json",
  "tracing",

--- a/Justfile
+++ b/Justfile
@@ -156,8 +156,8 @@ _run-integration-task *args='':
     "./etc/integration/httpbin.sh"
   ]
   for bin in bins:
-    print("Running {}".format([bin] + sys.argv[1:]))
-    # subprocess.call([bin] + sys.argv[1:])
+    if subprocess.call([bin] + sys.argv[1:]) != 0:
+      exit(1)
 
 _run-wasm-task task:
   #!{{python}}
@@ -170,7 +170,8 @@ _run-wasm-task task:
     "examples/http/middleware/request"
   ]
   for dir in wasm:
-    subprocess.call(["just", "{}/{{task}}".format(dir)])
+    if subprocess.call(["just", "{}/{{task}}".format(dir)]) != 0:
+      exit(1)
 
 # Run `wick` tests for db components
 _wick-db-tests:

--- a/crates/bins/wick/src/commands/invoke.rs
+++ b/crates/bins/wick/src/commands/invoke.rs
@@ -121,7 +121,7 @@ pub(crate) async fn handle(opts: InvokeCommand, settings: wick_settings::Setting
     }
   }
 
-  let inherent_data = opts.seed.map(|seed| {
+  let inherent_data = opts.seed.map_or_else(InherentData::unsafe_default, |seed| {
     InherentData::new(
       seed,
       SystemTime::now()

--- a/crates/bins/wick/src/commands/rpc/invoke.rs
+++ b/crates/bins/wick/src/commands/rpc/invoke.rs
@@ -64,7 +64,7 @@ pub(crate) async fn handle(
   let origin = Entity::server(crate::BIN_NAME);
   let target = Entity::local(&opts.component);
 
-  let inherent_data = opts.seed.map(|seed| {
+  let inherent_data = opts.seed.map_or_else(InherentData::unsafe_default, |seed| {
     InherentData::new(
       seed,
       SystemTime::now()

--- a/crates/components/wick-azure-sql/Cargo.toml
+++ b/crates/components/wick-azure-sql/Cargo.toml
@@ -43,3 +43,4 @@ wick-logger = { workspace = true }
 test-logger = { workspace = true }
 anyhow = { workspace = true }
 pretty_assertions = { workspace = true }
+wick-packet = { workspace = true, features = ["test"] }

--- a/crates/components/wick-azure-sql/src/component.rs
+++ b/crates/components/wick-azure-sql/src/component.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use bb8::Pool;
 use bb8_tiberius::ConnectionManager;
 use flow_component::{BoxFuture, Component, ComponentError, RuntimeCallback};
-use futures::StreamExt;
+use futures::{Future, StreamExt};
 use parking_lot::Mutex;
 use serde_json::{Map, Value};
 use tiberius::{Query, Row};
@@ -47,11 +47,15 @@ pub struct AzureSqlComponent {
 
 impl AzureSqlComponent {
   #[allow(clippy::needless_pass_by_value)]
-  pub fn new(config: SqlComponentConfig, metadata: Metadata, resolver: &Resolver) -> Result<Self, ComponentError> {
+  pub fn new(
+    config: SqlComponentConfig,
+    metadata: Option<Metadata>,
+    resolver: &Resolver,
+  ) -> Result<Self, ComponentError> {
     validate(&config, resolver)?;
     let mut sig = component! {
       name: "wick/component/sql",
-      version: metadata.version(),
+      version: metadata.map(|v|v.version().to_owned()),
       operations: config.operation_signatures(),
     };
 
@@ -149,7 +153,7 @@ impl Component for AzureSqlComponent {
     &self.signature
   }
 
-  fn init(&self) -> std::pin::Pin<Box<dyn futures::Future<Output = Result<(), ComponentError>> + Send + 'static>> {
+  fn init(&self) -> std::pin::Pin<Box<dyn Future<Output = Result<(), ComponentError>> + Send + 'static>> {
     let ctx = self.context.clone();
     let addr = self.url_resource.clone();
     let config = self.config.clone();

--- a/crates/components/wick-azure-sql/src/mssql.rs
+++ b/crates/components/wick-azure-sql/src/mssql.rs
@@ -45,7 +45,7 @@ mod integration_test {
   use futures::StreamExt;
   use serde_json::json;
   use wick_config::config::components::{SqlComponentConfigBuilder, SqlOperationDefinitionBuilder};
-  use wick_config::config::{Metadata, ResourceDefinition};
+  use wick_config::config::ResourceDefinition;
   use wick_interface_types::{Field, Type};
   use wick_packet::{packet_stream, Invocation, Packet};
 
@@ -84,7 +84,7 @@ mod integration_test {
       ),
     );
 
-    let component = AzureSqlComponent::new(config, Metadata::default(), &app_config.resolver())?;
+    let component = AzureSqlComponent::new(config, None, &app_config.resolver())?;
 
     component.init().await?;
 

--- a/crates/components/wick-http-client/Cargo.toml
+++ b/crates/components/wick-http-client/Cargo.toml
@@ -36,3 +36,4 @@ tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 wick-logger = { workspace = true }
 test-logger = { workspace = true }
 pretty_assertions = { workspace = true }
+wick-packet = { workspace = true, features = ["test"] }

--- a/crates/components/wick-http-client/src/component.rs
+++ b/crates/components/wick-http-client/src/component.rs
@@ -45,7 +45,7 @@ impl HttpClientComponent {
   #[allow(clippy::needless_pass_by_value)]
   pub fn new(
     config: HttpClientComponentConfig,
-    metadata: Metadata,
+    metadata: Option<Metadata>,
     resolver: &Resolver,
   ) -> Result<Self, ComponentError> {
     validate(&config, resolver)?;
@@ -55,7 +55,7 @@ impl HttpClientComponent {
       .into();
 
     let mut sig = ComponentSignature::new("wick/component/http");
-    sig.metadata.version = Some(metadata.version().to_owned());
+    sig.metadata.version = metadata.map(|v| v.version().to_owned());
     sig.operations = config.operation_signatures();
 
     Ok(Self {
@@ -447,7 +447,7 @@ mod test {
     component_config: HttpClientComponentConfig,
   ) -> HttpClientComponent {
     let resolver = app_config.resolver();
-    let component = HttpClientComponent::new(component_config, Metadata::default(), &resolver).unwrap();
+    let component = HttpClientComponent::new(component_config, None, &resolver).unwrap();
     component.init().await.unwrap();
     component
   }

--- a/crates/components/wick-sqlx/Cargo.toml
+++ b/crates/components/wick-sqlx/Cargo.toml
@@ -50,3 +50,4 @@ wick-logger = { workspace = true }
 test-logger = { workspace = true }
 anyhow = { workspace = true }
 pretty_assertions = { workspace = true }
+wick-packet = { workspace = true, features = ["test"] }

--- a/crates/components/wick-sqlx/src/mssql.rs
+++ b/crates/components/wick-sqlx/src/mssql.rs
@@ -26,7 +26,7 @@ mod integration_test {
   use futures::StreamExt;
   use serde_json::json;
   use wick_config::config::components::{SqlComponentConfigBuilder, SqlOperationDefinitionBuilder};
-  use wick_config::config::{Metadata, ResourceDefinition};
+  use wick_config::config::ResourceDefinition;
   use wick_interface_types::{Field, Type};
   use wick_packet::{packet_stream, Invocation, Packet};
 
@@ -65,7 +65,7 @@ mod integration_test {
       ),
     );
 
-    let component = SqlXComponent::new(config, Metadata::default(), &app_config.resolver())?;
+    let component = SqlXComponent::new(config, None, &app_config.resolver())?;
 
     component.init().await.unwrap();
 

--- a/crates/components/wick-sqlx/src/postgres.rs
+++ b/crates/components/wick-sqlx/src/postgres.rs
@@ -26,7 +26,7 @@ mod integration_test {
   use futures::StreamExt;
   use serde_json::json;
   use wick_config::config::components::{SqlComponentConfigBuilder, SqlOperationDefinitionBuilder};
-  use wick_config::config::{Metadata, ResourceDefinition};
+  use wick_config::config::ResourceDefinition;
   use wick_interface_types::{Field, Type};
   use wick_packet::{packet_stream, Invocation, Packet};
 
@@ -65,7 +65,7 @@ mod integration_test {
       ),
     );
 
-    let component = SqlXComponent::new(config, Metadata::default(), &app_config.resolver())?;
+    let component = SqlXComponent::new(config, None, &app_config.resolver())?;
 
     component.init().await.unwrap();
 

--- a/crates/integration/test-cli-with-db/src/lib.rs
+++ b/crates/integration/test-cli-with-db/src/lib.rs
@@ -32,7 +32,7 @@ impl MainOperation for Component {
 
       println!("cli:db: looking up user with id: {}.", console::style(id).green());
 
-      let provided = get_provided();
+      let provided = ctx.provided();
       println!(
         "cli:db: calling provided component operation at URL: {}",
         console::style(format!("{}get_user", provided.db.component())).green()

--- a/crates/interfaces/wick-interface-cli/component.yaml
+++ b/crates/interfaces/wick-interface-cli/component.yaml
@@ -2,6 +2,10 @@
 ---
 name: cli
 kind: wick/types@v1
+package:
+  registry:
+    host: registry.candle.dev
+    namespace: types
 types:
   - name: Interactive
     kind: wick/type/struct@v1

--- a/crates/misc/seeded-random/Cargo.toml
+++ b/crates/misc/seeded-random/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/candlecorp/wick"
 [features]
 default = ["rng"]
 rng = ["rand/rand_chacha", "rand/small_rng"]
-std = ["rand/std"]
+std = ["rand/std", "rand/std_rng"]
 uuid = ["uuid/v4"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/wick/flow-component/Cargo.toml
+++ b/crates/wick/flow-component/Cargo.toml
@@ -19,5 +19,6 @@ futures = { workspace = true }
 anyhow = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 tracing = { workspace = true }
+seeded-random = { workspace = true, features = ["rng"] }
 
 [dev-dependencies]

--- a/crates/wick/flow-component/src/traits.rs
+++ b/crates/wick/flow-component/src/traits.rs
@@ -67,7 +67,7 @@ pub type RuntimeCallback = dyn Fn(
     ComponentReference,
     String,
     PacketStream,
-    Option<InherentData>,
+    InherentData,
     Option<GenericConfig>,
     &tracing::Span,
   ) -> BoxFuture<'static, Result<PacketStream, ComponentError>>

--- a/crates/wick/flow-graph-interpreter/Cargo.toml
+++ b/crates/wick/flow-graph-interpreter/Cargo.toml
@@ -37,3 +37,4 @@ test-logger = { workspace = true }
 anyhow = { workspace = true }
 serde_json = { workspace = true }
 pretty_assertions = { workspace = true }
+wick-packet = { workspace = true, features = ["test"] }

--- a/crates/wick/flow-graph-interpreter/src/interpreter/components/core_collection/merge.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/components/core_collection/merge.rs
@@ -100,7 +100,7 @@ mod test {
   use flow_component::panic_callback;
   use serde_json::json;
   use tokio_stream::StreamExt;
-  use wick_packet::{packet_stream, Entity};
+  use wick_packet::{packet_stream, Entity, InherentData};
 
   use super::*;
 
@@ -113,7 +113,10 @@ mod test {
     let stream = packet_stream!(("input_a", "hello"), ("input_b", 1000));
     let inv = Invocation::test(file!(), Entity::test("noop"), stream, None)?;
     let mut packets = op
-      .handle(inv, Context::new(config, None, panic_callback()))
+      .handle(
+        inv,
+        Context::new(config, InherentData::unsafe_default(), panic_callback()),
+      )
       .await?
       .collect::<Vec<_>>()
       .await;

--- a/crates/wick/flow-graph-interpreter/src/interpreter/components/core_collection/pluck.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/components/core_collection/pluck.rs
@@ -111,7 +111,7 @@ impl Operation for Op {
 mod test {
   use anyhow::Result;
   use flow_component::panic_callback;
-  use wick_packet::{packet_stream, Entity};
+  use wick_packet::{packet_stream, Entity, InherentData};
 
   use super::*;
 
@@ -131,7 +131,10 @@ mod test {
     ));
     let inv = Invocation::test(file!(), Entity::test("noop"), stream, None)?;
     let mut packets = op
-      .handle(inv, Context::new(config, None, panic_callback()))
+      .handle(
+        inv,
+        Context::new(config, InherentData::unsafe_default(), panic_callback()),
+      )
       .await?
       .collect::<Vec<_>>()
       .await;

--- a/crates/wick/flow-graph-interpreter/src/interpreter/components/core_collection/switch.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/components/core_collection/switch.rs
@@ -174,6 +174,7 @@ impl Operation for Op {
         );
         trace!(operation = op, "core:switch:route");
         let span = invocation.span.clone();
+        let inherent = invocation.inherent.next();
         let stream = router.entry(op.clone()).or_insert_with(|| {
           let target = path_to_entity(op).unwrap(); // unwrap ok because the config has been pre-validated.
           let op_id = target.operation_id().to_owned();
@@ -182,7 +183,7 @@ impl Operation for Op {
           let tx = tx.clone();
           let callback = callback.clone();
           tokio::spawn(async move {
-            match callback(link, op_id, route_rx, None, None, &span).await {
+            match callback(link, op_id, route_rx, inherent, None, &span).await {
               Ok(mut call_rx) => {
                 while let Some(packet) = call_rx.next().await {
                   let _ = tx.send_result(packet);

--- a/crates/wick/flow-graph-interpreter/src/interpreter/components/schematic_component.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/components/schematic_component.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use flow_component::{Component, ComponentError, RuntimeCallback};
 use parking_lot::Mutex;
-use seeded_random::{Random, Seed};
 use tracing_futures::Instrument;
 use wick_interface_types::ComponentSignature;
 use wick_packet::{Invocation, PacketStream};
@@ -25,7 +24,6 @@ pub(crate) struct SchematicComponent {
   schematics: Arc<Vec<SchematicExecutor>>,
   components: Arc<HandlerMap>,
   self_collection: Mutex<Option<Arc<Self>>>,
-  rng: Random,
 }
 
 impl SchematicComponent {
@@ -33,7 +31,6 @@ impl SchematicComponent {
     components: Arc<HandlerMap>,
     state: &ProgramState,
     dispatcher: &InterpreterDispatchChannel,
-    seed: Seed,
   ) -> Arc<Self> {
     let schematics: Arc<Vec<SchematicExecutor>> = Arc::new(
       state
@@ -49,7 +46,6 @@ impl SchematicComponent {
       schematics,
       self_collection: Mutex::new(None),
       components,
-      rng: Random::from_seed(seed),
     });
     collection.update_self_collection();
     collection
@@ -84,7 +80,6 @@ impl Component for SchematicComponent {
       .map(|s| {
         s.invoke(
           invocation,
-          self.rng.seed(),
           self.components.clone(),
           self.clone_self_collection(),
           callback,

--- a/crates/wick/flow-graph-interpreter/src/interpreter/executor.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/executor.rs
@@ -38,14 +38,13 @@ impl SchematicExecutor {
   pub(crate) async fn invoke(
     &self,
     invocation: Invocation,
-    seed: Seed,
     components: Arc<HandlerMap>,
     self_component: Arc<dyn Component + Send + Sync>,
     callback: Arc<RuntimeCallback>,
   ) -> Result<PacketStream> {
     invocation.trace(|| debug!(schematic = self.name(), ?invocation,));
 
-    let seed = invocation.seed().map_or(seed, Seed::unsafe_new);
+    let seed = Seed::unsafe_new(invocation.seed());
 
     let mut transaction = Transaction::new(
       self.schematic.clone(),

--- a/crates/wick/flow-graph-interpreter/tests/test/mod.rs
+++ b/crates/wick/flow-graph-interpreter/tests/test/mod.rs
@@ -5,7 +5,6 @@ use flow_component::panic_callback;
 use flow_graph_interpreter::graph::from_def;
 use flow_graph_interpreter::Interpreter;
 pub use observer::JsonWriter;
-use seeded_random::Seed;
 pub use test_component::TestComponent;
 use wick_packet::{Entity, GenericConfig, Packet};
 
@@ -46,13 +45,13 @@ pub(crate) async fn base_setup(
   .unwrap();
 
   let mut interpreter = Interpreter::new(
-    Some(Seed::unsafe_new(1)),
     network,
     None,
     Some(collections),
     panic_callback(),
     &tracing::Span::current(),
   )?;
+
   interpreter.start(options, None).await;
   let stream = wick_packet::PacketStream::new(Box::new(futures::stream::iter(packets.into_iter().map(Ok))));
   let invocation = Invocation::test("test", entity, stream, None)?;

--- a/crates/wick/wick-component-codegen/src/generate.rs
+++ b/crates/wick/wick-component-codegen/src/generate.rs
@@ -144,6 +144,10 @@ fn codegen(wick_config: WickConfiguration, gen_config: &mut config::Config) -> R
 
   let expanded = quote! {
     #imports
+
+    #[allow(unused)]
+    pub(crate) use wick_component::prelude::*;
+
     #[allow(unused)]
     pub(crate) type WickStream<T> = wick_component::wasmrs_rx::BoxFlux<T, Box<dyn std::error::Error + Send + Sync>>;
     pub use wick_component::flow_component::Context;

--- a/crates/wick/wick-component-codegen/src/generate/templates/provided_struct.rs
+++ b/crates/wick/wick-component-codegen/src/generate/templates/provided_struct.rs
@@ -13,7 +13,7 @@ pub(crate) fn provided_struct(_config: &Config, required: &[BoundInterface]) -> 
       let name = id(&snake(r.id()));
       let orig_name = r.id();
       let response_name = id(&component_id(r));
-      quote! { #name : #response_name::new(config.provided.get(#orig_name).cloned().unwrap()) }
+      quote! { #name : #response_name::new(config.provided.get(#orig_name).cloned().unwrap(), inherent.clone()) }
     })
     .collect_vec();
   let fields = required
@@ -25,11 +25,12 @@ pub(crate) fn provided_struct(_config: &Config, required: &[BoundInterface]) -> 
     })
     .collect_vec();
   quote! {
+    #[allow(unused)]
     pub(crate) struct Provided {
       #(#fields),*
     }
 
-    pub(crate) fn get_provided() -> Provided {
+    pub(crate) fn get_provided(inherent: wick_component::flow_component::InherentContext) -> Provided {
       let config = get_config();
       Provided {
         #(#required_names,)*
@@ -42,7 +43,7 @@ pub(crate) fn provided_struct(_config: &Config, required: &[BoundInterface]) -> 
 
     impl<T> ProvidedContext for wick_component::flow_component::Context<T> where T:std::fmt::Debug{
       fn provided(&self) -> Provided {
-        get_provided()
+        get_provided(self.inherent.clone())
       }
     }
 

--- a/crates/wick/wick-config/src/config.rs
+++ b/crates/wick/wick-config/src/config.rs
@@ -115,12 +115,48 @@ impl WickConfiguration {
     resolve_configuration(src, source)
   }
 
+  pub fn name(&self) -> Option<&str> {
+    match self {
+      WickConfiguration::Component(v) => v.name().map(|s| s.as_str()),
+      WickConfiguration::App(v) => Some(v.name()),
+      WickConfiguration::Types(v) => v.name().map(|s| s.as_str()),
+      WickConfiguration::Tests(v) => v.name().map(|s| s.as_str()),
+    }
+  }
+
+  pub fn metadata(&self) -> Option<&Metadata> {
+    match self {
+      WickConfiguration::Component(v) => v.metadata(),
+      WickConfiguration::App(v) => v.metadata(),
+      WickConfiguration::Types(v) => v.metadata(),
+      WickConfiguration::Tests(_v) => None,
+    }
+  }
+
   pub fn kind(&self) -> ConfigurationKind {
     match self {
       WickConfiguration::Component(_) => ConfigurationKind::Component,
       WickConfiguration::App(_) => ConfigurationKind::App,
       WickConfiguration::Types(_) => ConfigurationKind::Types,
       WickConfiguration::Tests(_) => ConfigurationKind::Tests,
+    }
+  }
+
+  pub fn version(&self) -> Option<&str> {
+    match self {
+      WickConfiguration::Component(v) => v.version(),
+      WickConfiguration::App(v) => v.version(),
+      WickConfiguration::Types(v) => v.version(),
+      WickConfiguration::Tests(_) => None,
+    }
+  }
+
+  pub fn package(&self) -> Option<&PackageConfig> {
+    match self {
+      WickConfiguration::Component(v) => v.package(),
+      WickConfiguration::App(v) => v.package(),
+      WickConfiguration::Types(v) => v.package(),
+      WickConfiguration::Tests(_) => None,
     }
   }
 

--- a/crates/wick/wick-config/src/config/app_config.rs
+++ b/crates/wick/wick-config/src/config/app_config.rs
@@ -113,14 +113,14 @@ impl AppConfiguration {
 
   /// Return the version of the application.
   #[must_use]
-  pub fn version(&self) -> String {
-    self.metadata.clone().map(|m| m.version).unwrap_or_default()
+  pub fn version(&self) -> Option<&str> {
+    self.metadata.as_ref().map(|m| m.version.as_str())
   }
 
   /// Return the metadata of the component.
   #[must_use]
-  pub fn metadata(&self) -> config::Metadata {
-    self.metadata.clone().unwrap()
+  pub fn metadata(&self) -> Option<&config::Metadata> {
+    self.metadata.as_ref()
   }
 
   #[must_use]

--- a/crates/wick/wick-config/src/config/component_config.rs
+++ b/crates/wick/wick-config/src/config/component_config.rs
@@ -83,7 +83,8 @@ impl ComponentConfiguration {
     match &self.component {
       ComponentImplementation::Composite(c) => c.config(),
       ComponentImplementation::Wasm(c) => c.config(),
-      _ => unimplemented!(),
+      ComponentImplementation::Sql(_) => Default::default(),
+      ComponentImplementation::HttpClient(_) => Default::default(),
     }
   }
 
@@ -168,14 +169,14 @@ impl ComponentConfiguration {
 
   /// Return the version of the component.
   #[must_use]
-  pub fn version(&self) -> String {
-    self.metadata.clone().map(|m| m.version).unwrap_or_default()
+  pub fn version(&self) -> Option<&str> {
+    self.metadata.as_ref().map(|m| m.version.as_str())
   }
 
   /// Return the metadata of the component.
   #[must_use]
-  pub fn metadata(&self) -> config::Metadata {
-    self.metadata.clone().unwrap_or_default()
+  pub fn metadata(&self) -> Option<&config::Metadata> {
+    self.metadata.as_ref()
   }
 
   /// Return the underlying version of the source manifest.

--- a/crates/wick/wick-config/src/config/types_config.rs
+++ b/crates/wick/wick-config/src/config/types_config.rs
@@ -59,14 +59,14 @@ impl TypesConfiguration {
 
   /// Return the version of the application.
   #[must_use]
-  pub fn version(&self) -> String {
-    self.metadata.clone().map(|m| m.version).unwrap_or_default()
+  pub fn version(&self) -> Option<&str> {
+    self.metadata.as_ref().map(|m| m.version.as_str())
   }
 
   /// Return the metadata of the component.
   #[must_use]
-  pub fn metadata(&self) -> config::Metadata {
-    self.metadata.clone().unwrap()
+  pub fn metadata(&self) -> Option<&config::Metadata> {
+    self.metadata.as_ref()
   }
 
   /// Get the package files

--- a/crates/wick/wick-host/src/component_host.rs
+++ b/crates/wick/wick-host/src/component_host.rs
@@ -148,12 +148,7 @@ impl ComponentHost {
     Ok(metadata)
   }
 
-  pub async fn request(
-    &self,
-    operation: &str,
-    stream: PacketStream,
-    data: Option<InherentData>,
-  ) -> Result<PacketStream> {
+  pub async fn request(&self, operation: &str, stream: PacketStream, data: InherentData) -> Result<PacketStream> {
     match &self.runtime {
       Some(runtime) => {
         let invocation = Invocation::new(
@@ -242,7 +237,7 @@ mod test {
     host.start(None).await?;
     let passed_data = "logging output";
     let stream = packet_stream!(("input", passed_data));
-    let stream = host.request("logger", stream, None).await?;
+    let stream = host.request("logger", stream, InherentData::unsafe_default()).await?;
 
     let mut messages: Vec<_> = stream.collect().await;
     assert_eq!(messages.len(), 2);

--- a/crates/wick/wick-interface-types/src/signatures/component.rs
+++ b/crates/wick/wick-interface-types/src/signatures/component.rs
@@ -125,9 +125,9 @@ pub struct ComponentMetadata {
 }
 
 impl ComponentMetadata {
-  pub fn new(version: impl AsRef<str>) -> Self {
+  pub fn new(version: Option<impl AsRef<str>>) -> Self {
     Self {
-      version: Some(version.as_ref().to_owned()),
+      version: version.map(|v| v.as_ref().to_owned()),
     }
   }
 }

--- a/crates/wick/wick-interface-types/tests/parser.rs
+++ b/crates/wick/wick-interface-types/tests/parser.rs
@@ -83,12 +83,12 @@ fn test_component_macro() -> Result<()> {
   let expected = ComponentSignature {
     name: Some("test-native-component".to_owned()),
     operations: opmap,
-    metadata: ComponentMetadata::new("0.1.0"),
+    metadata: ComponentMetadata::new(Some("0.1.0")),
     ..Default::default()
   };
   let actual = component! {
       name: "test-native-component",
-      version: "0.1.0",
+      version: Some("0.1.0"),
       operations: {
         "test-component" => {
           inputs: {"input" => "string"},

--- a/crates/wick/wick-package/src/error.rs
+++ b/crates/wick/wick-package/src/error.rs
@@ -25,6 +25,10 @@ pub enum Error {
   #[error("Can not find file at {0}.")]
   NotFound(String),
 
+  /// Metadata required for this operation.
+  #[error("Must specify metadata & version when performing package actions: {0}")]
+  NoMetadata(String),
+
   /// Failed to read downloaded package
   #[error("Failed to read downloaded package: {0}")]
   PackageReadFailed(String),
@@ -48,6 +52,10 @@ pub enum Error {
   /// Tried to publish a component that didn't have a name
   #[error("Published components must be named")]
   NoName,
+
+  /// Tried to publish a component that didn't have a version
+  #[error("Published components must have a version")]
+  NoVersion,
 
   /// General Configuration error
   #[error(transparent)]

--- a/crates/wick/wick-packet/Cargo.toml
+++ b/crates/wick/wick-packet/Cargo.toml
@@ -17,10 +17,13 @@ maintenance = { status = "actively-developed" }
 
 [features]
 default = []
-invocation = ["uuid", "seeded-random/rng"]
+invocation = ["uuid", "rng"]
 rt-tokio = ["tokio/rt"]
 datetime = ["chrono"]
 validation = []
+rng = ["seeded-random/rng"]
+std = ["seeded-random/std"]
+test = ["invocation", "std"]
 
 [dependencies]
 wick-interface-types = { workspace = true, features = ["typeid"] }

--- a/crates/wick/wick-packet/src/collection_link.rs
+++ b/crates/wick/wick-packet/src/collection_link.rs
@@ -22,7 +22,7 @@ impl ComponentReference {
     &self,
     operation: &str,
     packets: impl Into<PacketStream>,
-    inherent: Option<crate::InherentData>,
+    inherent: crate::InherentData,
     follows_from: &tracing::Span,
   ) -> crate::Invocation {
     let target = crate::Entity::operation(self.target.component_id(), operation);
@@ -48,11 +48,9 @@ impl ComponentReference {
     operation: &str,
     stream: PacketStream,
     config: Option<crate::GenericConfig>,
+    previous_inherent: crate::InherentData,
   ) -> Result<PacketStream> {
-    // let origin = self.origin.clone();
-    // let target = Entity::operation(&self.target_ns, operation).url();
-
-    link_call(self.clone(), operation, stream, config)
+    link_call(self.clone(), operation, stream, config, previous_inherent)
   }
 }
 
@@ -75,6 +73,7 @@ fn link_call(
   target_op: &str,
   input: PacketStream,
   config: Option<crate::GenericConfig>,
+  previous_inherent: crate::InherentData,
 ) -> Result<PacketStream> {
   use tokio_stream::StreamExt;
   use wasmrs::RSocket;
@@ -88,7 +87,7 @@ fn link_call(
       reference: compref,
       operation: target_op.to_owned(),
     }),
-    inherent: None,
+    inherent: previous_inherent,
   };
 
   let _ = tx.send_result(crate::Packet::encode("", first).into());
@@ -115,6 +114,7 @@ fn link_call(
   _target_op: &str,
   _input: PacketStream,
   _config: Option<crate::GenericConfig>,
+  _previous_inherent: crate::InherentData,
 ) -> Result<PacketStream> {
   unimplemented!("Link calls from native components is not implemented yet")
 }

--- a/crates/wick/wick-packet/src/context.rs
+++ b/crates/wick/wick-packet/src/context.rs
@@ -72,7 +72,7 @@ where
   T: std::fmt::Debug + Serialize,
 {
   pub config: T,
-  pub inherent: Option<InherentData>,
+  pub inherent: InherentData,
   pub invocation: Option<InvocationRequest>,
 }
 
@@ -80,7 +80,7 @@ impl<T> ContextTransport<T>
 where
   T: std::fmt::Debug + Serialize,
 {
-  pub fn new(config: T, inherent: Option<InherentData>) -> Self {
+  pub fn new(config: T, inherent: InherentData) -> Self {
     Self {
       config,
       inherent,

--- a/crates/wick/wick-packet/src/inherent.rs
+++ b/crates/wick/wick-packet/src/inherent.rs
@@ -1,6 +1,7 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, Clone, Copy, PartialEq)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+#[allow(missing_copy_implementations)]
 /// Data inherent to an invocation. Meant to be supplied by a runtime, not a user.
 #[must_use]
 pub struct InherentData {
@@ -14,6 +15,47 @@ impl InherentData {
   /// Constructor for [InherentData]
   pub fn new(seed: u64, timestamp: u64) -> Self {
     Self { seed, timestamp }
+  }
+
+  #[cfg(all(feature = "rng", not(target_family = "wasm")))]
+  pub fn next(&self) -> Self {
+    Self {
+      seed: seeded_random::Random::from_seed(seeded_random::Seed::unsafe_new(self.seed)).gen(),
+      timestamp: std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis()
+        .try_into()
+        .unwrap(),
+    }
+  }
+
+  /// Create a new InherentData with the current time and a random seed.
+  ///
+  /// This is not "unsafe" in the Rust sense. It is unsafe because it should
+  /// only be used if you are sure you know what you're doing. If you don't know why this is unsafe, don't use it.
+  #[cfg(all(feature = "rng", feature = "std", not(target_family = "wasm")))]
+  pub fn unsafe_default() -> Self {
+    Self {
+      seed: seeded_random::Random::new().gen(),
+      timestamp: std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_millis()
+        .try_into()
+        .unwrap(),
+    }
+  }
+
+  /// Clone the InherentData struct.
+  ///
+  /// This is not "unsafe" in the Rust sense. It is unsafe because it should
+  /// only be used if you are sure you know what you're doing. If you don't know why this is unsafe, don't use it.
+  pub fn unsafe_clone(&self) -> Self {
+    Self {
+      seed: self.seed,
+      timestamp: self.timestamp,
+    }
   }
 }
 

--- a/crates/wick/wick-packet/src/macros.rs
+++ b/crates/wick/wick-packet/src/macros.rs
@@ -2,7 +2,8 @@
 macro_rules! packet_stream {
   ($(($port:expr, $value:expr)),*) => {{
     let packets = $crate::packets!($(($port, $value)),*);
-    wick_packet::PacketStream::new(Box::new(futures::stream::iter(packets.into_iter().map(Ok))))
+    let packets :$crate::PacketStream = packets.into();
+    packets
   }};
 }
 

--- a/crates/wick/wick-packet/src/packet_stream.rs
+++ b/crates/wick/wick-packet/src/packet_stream.rs
@@ -10,7 +10,7 @@ use crate::{BoxError, ContextTransport, GenericConfig, InherentData, Packet, Res
 
 pub type PacketSender = FluxChannel<Packet, crate::Error>;
 
-type ContextConfig = (GenericConfig, Option<InherentData>);
+type ContextConfig = (GenericConfig, InherentData);
 
 pub(crate) type BoxStream<'a, T> = Pin<Box<dyn Stream<Item = T> + Send + 'a>>;
 
@@ -74,7 +74,7 @@ impl PacketStream {
     self.span = span;
   }
 
-  pub fn set_context(&self, context: GenericConfig, inherent: Option<InherentData>) {
+  pub fn set_context(&self, context: GenericConfig, inherent: InherentData) {
     self.config.lock().replace((context, inherent));
   }
 

--- a/crates/wick/wick-rpc/src/error.rs
+++ b/crates/wick/wick-rpc/src/error.rs
@@ -19,6 +19,10 @@ pub enum RpcError {
   #[error("Internal Error: {0}")]
   InternalError(String),
 
+  /// No inherent data found in RPC message.
+  #[error("No inherent data found in RPC message")]
+  NoInherentData,
+
   /// Conversion error between types.
   #[error("Could not convert type to or from gRPC to wick.")]
   TypeConversion,

--- a/crates/wick/wick-runtime/Cargo.toml
+++ b/crates/wick/wick-runtime/Cargo.toml
@@ -12,7 +12,7 @@ description = "The runtime for the Wick project."
 [dependencies]
 cron = { workspace = true }
 chrono = { workspace = true }
-wick-packet = { workspace = true, features = ["validation"] }
+wick-packet = { workspace = true, features = ["validation", "rng", "std"] }
 flow-graph = { workspace = true }
 flow-graph-interpreter = { workspace = true }
 flow-component = { workspace = true }

--- a/crates/wick/wick-runtime/src/components.rs
+++ b/crates/wick/wick-runtime/src/components.rs
@@ -161,7 +161,7 @@ pub(crate) async fn init_manifest_component(
     config::ComponentImplementation::Sql(c) => {
       init_hlc_component(
         id,
-        metadata,
+        metadata.cloned(),
         wick_config::config::HighLevelComponent::Sql(c.clone()),
         manifest.resolver(),
       )
@@ -170,7 +170,7 @@ pub(crate) async fn init_manifest_component(
     config::ComponentImplementation::HttpClient(c) => {
       init_hlc_component(
         id,
-        metadata,
+        metadata.cloned(),
         wick_config::config::HighLevelComponent::HttpClient(c.clone()),
         manifest.resolver(),
       )
@@ -205,7 +205,7 @@ pub(crate) fn initialize_native_component(namespace: String, seed: Seed) -> Comp
 
 pub(crate) async fn init_hlc_component(
   id: String,
-  metadata: Metadata,
+  metadata: Option<Metadata>,
   component: wick_config::config::HighLevelComponent,
   resolver: Box<Resolver>,
 ) -> ComponentInitResult {

--- a/crates/wick/wick-runtime/src/triggers/cli.rs
+++ b/crates/wick/wick-runtime/src/triggers/cli.rs
@@ -11,7 +11,7 @@ use serde_json::json;
 use structured_output::StructuredOutput;
 use tokio_stream::StreamExt;
 use tracing::{Instrument, Span};
-use wick_packet::{packet_stream, Entity, Invocation};
+use wick_packet::{packet_stream, Entity, InherentData, Invocation};
 
 use super::{build_trigger_runtime, resolve_ref, Trigger, TriggerKind};
 use crate::dev::prelude::*;
@@ -63,7 +63,7 @@ impl Cli {
       Entity::server("cli_channel"),
       Entity::operation(cli_binding.id(), config.operation().name()),
       packet_stream,
-      None,
+      InherentData::unsafe_default(),
       &Span::current(),
     );
     let mut runtime = build_trigger_runtime(&app_config, Span::current())?;

--- a/crates/wick/wick-runtime/src/triggers/http/rest_router.rs
+++ b/crates/wick/wick-runtime/src/triggers/http/rest_router.rs
@@ -8,7 +8,7 @@ use hyper::service::Service;
 use hyper::{Body, Request, Response, StatusCode};
 use tracing::{Instrument, Span};
 use wick_config::config::{ComponentOperationExpression, ImportBinding, RestRouterConfig, WickRouter};
-use wick_packet::{Entity, Invocation, Packet};
+use wick_packet::{Entity, InherentData, Invocation, Packet};
 mod route;
 
 use super::{HttpError, RawRouter};
@@ -132,7 +132,7 @@ impl RestHandler {
         Entity::server("http_client"),
         Entity::operation(route.component.id(), route.operation.name()),
         packets,
-        None,
+        InherentData::unsafe_default(),
         &span,
       );
 

--- a/crates/wick/wick-runtime/src/triggers/time.rs
+++ b/crates/wick/wick-runtime/src/triggers/time.rs
@@ -13,7 +13,7 @@ use structured_output::StructuredOutput;
 use tokio::time::Duration;
 use tokio_stream::StreamExt;
 use tracing::Span;
-use wick_packet::{Entity, Packet};
+use wick_packet::{Entity, InherentData, Packet};
 
 use super::{build_trigger_runtime, Trigger, TriggerKind};
 use crate::dev::prelude::*;
@@ -34,7 +34,7 @@ async fn invoke_operation(
     Entity::server("schedule_client"),
     Entity::operation("0", operation.as_str()),
     packets,
-    None,
+    InherentData::unsafe_default(),
     &Span::current(),
   );
 

--- a/crates/wick/wick-runtime/tests/triggers.rs
+++ b/crates/wick/wick-runtime/tests/triggers.rs
@@ -81,7 +81,7 @@ mod integration_test {
         panic!("could not find trigger {}", &trigger_config.kind());
       }
     };
-    let fut = tokio::time::timeout(Duration::from_millis(5000), task);
+    let fut = tokio::time::timeout(Duration::from_millis(10000), task);
     println!("waiting for trigger to finish...");
     let _ = fut.await?;
     println!("trigger finished");

--- a/crates/wick/wick-stdlib/src/lib.rs
+++ b/crates/wick/wick-stdlib/src/lib.rs
@@ -112,7 +112,7 @@ impl Collection {
   pub fn new(seed: Seed) -> Self {
     let sig = component! {
         name: "wick-stdlib",
-        version: "0.1.0",
+        version: Some("0.1.0"),
         operations: {
           "core::error" => {
             inputs: { "input" => "string" },

--- a/examples/db/postgres-numeric.wick
+++ b/examples/db/postgres-numeric.wick
@@ -45,45 +45,46 @@ component:
         - u64
         - f64
 tests:
-  - name: native_types
-    operation: native_types
-    input:
-      - name: i16
-        data: 32767
-      - name: i32
-        data: 2147483647
-      - name: i64
-        data: 9223372036854775807
-      - name: f32
-        data: 3.4028234663852886e+38
-    output:
-      - name: output
-        data:
-          i16: 32767
-          i32: 2147483647
-          i64: 9223372036854775807
-          f32: 3.4028234663852886e+38
-      - name: output
-        flags:
-          done: true
-  - name: coerced_types
-    operation: coerced_types
-    input:
-      - name: u16
-        data: 32767
-      - name: u32
-        data: 2147483647
-      - name: u64
-        data: 9223372036854775807
-      - name: f64
-        data: 3.4028234663852886e+38
-    output:
-      - name: output
-        data:
-          i16: 32767
-          i32: 2147483647
-          i64: 9223372036854775807
-          f32: 3.4028234663852886e+38
-      - name: output
-        flags:
-          done: true
+  - cases:
+      - name: native_types
+        operation: native_types
+        input:
+          - name: i16
+            data: 32767
+          - name: i32
+            data: 2147483647
+          - name: i64
+            data: 9223372036854775807
+          - name: f32
+            data: 3.4028234663852886e+38
+        output:
+          - name: output
+            data:
+              i16: 32767
+              i32: 2147483647
+              i64: 9223372036854775807
+              f32: 3.4028234663852886e+38
+          - name: output
+            flags:
+              done: true
+      - name: coerced_types
+        operation: coerced_types
+        input:
+          - name: u16
+            data: 32767
+          - name: u32
+            data: 2147483647
+          - name: u64
+            data: 9223372036854775807
+          - name: f64
+            data: 3.4028234663852886e+38
+        output:
+          - name: output
+            data:
+              i16: 32767
+              i32: 2147483647
+              i64: 9223372036854775807
+              f32: 3.4028234663852886e+38
+          - name: output
+            flags:
+              done: true

--- a/examples/http/middleware/request/Cargo.lock
+++ b/examples/http/middleware/request/Cargo.lock
@@ -453,6 +453,7 @@ version = "0.5.0"
 dependencies = [
  "anyhow",
  "futures",
+ "seeded-random",
  "serde",
  "serde_json",
  "tracing",
@@ -1220,6 +1221,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "ppv-lite86"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
 name = "proc-macro-hack"
 version = "0.5.20+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1277,6 +1284,32 @@ checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "redox_syscall"
@@ -1442,6 +1475,15 @@ checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
 dependencies = [
  "ring",
  "untrusted",
+]
+
+[[package]]
+name = "seeded-random"
+version = "0.3.0"
+dependencies = [
+ "parking_lot",
+ "rand",
+ "rand_chacha",
 ]
 
 [[package]]

--- a/tests/codegen-tests/Cargo.toml
+++ b/tests/codegen-tests/Cargo.toml
@@ -20,22 +20,10 @@ bytes = { workspace = true }
 anyhow = { version = "1" }
 
 [dev-dependencies]
-wick-packet = { workspace = true }
+wick-packet = { workspace = true, features = ["test"] }
 wick-interface-types = { workspace = true, features = ["parser"] }
 anyhow = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt"] }
 tokio-stream = { workspace = true }
 
 [build-dependencies]
-# wick-rpc = { workspace = true }
-# tracing = { workspace = true }
-# futures = { workspace = true }
-# test-logger = { workspace = true }
-# tokio = { workspace = true, features = ["macros", "process", "rt"] }
-# wick-logger = { workspace = true }
-# clap = { version = "3.0", features = ["derive", "env"] }
-# pretty_assertions = { workspace = true }
-# wick-component-cli = { workspace = true }
-# tonic = { workspace = true }
-# wick-invocation-server = { workspace = true }
-# tokio-stream = { workspace = true }

--- a/tests/codegen-tests/src/import_types/mod.rs
+++ b/tests/codegen-tests/src/import_types/mod.rs
@@ -1,5 +1,7 @@
 pub use async_trait::async_trait;
 #[allow(unused)]
+pub(crate) use wick_component::prelude::*;
+#[allow(unused)]
 pub(crate) use wick_component::wasmrs_rx::{Observable, Observer};
 pub use wick_component::{packet as wick_packet, runtime, wasmrs, wasmrs_codec, wasmrs_rx};
 #[allow(unused)]

--- a/tests/codegen-tests/src/lib.rs
+++ b/tests/codegen-tests/src/lib.rs
@@ -43,7 +43,7 @@ mod test1 {
     use flow_component::{panic_callback, Context};
     use types::http;
     use wasmrs_guest::{FluxChannel, StreamExt};
-    use wick_packet::ContextTransport;
+    use wick_packet::{ContextTransport, InherentData};
 
     use super::*;
     use crate::import_types::types::http::HttpResponse;
@@ -67,7 +67,11 @@ mod test1 {
       let packets = tokio_stream::iter(vec![Ok(response)]).boxed();
       let tx = FluxChannel::new();
       let outputs = testop::Outputs::new(tx);
-      let ctx = Context::new(testop::Config::default(), None, panic_callback());
+      let ctx = Context::new(
+        testop::Config::default(),
+        InherentData::unsafe_default(),
+        panic_callback(),
+      );
 
       Component::testop(packets, outputs, ctx).await?;
       Ok(())
@@ -80,7 +84,7 @@ mod test1 {
         a: "value".to_owned(),
         b: 2,
       };
-      let expected = ContextTransport::new(config, None);
+      let expected = ContextTransport::new(config, InherentData::unsafe_default());
       let bytes = wasmrs_codec::messagepack::serialize(&expected).unwrap();
       let actual: ContextTransport<testop::Config> = wasmrs_codec::messagepack::deserialize(&bytes).unwrap();
       assert_eq!(actual.config, expected.config);

--- a/tests/integration/src/test.rs
+++ b/tests/integration/src/test.rs
@@ -24,7 +24,7 @@ impl Default for NativeComponent {
   fn default() -> Self {
     let sig = component! {
       name: "test-native-component",
-      version: "0.1.0",
+      version: Some("0.1.0"),
       operations: {
         "error" => {
           inputs: {"input" => "string"},
@@ -121,7 +121,7 @@ mod tests {
 
     let expected = ComponentSignature {
       name: Some("test-native-component".to_owned()),
-      metadata: ComponentMetadata::new("0.1.0"),
+      metadata: ComponentMetadata::new(Some("0.1.0")),
       operations: vec![
         OperationSignature {
           name: "error".to_string(),


### PR DESCRIPTION
This PR 
- makes `inherent` required and propagates it throughout. This makes the `seed` and `timestamp` (millis since UNIX epoch) available to every operation.
- removes interpreter seed in favor of invocation seed.
