### PR TITLE
Added `ctx.inherent.timestamp`, improved error message output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1688,6 +1688,7 @@ name = "flow-graph-interpreter"
 version = "0.20.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "flow-component",
  "flow-expression-parser",
  "flow-graph",

--- a/crates/bins/wick/src/utils.rs
+++ b/crates/bins/wick/src/utils.rs
@@ -110,7 +110,7 @@ pub(crate) fn parse_config_string(source: Option<&str>) -> anyhow::Result<Option
         .map_err(|e| anyhow::anyhow!("Failed to parse config argument as JSON: {}", e))?;
       let config: LiquidJsonConfig = config.into();
       let rendered = config
-        .render(None, None, Some(&std::env::vars().collect::<HashMap<_, _>>()))
+        .render(None, None, Some(&std::env::vars().collect::<HashMap<_, _>>()), None)
         .map_err(|e| anyhow::anyhow!("Failed to parse config: {}", e))?;
       trace!(config=?rendered, "rendered config");
       Some(rendered)

--- a/crates/components/wick-http-client/src/error.rs
+++ b/crates/components/wick-http-client/src/error.rs
@@ -1,4 +1,5 @@
 use flow_component::ComponentError;
+use url::Url;
 
 #[derive(thiserror::Error, Debug, PartialEq)]
 pub enum Error {
@@ -13,6 +14,9 @@ pub enum Error {
 
   #[error("Could not find operation {0} on this component")]
   OpNotFound(String),
+
+  #[error("Invalid baseurl: {0}")]
+  InvalidBaseUrl(Url),
 }
 
 impl From<Error> for ComponentError {

--- a/crates/wick/flow-graph-interpreter/Cargo.toml
+++ b/crates/wick/flow-graph-interpreter/Cargo.toml
@@ -38,3 +38,4 @@ anyhow = { workspace = true }
 serde_json = { workspace = true }
 pretty_assertions = { workspace = true }
 wick-packet = { workspace = true, features = ["test"] }
+chrono = { workspace = true }

--- a/crates/wick/flow-graph-interpreter/src/graph.rs
+++ b/crates/wick/flow-graph-interpreter/src/graph.rs
@@ -51,11 +51,11 @@ impl LiquidOperationConfig {
     }
   }
 
-  pub fn render(&self) -> Result<Option<RuntimeConfig>, InterpreterError> {
+  pub fn render(&self, inherent: &InherentData) -> Result<Option<RuntimeConfig>, InterpreterError> {
     if let Some(template) = self.template() {
       Ok(Some(
         template
-          .render(self.root.as_ref(), self.value.as_ref(), None)
+          .render(self.root.as_ref(), self.value.as_ref(), None, Some(inherent))
           .map_err(|e| InterpreterError::Configuration(e.to_string()))?,
       ))
     } else {
@@ -124,7 +124,7 @@ use serde_json::Value;
 use types::*;
 use wick_config::config::components::{ComponentConfig, OperationConfig};
 use wick_config::config::{ComponentImplementation, ExecutionSettings, FlowOperation, LiquidJsonConfig};
-use wick_packet::RuntimeConfig;
+use wick_packet::{InherentData, RuntimeConfig};
 
 use crate::constants::{NS_CORE, NS_NULL};
 use crate::error::InterpreterError;

--- a/crates/wick/flow-graph-interpreter/src/interpreter/components/core_collection.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/components/core_collection.rs
@@ -1,6 +1,6 @@
 use flow_component::{Component, ComponentError, Context, Operation, RenderConfiguration, RuntimeCallback};
 use wick_interface_types::{ComponentSignature, TypeDefinition};
-use wick_packet::{Invocation, PacketStream, RuntimeConfig};
+use wick_packet::{InherentData, Invocation, PacketStream, RuntimeConfig};
 
 use crate::constants::*;
 use crate::graph::types::Network;
@@ -88,7 +88,7 @@ impl CoreCollection {
           .data()
           .config
           .clone()
-          .render()
+          .render(&InherentData::unsafe_default()) // this is a first pass render to extract details so using unsafe_default should be OK.
           .map_err(|e| OpInitError::new(ComponentError::new(e), op))?;
 
         let result = match op {

--- a/crates/wick/flow-graph-interpreter/src/interpreter/executor/transaction/operation.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/executor/transaction/operation.rs
@@ -223,7 +223,7 @@ impl InstanceHandler {
 
     let config = associated_data
       .config
-      .render()
+      .render(&invocation.inherent)
       .map_err(|e| ExecutionError::ComponentError(ComponentError::new(e)))?;
 
     let timeout = associated_data

--- a/crates/wick/flow-graph-interpreter/tests/components.rs
+++ b/crates/wick/flow-graph-interpreter/tests/components.rs
@@ -1,6 +1,7 @@
 mod test;
 
 use std::collections::HashMap;
+use std::time::SystemTime;
 
 use anyhow::Result;
 use flow_component::Component;
@@ -98,7 +99,10 @@ async fn test_context_passing() -> Result<()> {
 
   let _wrapper = outputs.pop().unwrap(); //done signal
   let wrapper = outputs.pop().unwrap();
-  let expected = Packet::encode("output", "Hello, World! This works!");
+  let time = wick_packet::DateTime::from(SystemTime::now());
+  use chrono::Datelike;
+
+  let expected = Packet::encode("output", format!("Hello, World! Happy {}! This works!", time.year()));
 
   assert_eq!(wrapper.unwrap(), expected);
   interpreter.shutdown().await?;

--- a/crates/wick/flow-graph-interpreter/tests/manifests/v1/component-context-vars.yaml
+++ b/crates/wick/flow-graph-interpreter/tests/manifests/v1/component-context-vars.yaml
@@ -17,7 +17,7 @@ component:
         - name: GREET
           operation: self::greet
           with:
-            greeting: '{{ ctx.root_config.component_config_greeting }}, {{ ctx.config.op_config_name }}! '
+            greeting: '{{ ctx.root_config.component_config_greeting }}, {{ ctx.config.op_config_name }}! Happy {{ ctx.inherent.timestamp | date: "%Y" }}! '
       inputs:
         - name: input
           type: string

--- a/crates/wick/wick-component-codegen/src/generate/dependency.rs
+++ b/crates/wick/wick-component-codegen/src/generate/dependency.rs
@@ -39,10 +39,7 @@ impl ToTokens for Dependency {
       }
       Dependency::WickPacket => tokens.extend(quote! { pub use wick_component::packet as wick_packet; }),
       Dependency::SerdeJson => tokens.extend(quote! {
-        #[cfg(target_family="wasm")]
-        pub use wick_component::wasmrs_guest::Value;
-        #[cfg(not(target_family="wasm"))]
-        pub use serde_json::Value;
+        pub use wick_component::Value;
       }),
       Dependency::Bytes => tokens.extend(quote! { pub use wick_component::Bytes; }),
       Dependency::AsyncTrait => tokens.extend(quote! { pub use async_trait::async_trait; }),

--- a/crates/wick/wick-component-codegen/src/generate/f.rs
+++ b/crates/wick/wick-component-codegen/src/generate/f.rs
@@ -92,7 +92,7 @@ pub(crate) fn default_val() -> impl FnMut(Option<&Value>) -> TokenStream {
 
 fn from_json(value: &Value) -> TokenStream {
   let json_str = serde_json::to_string(&value).unwrap();
-  quote! {serde_json::from_str(#json_str).unwrap()}
+  quote! {wick_component::from_str(#json_str).unwrap()}
 }
 
 #[allow(clippy::needless_pass_by_value)]

--- a/crates/wick/wick-component-codegen/src/generate/templates/wrapper_fn.rs
+++ b/crates/wick/wick-component-codegen/src/generate/templates/wrapper_fn.rs
@@ -50,9 +50,15 @@ pub(crate) fn gen_wrapper_fn(config: &mut config::Config, component: &Ident, op:
           Ok(Ok(config)) => {
             config
           },
-          _ => {
+          Err(e) => {
             let _ = channel.send_result(
-              wick_packet::Packet::component_error("Component sent invalid context").into(),
+              wick_packet::Packet::component_error(format!("Component sent invalid context: {}", e)).into(),
+            );
+            return;
+          }
+          Ok(Err(e)) => {
+            let _ = channel.send_result(
+              wick_packet::Packet::component_error(format!("Component sent invalid context: {}", e)).into(),
             );
             return;
           }

--- a/crates/wick/wick-component/src/macros.rs
+++ b/crates/wick/wick-component/src/macros.rs
@@ -132,7 +132,7 @@ macro_rules! payload_fan_out {
               let mut packet: $crate::packet::Packet = payload.into();
               if let Some(config_tx) = config_tx.take() {
                 if let Some(context) = packet.context() {
-                  let config: Result<$crate::packet::ContextTransport<$config>, _> = $crate::wasmrs_codec::messagepack::deserialize(&context).map_err(|_e|$crate::flow_component::ComponentError::message("Cound not deserialize Context"));
+                  let config: Result<$crate::packet::ContextTransport<$config>, _> = $crate::wasmrs_codec::messagepack::deserialize(&context).map_err(|e|$crate::flow_component::ComponentError::message(&format!("Cound not deserialize context: {}", e)));
                   let _ = config_tx.send(config.map($crate::flow_component::Context::from));
                 } else {
                   packet = $crate::packet::Packet::component_error("No context attached to first invocation packet");

--- a/crates/wick/wick-config/Cargo.toml
+++ b/crates/wick/wick-config/Cargo.toml
@@ -11,7 +11,8 @@ version = "0.26.0"
 flow-component = { workspace = true }
 flow-expression-parser = { workspace = true }
 wick-packet = { workspace = true, default-features = false, features = [
-  "validation"
+  "validation",
+  "std"
 ] }
 wick-interface-types = { workspace = true, features = ["yaml", "parser"] }
 wick-asset-reference = { workspace = true }

--- a/crates/wick/wick-config/src/config/common/component_definition.rs
+++ b/crates/wick/wick-config/src/config/common/component_definition.rs
@@ -174,7 +174,7 @@ impl ComponentDefinition {
     env: Option<&HashMap<String, String>>,
   ) -> Result<(), ManifestError> {
     let val = if let Some(config) = self.config() {
-      Some(config.render(root_config, None, env)?)
+      Some(config.render(root_config, None, env, None)?)
     } else {
       None
     };

--- a/crates/wick/wick-config/src/config/common/template_config.rs
+++ b/crates/wick/wick-config/src/config/common/template_config.rs
@@ -109,7 +109,8 @@ where
     if let Some(value) = &self.value {
       return Ok(value.clone());
     }
-    let ctx = debug_span!("template-config").in_scope(|| LiquidJsonConfig::make_context(None, root, None, env))?;
+    let ctx =
+      debug_span!("template-config").in_scope(|| LiquidJsonConfig::make_context(None, root, None, env, None))?;
 
     if let Some(template) = &self.template {
       let rendered = template

--- a/crates/wick/wick-packet/Cargo.toml
+++ b/crates/wick/wick-packet/Cargo.toml
@@ -22,7 +22,7 @@ rt-tokio = ["tokio/rt"]
 datetime = ["chrono"]
 validation = []
 rng = ["seeded-random/rng"]
-std = ["seeded-random/std"]
+std = ["seeded-random/std", "chrono/std"]
 test = ["invocation", "std"]
 
 [dependencies]
@@ -53,7 +53,7 @@ uuid = { workspace = true, features = ["v4", "serde"], optional = true }
 #
 # feature = datetime
 chrono = { workspace = true, optional = true, features = [
-  "serde"
+  "serde",
 ], default-features = false }
 
 [target.'cfg(target_family = "wasm")'.dependencies]

--- a/crates/wick/wick-packet/src/error.rs
+++ b/crates/wick/wick-packet/src/error.rs
@@ -7,13 +7,13 @@ pub enum Error {
   #[error("No stream found for port '{0}'")]
   PortMissing(String),
 
-  /// Error serializing payload.
-  #[error("Error serializing payload: {1} (payload was: {:?})",.0)]
-  Encode(Vec<u8>, String),
-
   /// Error deserializing payload.
-  #[error("Error deserializing payload: {1} (payload was: {:?})",.0)]
-  Decode(Vec<u8>, String),
+  #[error("Error deserializing payload '{}': {} (raw payload was: {:?})",.as_json,.error,.payload)]
+  Decode {
+    as_json: String,
+    payload: Vec<u8>,
+    error: String,
+  },
 
   /// Error converting payload into JSON.
   #[error("Error JSON-ifying payload: {0}")]

--- a/crates/wick/wick-test/src/runner.rs
+++ b/crates/wick/wick-test/src/runner.rs
@@ -50,7 +50,7 @@ async fn run_unit<'a>(
   root_config: Option<RuntimeConfig>,
 ) -> Result<TestBlock, TestError> {
   let span = debug_span!("unit test", name = def.test.name());
-  let op_config = render_config(def.test.config())?;
+  let op_config = render_config(def.test.config(), None)?;
   let signature = component
     .signature()
     .get_operation(def.test.operation())

--- a/crates/wick/wick-test/src/test_suite.rs
+++ b/crates/wick/wick-test/src/test_suite.rs
@@ -26,7 +26,7 @@ impl<'a> TestSuite<'a> {
       .iter()
       .map(|config| {
         Ok(TestGroup::from_test_cases(
-          render_config(config.config())?,
+          render_config(config.config(), None)?,
           config.cases(),
         ))
       })
@@ -39,7 +39,7 @@ impl<'a> TestSuite<'a> {
     'b: 'a,
   {
     self.tests.push(TestGroup::from_test_cases(
-      render_config(config.config())?,
+      render_config(config.config(), None)?,
       config.cases(),
     ));
     Ok(())


### PR DESCRIPTION
Propagated the timestamp to `ctx.inherent` in configuration templates (in a string format that liquid templates would treat as a date). 

Adjusted some errors that make troubleshooting the HTTP client easier during the process.