### PR TITLE
Made name in test definitions optional

### DIFF
--- a/crates/wick/wick-config/definitions/v1/manifest.apex
+++ b/crates/wick/wick-config/definitions/v1/manifest.apex
@@ -682,7 +682,7 @@ type OperationInstance {
 "A test case for a component's operation."
 type TestDefinition {
   "The name of the test."
-  name: string @required
+  name: string?
 
   "The operaton to test."
   operation: string @required

--- a/crates/wick/wick-config/docs/v1.md
+++ b/crates/wick/wick-config/docs/v1.md
@@ -1379,7 +1379,7 @@ Any one of the following types:
 
 | Field name | Type | Description | Required? | Shortform? |
 |------------|------|-------------|-----------|------------|
-| `name` | <code>`string`</code> |The name of the test.|Yes||
+| `name` | <code>`string`</code> |The name of the test.|||
 | `operation` | <code>`string`</code> |The operaton to test.|Yes||
 | `inherent` | <code>[`InherentData`](#inherentdata)</code> |Inherent data to use for the test.|||
 | `with` | <code>`{` `string` `: ` [`LiquidJsonValue`](#liquidjsonvalue) `}`</code> |The configuration for the operation, if any.|||

--- a/crates/wick/wick-config/json-schema/manifest.json
+++ b/crates/wick/wick-config/json-schema/manifest.json
@@ -2331,6 +2331,7 @@
         "properties": {
           "name": {
             "description": "The name of the test.",
+            "required": false,
             "type": "string"
           },
           "operation": {
@@ -2368,7 +2369,6 @@
           }
         },
         "required": [
-          "name",
           "operation"
         ]
       },

--- a/crates/wick/wick-config/json-schema/v1/manifest.json
+++ b/crates/wick/wick-config/json-schema/v1/manifest.json
@@ -1874,6 +1874,7 @@
       "properties": {
         "name": {
           "description": "The name of the test.",
+          "required": false,
 
           "type": "string"
         },
@@ -1916,7 +1917,7 @@
           }
         }
       },
-      "required": ["name", "operation"]
+      "required": ["operation"]
     },
 
     "InherentData": {

--- a/crates/wick/wick-config/src/config/common/test_case.rs
+++ b/crates/wick/wick-config/src/config/common/test_case.rs
@@ -8,7 +8,7 @@ use crate::config::{LiquidJsonConfig, TemplateConfig};
 /// A test case for a component.
 pub struct TestCase {
   /// The name of the test.
-  pub(crate) name: String,
+  pub(crate) name: Option<String>,
   /// The operaton to test.
   pub(crate) operation: String,
   /// The configuration for the operation being tested, if any.

--- a/crates/wick/wick-config/src/v1.rs
+++ b/crates/wick/wick-config/src/v1.rs
@@ -1352,7 +1352,10 @@ pub(crate) struct OperationInstance {
 /// A test case for a component's operation.
 pub(crate) struct TestDefinition {
   /// The name of the test.
-  pub(crate) name: String,
+
+  #[serde(default)]
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub(crate) name: Option<String>,
   /// The operaton to test.
   pub(crate) operation: String,
   /// Inherent data to use for the test.

--- a/crates/wick/wick-test/src/runner.rs
+++ b/crates/wick/wick-test/src/runner.rs
@@ -14,7 +14,7 @@ use crate::{get_payload, TestError, UnitTest};
 pub fn get_description(test: &UnitTest) -> String {
   format!(
     "(test name='{}', operation='{}')",
-    test.test.name(),
+    test.test.name().map_or("Test", |v| v.as_str()),
     test.test.operation()
   )
 }
@@ -55,8 +55,12 @@ async fn run_unit<'a>(
     .signature()
     .get_operation(def.test.operation())
     .ok_or(TestError::OpNotFound(def.test.operation().to_owned()))?;
-  wick_packet::validation::expect_configuration_matches(def.test.name(), op_config.as_ref(), &signature.config)
-    .map_err(TestError::ConfigUnsatisfied)?;
+  wick_packet::validation::expect_configuration_matches(
+    def.test.name().map_or("Test", |v| v.as_str()),
+    op_config.as_ref(),
+    &signature.config,
+  )
+  .map_err(TestError::ConfigUnsatisfied)?;
   let (stream, inherent) = get_payload(def, root_config.as_ref(), op_config.as_ref())?;
   let test_name = get_description(def);
   let mut test_block = TestBlock::new(Some(test_name.clone()));

--- a/docs/content/configuration/reference/v1.md
+++ b/docs/content/configuration/reference/v1.md
@@ -1379,7 +1379,7 @@ Any one of the following types:
 
 | Field name | Type | Description | Required? | Shortform? |
 |------------|------|-------------|-----------|------------|
-| `name` | <code>`string`</code> |The name of the test.|Yes||
+| `name` | <code>`string`</code> |The name of the test.|||
 | `operation` | <code>`string`</code> |The operaton to test.|Yes||
 | `inherent` | <code>[`InherentData`](#inherentdata)</code> |Inherent data to use for the test.|||
 | `with` | <code>`{` `string` `: ` [`LiquidJsonValue`](#liquidjsonvalue) `}`</code> |The configuration for the operation, if any.|||


### PR DESCRIPTION
Simple change that makes the `name` in test definitions optional.