### PR TITLE
Surfaced errors from sql server data conversion

### DIFF
--- a/crates/components/wick-sql/src/common/sql_wrapper.rs
+++ b/crates/components/wick-sql/src/common/sql_wrapper.rs
@@ -1,5 +1,6 @@
 use wick_packet::TypeWrapper;
 
+/// [SqlWrapper] is a generic wrapper struct that can implement DB-specific traits.
 #[derive(Debug, Clone)]
 pub(crate) struct SqlWrapper(pub(crate) TypeWrapper);
 

--- a/crates/components/wick-sql/src/error.rs
+++ b/crates/components/wick-sql/src/error.rs
@@ -1,5 +1,8 @@
 use flow_component::ComponentError;
 use wick_config::error::ManifestError;
+use wick_packet::TypeWrapper;
+
+use crate::mssql_tiberius::sql_wrapper::MsSqlConversionError;
 
 #[derive(thiserror::Error, Debug)]
 #[allow(missing_docs)]
@@ -54,6 +57,9 @@ pub enum Error {
 
   #[error("Could not find a value for input '{0}' to bind to a positional argument")]
   MissingPacket(String),
+
+  #[error("Could not encode wick type {} with value '{}' into the DB's type for {1}. Try a different value, type, or coersion within the SQL query.",.0.type_signature(),.0.inner())]
+  SqlServerEncodingFault(TypeWrapper, MsSqlConversionError),
 
   #[error(transparent)]
   ComponentError(wick_packet::Error),

--- a/crates/components/wick-sql/src/mssql_tiberius/component.rs
+++ b/crates/components/wick-sql/src/mssql_tiberius/component.rs
@@ -17,7 +17,7 @@ use wick_config::{ConfigValidation, Resolver};
 use wick_interface_types::{ComponentSignature, Field, OperationSignatures, Type};
 use wick_packet::{FluxChannel, Invocation, Observer, Packet, PacketSender, PacketStream, RuntimeConfig};
 
-use super::sql_wrapper::FromSqlWrapper;
+use super::sql_wrapper::{FromSqlWrapper, MsSqlWrapper};
 use crate::{common, Error};
 
 #[derive()]
@@ -252,8 +252,9 @@ async fn exec(
 
   #[allow(trivial_casts)]
   let mut query = Query::new(&stmt.1);
+
   for param in bound_args {
-    query.bind(param);
+    query.bind(MsSqlWrapper::try_from(&param).map_err(|e| Error::SqlServerEncodingFault(param.0, e))?);
   }
 
   let mut result = query.query(client).await.map_err(|e| Error::Failed(e.to_string()))?;

--- a/crates/components/wick-sql/src/mssql_tiberius/sql_wrapper.rs
+++ b/crates/components/wick-sql/src/mssql_tiberius/sql_wrapper.rs
@@ -5,79 +5,177 @@ use wick_packet::{parse_date, TypeWrapper};
 
 use crate::common::sql_wrapper::SqlWrapper;
 
-impl<'a> IntoSql<'a> for SqlWrapper {
-  fn into_sql(self) -> ColumnData<'a> {
-    let ty = self.0.type_signature().clone();
-    let v = self.0.into_inner();
+#[allow(unused)]
+#[derive(thiserror::Error, Debug, Copy, Clone)]
+pub enum MsSqlConversionError {
+  #[error("i8")]
+  I8,
+  #[error("i16")]
+  I16,
+  #[error("i32")]
+  I32,
+  #[error("i64")]
+  I64,
+  #[error("u8")]
+  U8,
+  #[error("u16")]
+  U16,
+  #[error("u32")]
+  U32,
+  #[error("u64")]
+  U64,
+  #[error("f32")]
+  F32,
+  #[error("f64")]
+  F64,
+  #[error("bool")]
+  Bool,
+  #[error("string")]
+  String,
+  #[error("datetime")]
+  Datetime,
+  #[error("bytes")]
+  Bytes,
+  #[error("named")]
+  Named,
+  #[error("list")]
+  List,
+  #[error("optional")]
+  Optional,
+  #[error("map")]
+  Map,
+  #[error("link")]
+  Link,
+  #[error("object")]
+  Object,
+  #[error("anonymous struct")]
+  AnonymousStruct,
+}
 
-    match ty {
-      wick_interface_types::Type::I8 => {
-        let v = to_int::<i16>(&v).unwrap();
-        v.into_sql()
-      }
-      wick_interface_types::Type::I16 => to_int::<i16>(&v).unwrap().into_sql(),
-      wick_interface_types::Type::I32 => to_int::<i32>(&v).unwrap().into_sql(),
-      wick_interface_types::Type::I64 => to_int::<i64>(&v).unwrap().into_sql(),
-      wick_interface_types::Type::U8 => to_uint::<u8>(&v).unwrap().into_sql(),
-      wick_interface_types::Type::U16 => to_int::<i16>(&v).unwrap().into_sql(),
-      wick_interface_types::Type::U32 => to_int::<i32>(&v).unwrap().into_sql(),
-      wick_interface_types::Type::U64 => to_int::<i64>(&v).unwrap().into_sql(),
-      wick_interface_types::Type::F32 => v.as_f64().unwrap().into_sql(),
-      wick_interface_types::Type::F64 => v.as_f64().unwrap().into_sql(),
-      wick_interface_types::Type::Bool => v.as_bool().unwrap().into_sql(),
-      wick_interface_types::Type::String => v.as_str().unwrap().to_owned().into_sql(),
-      wick_interface_types::Type::Datetime => parse_date(v.as_str().unwrap()).unwrap().into_sql(),
-      wick_interface_types::Type::Bytes => unimplemented!("Bytes are not supported yet."),
-      wick_interface_types::Type::Named(_) => unimplemented!("Custom types are not supported yet."),
-      wick_interface_types::Type::List { .. } => unimplemented!("Lists are not supported yet."),
-      wick_interface_types::Type::Optional { ty } => match v {
-        Value::Null => match *ty {
-          // This satisfies types but may be optimizable into one generic call
-          // if tiberius doesn't do anything type-specific with the impls underneath.
-          wick_interface_types::Type::I8 => None::<i16>.into_sql(),
-          wick_interface_types::Type::I16 => None::<i16>.into_sql(),
-          wick_interface_types::Type::I32 => None::<i32>.into_sql(),
-          wick_interface_types::Type::I64 => None::<i64>.into_sql(),
-          wick_interface_types::Type::U8 => None::<u8>.into_sql(),
-          wick_interface_types::Type::U16 => None::<i16>.into_sql(),
-          wick_interface_types::Type::U32 => None::<i32>.into_sql(),
-          wick_interface_types::Type::U64 => None::<i64>.into_sql(),
-          wick_interface_types::Type::F32 => None::<f32>.into_sql(),
-          wick_interface_types::Type::F64 => None::<f64>.into_sql(),
-          wick_interface_types::Type::Bool => None::<bool>.into_sql(),
-          wick_interface_types::Type::String => None::<String>.into_sql(),
-          wick_interface_types::Type::Datetime => None::<wick_packet::DateTime>.into_sql(),
-          _ => None::<i16>.into_sql(), // Delegating to generic impl as a test.
-        },
-        _ => SqlWrapper(TypeWrapper::new(*ty, v)).into_sql(),
-      },
-      wick_interface_types::Type::Map { .. } => unimplemented!("Maps are not supported yet."),
-      #[allow(deprecated)]
-      wick_interface_types::Type::Link { .. } => unimplemented!("Links are not supported yet."),
-      wick_interface_types::Type::Object => unimplemented!("Objects are not supported yet."),
-      wick_interface_types::Type::AnonymousStruct(_) => {
-        unimplemented!("Anonymous structs are not supported yet.")
-      }
+// The converted types that we *know* we can encode into SQL.
+pub(super) enum MsSqlWrapper {
+  I8(Option<i16>),
+  I16(Option<i16>),
+  I32(Option<i32>),
+  I64(Option<i64>),
+  U8(Option<u8>),
+  U16(Option<i32>),
+  U32(Option<i64>),
+  U64(Option<i64>),
+  F32(Option<f32>),
+  F64(Option<f64>),
+  Bool(Option<bool>),
+  String(Option<String>),
+  Datetime(Option<DateTime<Utc>>),
+}
+
+impl<'a> IntoSql<'a> for MsSqlWrapper {
+  fn into_sql(self) -> ColumnData<'a> {
+    match self {
+      MsSqlWrapper::I8(v) => v.into_sql(),
+      MsSqlWrapper::I16(v) => v.into_sql(),
+      MsSqlWrapper::I32(v) => v.into_sql(),
+      MsSqlWrapper::I64(v) => v.into_sql(),
+      MsSqlWrapper::U8(v) => v.into_sql(),
+      MsSqlWrapper::U16(v) => v.into_sql(),
+      MsSqlWrapper::U32(v) => v.into_sql(),
+      MsSqlWrapper::U64(v) => v.into_sql(),
+      MsSqlWrapper::F32(v) => v.into_sql(),
+      MsSqlWrapper::F64(v) => v.into_sql(),
+      MsSqlWrapper::Bool(v) => v.into_sql(),
+      MsSqlWrapper::String(v) => v.into_sql(),
+      MsSqlWrapper::Datetime(v) => v.into_sql(),
     }
   }
 }
 
-fn to_int<T>(v: &Value) -> Result<T, T::Error>
-where
-  T: TryFrom<i64>,
-  T::Error: std::fmt::Debug,
-  T: std::fmt::Debug,
-{
-  v.as_i64().unwrap().try_into()
+impl TryFrom<&SqlWrapper> for MsSqlWrapper {
+  type Error = MsSqlConversionError;
+
+  fn try_from(wrapper: &SqlWrapper) -> Result<Self, Self::Error> {
+    convert(wrapper)
+  }
 }
 
-fn to_uint<T>(v: &Value) -> Result<T, T::Error>
+fn convert(wrapper: &SqlWrapper) -> Result<MsSqlWrapper, MsSqlConversionError> {
+  let ty = wrapper.0.type_signature().clone();
+  let v = wrapper.0.inner();
+
+  let data = match ty {
+    wick_interface_types::Type::I8 => MsSqlWrapper::I16(Some(to_int::<i16>(v)?)),
+    wick_interface_types::Type::I16 => MsSqlWrapper::I16(Some(to_int::<i16>(v)?)),
+    wick_interface_types::Type::I32 => MsSqlWrapper::I32(Some(to_int::<i32>(v)?)),
+    wick_interface_types::Type::I64 => MsSqlWrapper::I64(Some(to_int::<i64>(v)?)),
+    wick_interface_types::Type::U8 => MsSqlWrapper::U8(Some(to_uint::<u8>(v)?)),
+    wick_interface_types::Type::U16 => MsSqlWrapper::I16(Some(to_int::<i16>(v)?)),
+    wick_interface_types::Type::U32 => MsSqlWrapper::I32(Some(to_int::<i32>(v)?)),
+    wick_interface_types::Type::U64 => MsSqlWrapper::I64(Some(to_int::<i64>(v)?)),
+    wick_interface_types::Type::F32 => MsSqlWrapper::F64(Some(v.as_f64().ok_or(MsSqlConversionError::F64)?)),
+    wick_interface_types::Type::F64 => MsSqlWrapper::F64(Some(v.as_f64().ok_or(MsSqlConversionError::F64)?)),
+    wick_interface_types::Type::Bool => MsSqlWrapper::Bool(Some(v.as_bool().ok_or(MsSqlConversionError::Bool)?)),
+    wick_interface_types::Type::String => {
+      MsSqlWrapper::String(Some(v.as_str().ok_or(MsSqlConversionError::String)?.to_owned()))
+    }
+    wick_interface_types::Type::Datetime => MsSqlWrapper::Datetime(Some(
+      parse_date(v.as_str().ok_or(MsSqlConversionError::Datetime)?).map_err(|_| MsSqlConversionError::Datetime)?,
+    )),
+    wick_interface_types::Type::Bytes => return Err(MsSqlConversionError::Bytes),
+    wick_interface_types::Type::Named(_) => return Err(MsSqlConversionError::Named),
+    wick_interface_types::Type::List { .. } => return Err(MsSqlConversionError::List),
+    wick_interface_types::Type::Optional { ty } => {
+      if v.is_null() {
+        match *ty {
+          wick_interface_types::Type::I8 => MsSqlWrapper::I8(None),
+          wick_interface_types::Type::I16 => MsSqlWrapper::I16(None),
+          wick_interface_types::Type::I32 => MsSqlWrapper::I32(None),
+          wick_interface_types::Type::I64 => MsSqlWrapper::I64(None),
+          wick_interface_types::Type::U8 => MsSqlWrapper::U8(None),
+          wick_interface_types::Type::U16 => MsSqlWrapper::U16(None),
+          wick_interface_types::Type::U32 => MsSqlWrapper::U32(None),
+          wick_interface_types::Type::U64 => MsSqlWrapper::U64(None),
+          wick_interface_types::Type::F32 => MsSqlWrapper::F32(None),
+          wick_interface_types::Type::F64 => MsSqlWrapper::F64(None),
+          wick_interface_types::Type::Bool => MsSqlWrapper::Bool(None),
+          wick_interface_types::Type::String => MsSqlWrapper::String(None),
+          wick_interface_types::Type::Datetime => MsSqlWrapper::Datetime(None),
+          wick_interface_types::Type::Bytes => return Err(MsSqlConversionError::Bytes),
+          wick_interface_types::Type::Named(_) => return Err(MsSqlConversionError::Named),
+          wick_interface_types::Type::List { .. } => return Err(MsSqlConversionError::List),
+          wick_interface_types::Type::Optional { .. } => return Err(MsSqlConversionError::Optional),
+          wick_interface_types::Type::Map { .. } => return Err(MsSqlConversionError::Map),
+          #[allow(deprecated)]
+          wick_interface_types::Type::Link { .. } => return Err(MsSqlConversionError::Link),
+          wick_interface_types::Type::Object => return Err(MsSqlConversionError::Object),
+          wick_interface_types::Type::AnonymousStruct(_) => return Err(MsSqlConversionError::AnonymousStruct),
+        }
+      } else {
+        convert(&SqlWrapper(TypeWrapper::new(*ty, v.clone())))?
+      }
+    }
+    wick_interface_types::Type::Map { .. } => return Err(MsSqlConversionError::Map),
+    #[allow(deprecated)]
+    wick_interface_types::Type::Link { .. } => return Err(MsSqlConversionError::Link),
+    wick_interface_types::Type::Object => return Err(MsSqlConversionError::Object),
+    wick_interface_types::Type::AnonymousStruct(_) => return Err(MsSqlConversionError::AnonymousStruct),
+  };
+
+  Ok(data)
+}
+
+fn to_int<T>(v: &Value) -> Result<T, MsSqlConversionError>
 where
-  T: TryFrom<u64>,
-  T::Error: std::fmt::Debug,
+  T: TryFrom<i64>,
   T: std::fmt::Debug,
 {
-  v.as_u64().unwrap().try_into()
+  v.as_i64().unwrap().try_into().map_err(|_| MsSqlConversionError::I64)
+}
+
+fn to_uint<T>(v: &Value) -> Result<T, MsSqlConversionError>
+where
+  T: TryFrom<u64>,
+  T: std::fmt::Debug,
+{
+  v.as_u64().unwrap().try_into().map_err(|_| MsSqlConversionError::U64)
 }
 
 pub(crate) struct FromSqlWrapper(pub(crate) Value);
@@ -102,11 +200,11 @@ impl<'a> FromSql<'a> for FromSqlWrapper {
         Value::Number(Number::from(v))
       }),
       ColumnData::Xml(_) => unimplemented!(),
-      ColumnData::DateTime(_)
-      | ColumnData::SmallDateTime(_)
-      | ColumnData::DateTime2(_)
-      | ColumnData::DateTimeOffset(_) => DateTime::<Utc>::from_sql(col)?.map(|d| Value::String(d.to_string())),
-
+      ColumnData::DateTime(_) | ColumnData::SmallDateTime(_) | ColumnData::DateTime2(_) => {
+        tiberius::time::chrono::NaiveDateTime::from_sql(col)?
+          .map(|d| Value::String(DateTime::<Utc>::from_utc(d, Utc).to_rfc3339()))
+      }
+      ColumnData::DateTimeOffset(_) => DateTime::<Utc>::from_sql(col)?.map(|d| Value::String(d.to_rfc3339())),
       ColumnData::Time(_) => NaiveTime::from_sql(col)?.map(|d| Value::String(d.to_string())),
       ColumnData::Date(_) => NaiveDate::from_sql(col)?.map(|d| Value::String(d.to_string())),
     };


### PR DESCRIPTION
This PR removes the hard fails on transcoding data from wick types to SQL server types and makes them errors within the wick operation lifecycle.