### PR TITLE
Added ability to pass `with` config to switch cases

### DIFF
--- a/crates/wick/flow-graph-interpreter/src/graph.rs
+++ b/crates/wick/flow-graph-interpreter/src/graph.rs
@@ -1,10 +1,12 @@
 pub mod types {
+  #![allow(unused)]
   use super::AssociatedData;
 
   pub(crate) type Network = flow_graph::Network<AssociatedData>;
   pub(crate) type Operation = flow_graph::Node<AssociatedData>;
   pub(crate) type OperationPort = flow_graph::NodePort;
   pub(crate) type Schematic = flow_graph::Schematic<AssociatedData>;
+  pub(crate) type Node = flow_graph::Node<AssociatedData>;
   pub(crate) type Port<'a> = flow_graph::iterators::Port<'a, AssociatedData>;
 }
 use std::collections::HashMap;
@@ -363,8 +365,6 @@ pub fn from_def(
       register_operation(vec![], &mut network, flow, &op_config)?;
     }
   }
-
-  trace!(graph=?network,"initialized graph");
 
   Ok(network)
 }

--- a/crates/wick/flow-graph-interpreter/src/interpreter.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter.rs
@@ -87,12 +87,14 @@ impl Interpreter {
       }
       handler.component.signature().clone()
     });
-    handlers.add_core(&network)?;
+
     handlers.add(NamespaceHandler::new(NS_NULL, Box::new(NullComponent::new())))?;
 
     // Add the component:: component
     let component_component = ComponentComponent::new(&handlers);
     handlers.add(NamespaceHandler::new(NS_COMPONENTS, Box::new(component_component)))?;
+
+    handlers.add_core(&network)?;
 
     let mut signatures = handlers.component_signatures();
     program::generate_self_signature(&network, &mut signatures).map_err(Error::EarlyError)?;

--- a/crates/wick/flow-graph-interpreter/src/interpreter/components.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/components.rs
@@ -51,7 +51,10 @@ impl HandlerMap {
   }
 
   pub(crate) fn add_core(&mut self, network: &Network) -> Result<(), InterpreterError> {
-    self.add(NamespaceHandler::new(NS_CORE, Box::new(CoreCollection::new(network)?)))
+    self.add(NamespaceHandler::new(
+      NS_CORE,
+      Box::new(CoreCollection::new(network, self)?),
+    ))
   }
 
   #[must_use]

--- a/crates/wick/flow-graph-interpreter/src/interpreter/components/core_collection.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/components/core_collection.rs
@@ -5,7 +5,7 @@ use wick_packet::{Invocation, PacketStream, RuntimeConfig};
 use crate::constants::*;
 use crate::graph::types::Network;
 use crate::interpreter::components::dyn_component_id;
-use crate::BoxFuture;
+use crate::{BoxFuture, HandlerMap};
 
 mod merge;
 mod pluck;
@@ -58,7 +58,7 @@ impl std::fmt::Display for DynamicOperation {
 }
 
 impl CoreCollection {
-  pub(crate) fn new(graph: &Network) -> Result<Self, OpInitError> {
+  pub(crate) fn new(graph: &Network, handlers: &HandlerMap) -> Result<Self, OpInitError> {
     let mut this = Self {
       signature: ComponentSignature::new(NS_CORE).version("0.0.0"),
       pluck: pluck::Op::new(),
@@ -106,7 +106,7 @@ impl CoreCollection {
           },
           DynamicOperation::Switch => match switch::Op::decode_config(config) {
             Ok(config) => {
-              let op_sig = this.switch.gen_signature(graph, config);
+              let op_sig = this.switch.gen_signature(schematic, graph, handlers, config);
 
               this.signature.operations.push(op_sig);
               Ok(())

--- a/crates/wick/flow-graph-interpreter/src/utils.rs
+++ b/crates/wick/flow-graph-interpreter/src/utils.rs
@@ -1,6 +1,9 @@
 use wick_packet::Entity;
 
 pub(crate) fn path_to_entity(path: &str) -> Result<Entity, &str> {
-  let (path, op) = path.split_once("::").ok_or(path)?;
-  Ok(Entity::operation(path, op))
+  Ok(
+    path
+      .split_once("::")
+      .map_or_else(|| Entity::local(path), |(path, op)| Entity::operation(path, op)),
+  )
 }

--- a/crates/wick/flow-graph-interpreter/tests/manifests/v1/core-switch.yaml
+++ b/crates/wick/flow-graph-interpreter/tests/manifests/v1/core-switch.yaml
@@ -4,7 +4,23 @@ metadata:
   version: '0.0.2'
 component:
   kind: wick/component/composite@v1
+  with:
+    - name: greeting
+      type: string
   operations:
+    - name: greet
+      with:
+        - name: greeting
+          type: string
+      uses:
+        - name: sender
+          operation: core::sender
+          with:
+            output: '{{ctx.config.greeting}}'
+      flow:
+        - <>.message -> test::concat[a].right
+        - sender.output -> a.left
+        - a.output -> <>.output
     - name: test
       uses:
         - name: s
@@ -17,8 +33,10 @@ component:
               - name: output
                 type: string
             cases:
-              - case: want_reverse
-                do: self::test::reverse
+              - case: want_greeting
+                do: self::greet
+                with:
+                  greeting: '{{ctx.root_config.greeting}}, '
               - case: want_uppercase
                 do: self::test::uppercase
             default: self::test::default

--- a/crates/wick/flow-graph/src/node.rs
+++ b/crates/wick/flow-graph/src/node.rs
@@ -84,7 +84,7 @@ impl std::fmt::Display for NodeKind {
   }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Eq)]
 #[must_use]
 pub struct Node<DATA> {
   pub name: String,

--- a/crates/wick/flow-graph/src/schematic.rs
+++ b/crates/wick/flow-graph/src/schematic.rs
@@ -132,6 +132,24 @@ where
   }
 
   #[must_use]
+  pub fn used_nodes(&self) -> Vec<&Node<DATA>> {
+    let mut nodes_connected_to_input: HashMap<String, _> = SchematicWalker::new_from_input(self)
+      .filter_map(|hop| match hop {
+        iterators::SchematicHop::Node(n) => Some((n.name().to_owned(), n.inner())),
+        _ => None,
+      })
+      .collect();
+    let nodes_connected_to_output: HashMap<String, _> = SchematicWalker::new_from_output(self)
+      .filter_map(|hop| match hop {
+        iterators::SchematicHop::Node(n) => Some((n.name().to_owned(), n.inner())),
+        _ => None,
+      })
+      .collect();
+    nodes_connected_to_input.extend(nodes_connected_to_output);
+    nodes_connected_to_input.into_values().collect()
+  }
+
+  #[must_use]
   pub fn get(&self, index: NodeIndex) -> Option<&Node<DATA>> {
     self.nodes.get(index)
   }

--- a/crates/wick/flow-graph/src/schematic/iterators/node.rs
+++ b/crates/wick/flow-graph/src/schematic/iterators/node.rs
@@ -59,7 +59,7 @@ where
     self.index
   }
 
-  pub fn inner(&self) -> &Node<DATA> {
+  pub fn inner(&self) -> &'graph Node<DATA> {
     &self.schematic.nodes[self.index]
   }
 


### PR DESCRIPTION
This PR adds the ability to specify `with: ` config for the operations in switch cases. It also fixes referring to operations other than those referenced by `self::`.