### PR TITLE
Fixed: silenced errors from hushed modules & {{ ctx.root_config }} access in operations

### DIFF
--- a/crates/wick/flow-graph-interpreter/src/interpreter/event_loop/state.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/event_loop/state.rs
@@ -75,18 +75,14 @@ impl State {
     mut transaction: Transaction,
     options: &InterpreterOptions,
   ) -> Result<(), ExecutionError> {
-    let result = match transaction.start(options).await {
+    match transaction.start(options).await {
       Ok(_) => {
         self.transactions.init_tx(transaction.id(), transaction);
+        trace!("transaction started");
         Ok(())
       }
-      Err(e) => {
-        error!(tx_error = %e);
-        Err(e)
-      }
-    };
-    trace!("transaction started");
-    result
+      Err(e) => Err(e),
+    }
   }
 
   #[allow(clippy::unused_async)]
@@ -103,7 +99,7 @@ impl State {
     let tx = match self.get_tx(&tx_id) {
       Ok(tx) => tx,
       Err(e) => {
-        error!(
+        debug!(
           port = %port, error=%e, "error handling port input"
         );
         return Err(e);
@@ -137,7 +133,7 @@ impl State {
     let tx = match self.get_tx(&tx_id) {
       Ok(tx) => tx,
       Err(e) => {
-        error!(
+        debug!(
           port = %port, error=%e, "error handling port output"
         );
         return Err(e);

--- a/crates/wick/flow-graph-interpreter/src/interpreter/executor/transaction/operation.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/executor/transaction/operation.rs
@@ -173,14 +173,7 @@ impl InstanceHandler {
       let current_status = port.status();
 
       let new_status = match current_status {
-        PortStatus::Open => {
-          // Note: A port can still be "Open" after a call if the operation panics.
-          // if port.is_empty() {
-          //   PortStatus::DoneClosed
-          // } else {
-          PortStatus::DoneClosing
-          // }
-        }
+        PortStatus::Open => PortStatus::UpstreamComplete,
         orig => orig,
       };
 
@@ -219,7 +212,11 @@ impl InstanceHandler {
     let namespace = self.namespace().to_owned();
 
     let mut associated_data = self.schematic.nodes()[self.index()].data().clone();
-    associated_data.config.set_root(config.root().cloned());
+
+    if associated_data.config.root().is_none() {
+      associated_data.config.set_root(config.root().cloned());
+    }
+
     if associated_data.config.value().is_none() {
       associated_data.config.set_value(config.value().cloned());
     }

--- a/crates/wick/flow-graph-interpreter/src/interpreter/executor/transaction/operation/port.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/executor/transaction/operation/port.rs
@@ -15,6 +15,7 @@ pub(crate) enum PortStatus {
   Open,
   DoneClosing,
   DoneClosed,
+  UpstreamComplete,
 }
 
 impl PortStatus {
@@ -45,6 +46,7 @@ impl std::fmt::Display for PortStatus {
         PortStatus::Open => "Open",
         PortStatus::DoneClosing => "DoneClosing",
         PortStatus::DoneClosed => "DoneClosed",
+        PortStatus::UpstreamComplete => "UpstreamComplete",
       }
     )
   }


### PR DESCRIPTION
The logger wasn't properly propagating warning or error messages from the chatty modules. This PR fixes it and fixes an issue where `root_config` was being erased before populating operation instance configuation
