### PR TITLE
Added number type as an alias to i64

### DIFF
--- a/crates/wick/wick-interface-types/src/parser.rs
+++ b/crates/wick/wick-interface-types/src/parser.rs
@@ -104,6 +104,7 @@ fn typename(input: &str) -> IResult<&str, Type> {
     "u16" => Type::U16,
     "u32" => Type::U32,
     "u64" => Type::U64,
+    "number" => Type::I64,
     "f32" => Type::F32,
     "f64" => Type::F64,
     "bytes" => Type::Bytes,
@@ -264,6 +265,7 @@ mod test {
   #[case("i16", Type::I16)]
   #[case("i32", Type::I32)]
   #[case("i64", Type::I64)]
+  #[case("number", Type::I64)]
   #[case("u8", Type::U8)]
   #[case("u16", Type::U16)]
   #[case("u32", Type::U32)]

--- a/crates/wick/wick-interface-types/src/types.rs
+++ b/crates/wick/wick-interface-types/src/types.rs
@@ -1,5 +1,5 @@
 #![allow(deprecated)]
-
+#[cfg(feature = "typeid")]
 use std::any::TypeId;
 use std::error::Error;
 use std::str::FromStr;


### PR DESCRIPTION
The interface-types parser will now parse the type name "number" as "i64"