### PR TITLE
Updated generated markdown for enums

### DIFF
--- a/crates/wick/wick-config/definitions/v1/doc-templates/rust/partials/enum-definition.hbs
+++ b/crates/wick/wick-config/definitions/v1/doc-templates/rust/partials/enum-definition.hbs
@@ -3,6 +3,7 @@
 
 
 | Field name | Type | Description |
+|------------|------|-------------|
 {{#each values}}
 | {{name.value}} | {{> expand-type type}} | {{description.value}} |
 {{/each}}

--- a/crates/wick/wick-config/docs/v1.md
+++ b/crates/wick/wick-config/docs/v1.md
@@ -1524,6 +1524,7 @@ Any one of the following types:
 
 
 | Field name | Type | Description |
+|------------|------|-------------|
 | Commit | unknown type | The operation will commit what has succeeded. |
 | Rollback | unknown type | The operation will rollback changes. |
 | Ignore | unknown type | Errors will be ignored. |
@@ -1584,6 +1585,7 @@ Any one of the following types:
 
 
 | Field name | Type | Description |
+|------------|------|-------------|
 | Json | unknown type | JSON data |
 | Raw | unknown type | Raw |
 | FormData | unknown type | Form Data |
@@ -1602,6 +1604,7 @@ Any one of the following types:
 
 
 | Field name | Type | Description |
+|------------|------|-------------|
 | Get | unknown type | GET method |
 | Post | unknown type | POST method |
 | Put | unknown type | PUT method |

--- a/docs/content/configuration/reference/v1.md
+++ b/docs/content/configuration/reference/v1.md
@@ -1524,6 +1524,7 @@ Any one of the following types:
 
 
 | Field name | Type | Description |
+|------------|------|-------------|
 | Commit | unknown type | The operation will commit what has succeeded. |
 | Rollback | unknown type | The operation will rollback changes. |
 | Ignore | unknown type | Errors will be ignored. |
@@ -1584,6 +1585,7 @@ Any one of the following types:
 
 
 | Field name | Type | Description |
+|------------|------|-------------|
 | Json | unknown type | JSON data |
 | Raw | unknown type | Raw |
 | FormData | unknown type | Form Data |
@@ -1602,6 +1604,7 @@ Any one of the following types:
 
 
 | Field name | Type | Description |
+|------------|------|-------------|
 | Get | unknown type | GET method |
 | Post | unknown type | POST method |
 | Put | unknown type | PUT method |


### PR DESCRIPTION
The markdown generation for enums was broken. This PR fixes it.