### PR TITLE
Changed pre-request middleware to one output union vs request/response race

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6335,14 +6335,18 @@ dependencies = [
  "flow-component",
  "paste",
  "serde",
+ "serde-value",
  "serde_json",
+ "test-logger",
  "tokio",
  "tokio-stream",
+ "tracing",
  "wasmrs",
  "wasmrs-codec",
  "wasmrs-guest",
  "wasmrs-runtime",
  "wasmrs-rx",
+ "wick-logger",
  "wick-packet",
 ]
 
@@ -6531,9 +6535,15 @@ dependencies = [
 name = "wick-interface-http"
 version = "0.2.0"
 dependencies = [
+ "anyhow",
  "serde",
+ "serde-value",
+ "test-logger",
+ "tokio",
+ "tracing",
  "wick-component",
  "wick-component-codegen",
+ "wick-logger",
 ]
 
 [[package]]

--- a/crates/interfaces/wick-interface-http/Cargo.toml
+++ b/crates/interfaces/wick-interface-http/Cargo.toml
@@ -11,11 +11,18 @@ repository = "https://github.com/candlecorp/wick"
 default = []
 localgen = []
 
-[dev-dependencies]
-
 [dependencies]
 wick-component = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
+
+[dev-dependencies]
+wick-component = { workspace = true, features = ["json"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+wick-logger = { workspace = true }
+test-logger = { workspace = true }
+anyhow = { workspace = true }
+tracing = { workspace = true }
+serde-value = { workspace = true }
 
 [build-dependencies]
 wick-component-codegen = { workspace = true }

--- a/crates/interfaces/wick-interface-http/component.yaml
+++ b/crates/interfaces/wick-interface-http/component.yaml
@@ -13,41 +13,41 @@ types:
     kind: wick/type/enum@v1
     description: HTTP method enum
     variants:
-      - name: GET
+      - name: Get
         description: HTTP GET method
-      - name: POST
+      - name: Post
         description: HTTP POST method
-      - name: PUT
+      - name: Put
         description: HTTP PUT method
-      - name: DELETE
+      - name: Delete
         description: HTTP DELETE method
-      - name: PATCH
+      - name: Patch
         description: HTTP PATCH method
-      - name: HEAD
+      - name: Head
         description: HTTP HEAD method
-      - name: OPTIONS
+      - name: Options
         description: HTTP OPTIONS method
-      - name: TRACE
+      - name: Trace
         description: HTTP TRACE method
   - name: HttpScheme
     kind: wick/type/enum@v1
     description: HTTP scheme
     variants:
-      - name: HTTP
+      - name: Http
         description: HTTP scheme
-      - name: HTTPS
+      - name: Https
         description: HTTPS scheme
   - name: HttpVersion
     kind: wick/type/enum@v1
     description: HTTP version
     variants:
-      - name: HTTP_1_0
+      - name: Http1_0
         value: '1.0'
         description: HTTP 1.0 version
-      - name: HTTP_1_1
+      - name: Http1_1
         value: '1.1'
         description: HTTP 1.1 version
-      - name: HTTP_2_0
+      - name: Http2_0
         value: '2.0'
         description: HTTP 2.0 version
   - name: StatusCode
@@ -60,7 +60,7 @@ types:
       - name: SwitchingProtocols
         value: '101'
         description: SwitchingProtocols status code
-      - name: OK
+      - name: Ok
         value: '200'
         description: HTTP OK status code
       - name: Created
@@ -236,3 +236,9 @@ types:
       - name: remote_addr
         type: string
         description: The remote address of the connected client
+  - name: RequestMiddlewareResponse
+    kind: wick/type/union@v1
+    description: A response from pre-request middleware
+    types:
+      - HttpRequest
+      - HttpResponse

--- a/crates/interfaces/wick-interface-http/tests/serde.rs
+++ b/crates/interfaces/wick-interface-http/tests/serde.rs
@@ -1,0 +1,90 @@
+use anyhow::Result;
+use wick_component::{json, Value};
+use wick_interface_http::types::{HttpRequest, HttpResponse, RequestMiddlewareResponse};
+
+#[test_logger::test(tokio::test)]
+async fn request_repr() -> Result<()> {
+  let expected = HttpRequest {
+    version: wick_interface_http::types::HttpVersion::Http11,
+    headers: [("accept".to_owned(), vec!["*/*".to_owned()])].into(),
+    authority: "localhost:8080".to_owned(),
+    path: "/redirect".to_owned(),
+    remote_addr: "127.0.0.1:53371".to_owned(),
+    uri: "/redirect?url=https://google.com".to_owned(),
+    method: wick_interface_http::types::HttpMethod::Get,
+    query_parameters: [("url".to_owned(), vec!["https://google.com".to_owned()])].into(),
+    scheme: wick_interface_http::types::HttpScheme::Http,
+  };
+  let expected_json = json!({
+    "authority":"localhost:8080",
+    "headers":{
+      "accept":["*/*"],
+    },
+    "method":"Get",
+    "path":"/redirect",
+    "query_parameters":{"url":["https://google.com"]},
+    "remote_addr":"127.0.0.1:53371",
+    "scheme":"Http",
+    "uri":"/redirect?url=https://google.com",
+    "version":"1.1"
+  });
+
+  let expected_as_bytes = wick_component::wasmrs_codec::messagepack::serialize(&expected)?;
+
+  let actual_as_json: Value = wick_component::wasmrs_codec::messagepack::deserialize(&expected_as_bytes)?;
+  println!("expected_json: {}", expected_json);
+  println!("actual_json: {}", actual_as_json);
+  assert_eq!(actual_as_json, expected_json);
+
+  let actual: HttpRequest = wick_component::wasmrs_codec::messagepack::deserialize(&expected_as_bytes)?;
+  assert_eq!(actual, expected);
+
+  let expected_json_as_bytes = wick_component::wasmrs_codec::messagepack::serialize(&expected_json)?;
+  let actual_json: HttpRequest = wick_component::wasmrs_codec::messagepack::deserialize(&expected_json_as_bytes)?;
+  assert_eq!(actual_json, expected);
+
+  Ok(())
+}
+
+#[test_logger::test(tokio::test)]
+async fn response_repr() -> Result<()> {
+  let expected = HttpResponse {
+    status: wick_interface_http::types::StatusCode::TemporaryRedirect,
+    version: wick_interface_http::types::HttpVersion::Http11,
+    headers: [("location".to_owned(), vec!["https://google.com".to_owned()])].into(),
+  };
+  let expected_json = json!({"headers":{"location":["https://google.com"]},"status":"307","version":"1.1"});
+
+  let expected_as_bytes = wick_component::wasmrs_codec::messagepack::serialize(&expected)?;
+
+  let actual_as_json: Value = wick_component::wasmrs_codec::messagepack::deserialize(&expected_as_bytes)?;
+  println!("as_json: {}", actual_as_json);
+  assert_eq!(actual_as_json, expected_json);
+
+  let expected_json_as_bytes = wick_component::wasmrs_codec::messagepack::serialize(&expected)?;
+
+  let actual: HttpResponse = wick_component::wasmrs_codec::messagepack::deserialize(&expected_as_bytes)?;
+  assert_eq!(actual, expected);
+
+  let actual_json: HttpResponse = wick_component::wasmrs_codec::messagepack::deserialize(&expected_json_as_bytes)?;
+  assert_eq!(actual_json, expected);
+
+  Ok(())
+}
+
+#[test_logger::test(tokio::test)]
+async fn enum_repr() -> Result<()> {
+  let expected = HttpResponse {
+    status: wick_interface_http::types::StatusCode::TemporaryRedirect,
+    version: wick_interface_http::types::HttpVersion::Http11,
+    headers: [("location".to_owned(), vec!["https://google.com".to_owned()])].into(),
+  };
+
+  let expected_as_bytes =
+    wick_component::wasmrs_codec::messagepack::serialize(&RequestMiddlewareResponse::HttpResponse(expected.clone()))?;
+
+  let actual: HttpResponse = wick_component::wasmrs_codec::messagepack::deserialize(&expected_as_bytes)?;
+  assert_eq!(actual, expected);
+
+  Ok(())
+}

--- a/crates/wick/wick-component/Cargo.toml
+++ b/crates/wick/wick-component/Cargo.toml
@@ -25,11 +25,12 @@ wick-packet = { workspace = true, default-features = false }
 flow-component = { workspace = true, default-features = false }
 wasmrs = { workspace = true }
 wasmrs-rx = { workspace = true }
-wasmrs-codec = { workspace = true }
+wasmrs-codec = { workspace = true, features = ["std"] }
 wasmrs-runtime = { workspace = true }
 tokio-stream = { workspace = true }
 paste = { workspace = true }
 serde_json = { workspace = true }
+serde = { workspace = true }
 chrono = { workspace = true, features = ["std"], optional = true }
 bytes = { workspace = true, optional = true }
 
@@ -40,3 +41,7 @@ wasmrs-guest = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 serde = { workspace = true }
 anyhow = { workspace = true }
+wick-logger = { workspace = true }
+test-logger = { workspace = true }
+tracing = { workspace = true }
+serde-value = { workspace = true }

--- a/crates/wick/wick-component/src/lib.rs
+++ b/crates/wick/wick-component/src/lib.rs
@@ -87,6 +87,9 @@
 // Add exceptions here
 #![allow()]
 
+/// A module implementing custom serializers/deserializers for wick types.
+pub mod serde;
+
 /// Macros used by wick components and generated code.
 pub mod macros;
 #[cfg(feature = "bytes")]

--- a/crates/wick/wick-component/src/serde.rs
+++ b/crates/wick/wick-component/src/serde.rs
@@ -1,0 +1,2 @@
+/// Custom serializer/deserializer for Wick enum types
+pub mod enum_repr;

--- a/crates/wick/wick-component/src/serde/enum_repr.rs
+++ b/crates/wick/wick-component/src/serde/enum_repr.rs
@@ -1,0 +1,35 @@
+#[derive(Debug, ::serde::Serialize, ::serde::Deserialize, PartialEq)]
+#[serde(untagged)]
+/// A string or number to attempt deserializing from.
+#[allow(missing_docs)]
+pub enum StringOrNum {
+  String(String),
+  Int(i64),
+  Float(f64),
+}
+
+/// Serialize a value as a string using its [std::fmt::Display] implementation.
+pub fn serialize<T, S>(val: &T, serializer: S) -> Result<S::Ok, S::Error>
+where
+  S: serde::Serializer,
+  T: std::fmt::Display,
+{
+  let s = val.to_string();
+  serializer.serialize_str(&s)
+}
+
+/// Deserialize a value from a number or string using its [std::str::FromStr] implementation.
+pub fn deserialize<'de, S, D>(deserializer: D) -> Result<S, D::Error>
+where
+  S: std::str::FromStr,
+  S::Err: std::fmt::Display,
+  D: serde::Deserializer<'de>,
+{
+  let s: StringOrNum = serde::Deserialize::deserialize(deserializer)?;
+  let s = match s {
+    StringOrNum::String(s) => s,
+    StringOrNum::Int(i) => i.to_string(),
+    StringOrNum::Float(i) => i.to_string(),
+  };
+  S::from_str(&s).map_err(serde::de::Error::custom)
+}

--- a/crates/wick/wick-component/tests/serde.rs
+++ b/crates/wick/wick-component/tests/serde.rs
@@ -1,0 +1,89 @@
+use std::str::FromStr;
+
+use anyhow::Result;
+use wick_component::serde::enum_repr::StringOrNum;
+use wick_component::{json, Value};
+
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq)]
+struct Test {
+  value: TestEnum,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize, PartialEq, Clone)]
+#[serde(into = "String", try_from = "wick_component::serde::enum_repr::StringOrNum")]
+enum TestEnum {
+  First,
+  Second,
+}
+
+impl TryFrom<StringOrNum> for TestEnum {
+  type Error = String;
+
+  fn try_from(value: StringOrNum) -> std::result::Result<Self, String> {
+    match value {
+      StringOrNum::String(v) => Self::from_str(&v),
+      StringOrNum::Int(v) => Self::from_str(&v.to_string()),
+      StringOrNum::Float(v) => Self::from_str(&v.to_string()),
+    }
+  }
+}
+
+impl From<TestEnum> for String {
+  fn from(value: TestEnum) -> Self {
+    value.value().to_owned()
+  }
+}
+
+impl TestEnum {
+  fn value(&self) -> &str {
+    match self {
+      TestEnum::First => "1",
+      TestEnum::Second => "2",
+    }
+  }
+}
+
+impl FromStr for TestEnum {
+  type Err = String;
+
+  fn from_str(s: &str) -> Result<Self, Self::Err> {
+    match s {
+      "1" => Ok(TestEnum::First),
+      "2" => Ok(TestEnum::Second),
+      _ => Err(s.to_owned()),
+    }
+  }
+}
+
+impl std::fmt::Display for TestEnum {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{}", self.value())
+  }
+}
+
+#[test_logger::test(tokio::test)]
+async fn enum_repr() -> Result<()> {
+  let expected = Test { value: TestEnum::First };
+  let bytes = wick_component::wasmrs_codec::messagepack::serialize(&expected)?;
+  let expected_good_json_str = json!({"value": "1"});
+  let expected_good_json_num = json!({"value": 1});
+
+  let actual_json: Value = wick_component::wasmrs_codec::messagepack::deserialize(&bytes)?;
+
+  let actual = wick_component::wasmrs_codec::messagepack::deserialize(&bytes)?;
+  assert_eq!(expected, actual);
+
+  let actual_json_bytes = wick_component::wasmrs_codec::messagepack::serialize(&actual_json)?;
+  let actual_from_json = wick_component::wasmrs_codec::messagepack::deserialize(&actual_json_bytes)?;
+  assert_eq!(expected, actual_from_json);
+
+  let expected_json_str_bytes = wick_component::wasmrs_codec::messagepack::serialize(&expected_good_json_str)?;
+  let expected_json_str_rt = wick_component::wasmrs_codec::messagepack::deserialize(&expected_json_str_bytes)?;
+  assert_eq!(expected, expected_json_str_rt);
+
+  let expected_json_num_bytes = wick_component::wasmrs_codec::messagepack::serialize(&expected_good_json_num)?;
+  let expected_json_num_rt = wick_component::wasmrs_codec::messagepack::deserialize(&expected_json_num_bytes)?;
+  assert_eq!(expected, expected_json_num_rt);
+
+  Ok(())
+}

--- a/crates/wick/wick-runtime/src/triggers/http.rs
+++ b/crates/wick/wick-runtime/src/triggers/http.rs
@@ -686,7 +686,7 @@ mod test {
       // check that our response middleware has been called again.
       let res = get("/this/FIRST_VALUE/some/222?third=third_a&fourth=true").await?;
       let header = res.headers().get("x-wick-count").unwrap();
-      assert_eq!(header, "3");
+      assert_eq!(header, "4");
 
       trigger.shutdown_gracefully().await?;
 

--- a/crates/wick/wick-runtime/src/triggers/http.rs
+++ b/crates/wick/wick-runtime/src/triggers/http.rs
@@ -92,11 +92,11 @@ enum HttpError {
   #[error("Invalid pre-request middleware response: {0}")]
   InvalidPreRequestResponse(String),
 
-  #[error("Pre-request middleware did not provide a request or response")]
-  PreRequestResponseNoData,
+  #[error("Pre-request middleware '{0}' did not provide a request or response")]
+  PreRequestResponseNoData(Entity),
 
-  #[error("Post-request middleware did not provide a response")]
-  PostRequestResponseNoData,
+  #[error("Post-request middleware '{0}' did not provide a response")]
+  PostRequestResponseNoData(Entity),
 
   #[error("Invalid post-request middleware response: {0}")]
   InvalidPostRequestResponse(String),
@@ -660,6 +660,13 @@ mod test {
 
       assert!(res.contains("Google"));
 
+      // requests to /google should result in a redirected response (from a composite component)
+      let res = get("/google").await?.text().await?;
+
+      println!("{:#?}", res);
+
+      assert!(res.contains("Google"));
+
       // check that other requests still go through.
       let res = get("/this/FIRST_VALUE/some/222?third=third_a&fourth=true").await?;
 
@@ -668,7 +675,7 @@ mod test {
       assert_eq!(header, "false");
       // check our response middleware added a header.
       let header = res.headers().get("x-wick-count").unwrap();
-      assert_eq!(header, "2");
+      assert_eq!(header, "3");
       let res: serde_json::Value = res.json().await?;
       println!("{:#?}", res);
       assert_eq!(

--- a/crates/wick/wick-runtime/src/triggers/http/service_factory.rs
+++ b/crates/wick/wick-runtime/src/triggers/http/service_factory.rs
@@ -9,8 +9,9 @@ use hyper::server::conn::AddrStream;
 use hyper::service::Service;
 use hyper::{Body, Request, Response, StatusCode};
 use tracing::Span;
+use wick_interface_http::types::RequestMiddlewareResponse;
 
-use super::component_utils::{handle_request_middleware, handle_response_middleware, Either};
+use super::component_utils::{handle_request_middleware, handle_response_middleware};
 use super::conversions::{convert_response, convert_to_wick_response, merge_requests, request_to_wick};
 use super::{HttpError, HttpRouter, RawRouterHandler};
 use crate::Runtime;
@@ -174,8 +175,8 @@ where
   for (entity, config) in &r.middleware.request {
     let response = handle_request_middleware(entity.clone(), config.clone(), engine.clone(), &wick_req).await?;
     match response {
-      Some(Either::Request(req)) => wick_req = req,
-      Some(Either::Response(res)) => {
+      Some(RequestMiddlewareResponse::HttpRequest(req)) => wick_req = req,
+      Some(RequestMiddlewareResponse::HttpResponse(res)) => {
         let builder = convert_response(Response::builder(), res)?;
         let res = builder.body(Body::empty()).unwrap();
         return Ok((wick_req, Some(res)));

--- a/examples/http/middleware.wick
+++ b/examples/http/middleware.wick
@@ -25,6 +25,10 @@ import:
     component:
       kind: wick/component/manifest@v1
       ref: ./middleware/request/component.wick
+  - name: composite_middleware
+    component:
+      kind: wick/component/manifest@v1
+      ref: ./middleware/redirect.wick
 triggers:
   - kind: wick/trigger/http@v1
     resource: http
@@ -34,9 +38,10 @@ triggers:
         middleware:
           request:
             - middleware::redirect
+            - composite_middleware::pathcheck
           response:
             - middleware::count
         routes:
-          - uri: '/this/{first:string}/some/{second:u32}?third:string&fourth:bool'
+          - sub_path: '/this/{first:string}/some/{second:u32}?third:string&fourth:bool'
             operation: sample::echo
             description: 'Echoes inputs first, second, third, and fourth back as JSON'

--- a/examples/http/middleware/redirect.wick
+++ b/examples/http/middleware/redirect.wick
@@ -13,7 +13,7 @@ import:
   - name: http
     component:
       kind: wick/component/types@v1
-      ref: 'registry.candle.dev/common/http:0.0.1'
+      ref: ../../../crates/interfaces/wick-interface-http/component.yaml
 component:
   kind: wick/component/composite@v1
   operations:
@@ -26,10 +26,8 @@ component:
               - name: request
                 type: http::HttpRequest
             outputs:
-              - name: request
-                type: http::HttpRequest
-              - name: response
-                type: http::HttpResponse?
+              - name: output
+                type: http::RequestMiddlewareResponse
             cases:
               - case: '/google'
                 do: self::pathcheck::to_google
@@ -37,8 +35,7 @@ component:
       flow:
         - <>.request.path -> switch.match
         - <>.request -> switch.request
-        - switch.request -> <>.request
-        - switch.response -> <>.response
+        - switch.output -> <>.output
       operations:
         - name: to_google
           uses:
@@ -51,18 +48,14 @@ component:
                   headers:
                     location: ['https://google.com']
           outputs:
-            - name: request
-              type: http::HttpRequest
-            - name: response
-              type: http::HttpResponse?
+            - name: output
+              type: http::RequestMiddlewareResponse
           flow:
             - <>.request -> drop
-            - STATUS.output -> <>.response
+            - STATUS.output -> <>.output
         - name: none
           outputs:
-            - name: request
-              type: http::HttpRequest
-            - name: response
-              type: http::HttpResponse?
+            - name: output
+              type: http::RequestMiddlewareResponse
           flow:
-            - <>.request -> <>.request
+            - <>.request -> <>.output

--- a/examples/http/middleware/request/Cargo.lock
+++ b/examples/http/middleware/request/Cargo.lock
@@ -1357,6 +1357,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
  "rand_chacha",
  "rand_core",
 ]
@@ -1376,6 +1377,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -2361,6 +2365,7 @@ version = "0.15.0"
 dependencies = [
  "flow-component",
  "paste",
+ "serde",
  "serde_json",
  "tokio-stream",
  "wasmrs",
@@ -2466,6 +2471,7 @@ dependencies = [
  "liquid-json",
  "parking_lot",
  "pin-project-lite",
+ "seeded-random",
  "serde",
  "serde_json",
  "thiserror",

--- a/examples/http/middleware/request/component.wick
+++ b/examples/http/middleware/request/component.wick
@@ -18,10 +18,8 @@ component:
         - name: request
           type: http::HttpRequest
       outputs:
-        - name: request
-          type: http::HttpRequest
-        - name: response
-          type: http::HttpResponse
+        - name: output
+          type: http::RequestMiddlewareResponse
     - name: count
       inputs:
         - name: request

--- a/examples/http/middleware/request/src/lib.rs
+++ b/examples/http/middleware/request/src/lib.rs
@@ -5,7 +5,7 @@ mod wick {
 }
 use wick::*;
 
-use self::wick::types::http;
+use self::wick::types::http::{self, RequestMiddlewareResponse};
 
 #[async_trait::async_trait(?Send)]
 impl RedirectOperation for Component {
@@ -29,17 +29,17 @@ impl RedirectOperation for Component {
         let url = request.query_parameters.get("url").and_then(|v| v.get(0));
         if let Some(url) = url {
           response.headers.insert("Location".to_owned(), vec![url.to_owned()]);
-          outputs.response.send(&response);
+          outputs.output.send(&RequestMiddlewareResponse::HttpResponse(response));
         }
       } else {
         request
           .headers
           .insert("x-wick-redirect".to_owned(), vec!["false".to_owned()]);
-        outputs.request.send(&request);
+        outputs.output.send(&RequestMiddlewareResponse::HttpRequest(request));
       }
     }
-    outputs.request.done();
-    outputs.response.done();
+    outputs.output.done();
+
     Ok(())
   }
 }

--- a/examples/http/wasm-http-call/wasm-component/Cargo.lock
+++ b/examples/http/wasm-http-call/wasm-component/Cargo.lock
@@ -1319,6 +1319,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
+ "libc",
  "rand_chacha",
  "rand_core",
 ]
@@ -1338,6 +1339,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -2332,6 +2336,7 @@ version = "0.15.0"
 dependencies = [
  "flow-component",
  "paste",
+ "serde",
  "serde_json",
  "tokio-stream",
  "wasmrs",
@@ -2437,6 +2442,7 @@ dependencies = [
  "liquid-json",
  "parking_lot",
  "pin-project-lite",
+ "seeded-random",
  "serde",
  "serde_json",
  "thiserror",

--- a/tests/codegen-tests/src/import_types/mod.rs
+++ b/tests/codegen-tests/src/import_types/mod.rs
@@ -105,8 +105,11 @@ pub mod types {
   #[doc = "a weird union"]
   #[serde(untagged)]
   pub enum LocalUnion {
+    #[doc = "A string value."]
     String(String),
+    #[doc = "A LocalStructInner value."]
     LocalStructInner(types::LocalStructInner),
+    #[doc = "A datetime value."]
     Datetime(wick_component::datetime::DateTime),
   }
   pub mod aaa {
@@ -114,6 +117,7 @@ pub mod types {
     use super::aaa;
     #[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize, PartialEq)]
     #[doc = "HTTP method enum"]
+    #[serde(into = "String", try_from = "wick_component::serde::enum_repr::StringOrNum")]
     pub enum HttpMethod {
       #[doc = "HTTP GET method"]
       Get,
@@ -131,6 +135,22 @@ pub mod types {
       Options,
       #[doc = "HTTP TRACE method"]
       Trace,
+    }
+    impl TryFrom<wick_component::serde::enum_repr::StringOrNum> for HttpMethod {
+      type Error = String;
+      fn try_from(value: wick_component::serde::enum_repr::StringOrNum) -> std::result::Result<Self, String> {
+        use std::str::FromStr;
+        match value {
+          wick_component::serde::enum_repr::StringOrNum::String(v) => Self::from_str(&v),
+          wick_component::serde::enum_repr::StringOrNum::Int(v) => Self::from_str(&v.to_string()),
+          wick_component::serde::enum_repr::StringOrNum::Float(v) => Self::from_str(&v.to_string()),
+        }
+      }
+    }
+    impl From<HttpMethod> for String {
+      fn from(value: HttpMethod) -> Self {
+        value.value().map_or_else(|| value.to_string(), |v| v.to_owned())
+      }
     }
     impl HttpMethod {
       #[allow(unused)]
@@ -164,6 +184,14 @@ pub mod types {
       fn from_str(s: &str) -> Result<Self, Self::Err> {
         #[allow(clippy::match_single_binding)]
         match s {
+          "Get" => Ok(Self::Get),
+          "Post" => Ok(Self::Post),
+          "Put" => Ok(Self::Put),
+          "Delete" => Ok(Self::Delete),
+          "Patch" => Ok(Self::Patch),
+          "Head" => Ok(Self::Head),
+          "Options" => Ok(Self::Options),
+          "Trace" => Ok(Self::Trace),
           _ => Err(s.to_owned()),
         }
       }
@@ -172,14 +200,14 @@ pub mod types {
       fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         #[allow(clippy::match_single_binding)]
         match self {
-          Self::Get => f.write_str("GET"),
-          Self::Post => f.write_str("POST"),
-          Self::Put => f.write_str("PUT"),
-          Self::Delete => f.write_str("DELETE"),
-          Self::Patch => f.write_str("PATCH"),
-          Self::Head => f.write_str("HEAD"),
-          Self::Options => f.write_str("OPTIONS"),
-          Self::Trace => f.write_str("TRACE"),
+          Self::Get => f.write_str("Get"),
+          Self::Post => f.write_str("Post"),
+          Self::Put => f.write_str("Put"),
+          Self::Delete => f.write_str("Delete"),
+          Self::Patch => f.write_str("Patch"),
+          Self::Head => f.write_str("Head"),
+          Self::Options => f.write_str("Options"),
+          Self::Trace => f.write_str("Trace"),
         }
       }
     }
@@ -235,11 +263,28 @@ pub mod types {
     }
     #[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize, PartialEq)]
     #[doc = "HTTP scheme"]
+    #[serde(into = "String", try_from = "wick_component::serde::enum_repr::StringOrNum")]
     pub enum HttpScheme {
       #[doc = "HTTP scheme"]
       Http,
       #[doc = "HTTPS scheme"]
       Https,
+    }
+    impl TryFrom<wick_component::serde::enum_repr::StringOrNum> for HttpScheme {
+      type Error = String;
+      fn try_from(value: wick_component::serde::enum_repr::StringOrNum) -> std::result::Result<Self, String> {
+        use std::str::FromStr;
+        match value {
+          wick_component::serde::enum_repr::StringOrNum::String(v) => Self::from_str(&v),
+          wick_component::serde::enum_repr::StringOrNum::Int(v) => Self::from_str(&v.to_string()),
+          wick_component::serde::enum_repr::StringOrNum::Float(v) => Self::from_str(&v.to_string()),
+        }
+      }
+    }
+    impl From<HttpScheme> for String {
+      fn from(value: HttpScheme) -> Self {
+        value.value().map_or_else(|| value.to_string(), |v| v.to_owned())
+      }
     }
     impl HttpScheme {
       #[allow(unused)]
@@ -267,6 +312,8 @@ pub mod types {
       fn from_str(s: &str) -> Result<Self, Self::Err> {
         #[allow(clippy::match_single_binding)]
         match s {
+          "Http" => Ok(Self::Http),
+          "Https" => Ok(Self::Https),
           _ => Err(s.to_owned()),
         }
       }
@@ -275,13 +322,14 @@ pub mod types {
       fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         #[allow(clippy::match_single_binding)]
         match self {
-          Self::Http => f.write_str("HTTP"),
-          Self::Https => f.write_str("HTTPS"),
+          Self::Http => f.write_str("Http"),
+          Self::Https => f.write_str("Https"),
         }
       }
     }
     #[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize, PartialEq)]
     #[doc = "HTTP version"]
+    #[serde(into = "String", try_from = "wick_component::serde::enum_repr::StringOrNum")]
     pub enum HttpVersion {
       #[doc = "HTTP 1.0 version"]
       Http10,
@@ -289,6 +337,22 @@ pub mod types {
       Http11,
       #[doc = "HTTP 2.0 version"]
       Http20,
+    }
+    impl TryFrom<wick_component::serde::enum_repr::StringOrNum> for HttpVersion {
+      type Error = String;
+      fn try_from(value: wick_component::serde::enum_repr::StringOrNum) -> std::result::Result<Self, String> {
+        use std::str::FromStr;
+        match value {
+          wick_component::serde::enum_repr::StringOrNum::String(v) => Self::from_str(&v),
+          wick_component::serde::enum_repr::StringOrNum::Int(v) => Self::from_str(&v.to_string()),
+          wick_component::serde::enum_repr::StringOrNum::Float(v) => Self::from_str(&v.to_string()),
+        }
+      }
+    }
+    impl From<HttpVersion> for String {
+      fn from(value: HttpVersion) -> Self {
+        value.value().map_or_else(|| value.to_string(), |v| v.to_owned())
+      }
     }
     impl HttpVersion {
       #[allow(unused)]
@@ -318,8 +382,11 @@ pub mod types {
         #[allow(clippy::match_single_binding)]
         match s {
           "1.0" => Ok(Self::Http10),
+          "Http10" => Ok(Self::Http10),
           "1.1" => Ok(Self::Http11),
+          "Http11" => Ok(Self::Http11),
           "2.0" => Ok(Self::Http20),
+          "Http20" => Ok(Self::Http20),
           _ => Err(s.to_owned()),
         }
       }
@@ -328,14 +395,24 @@ pub mod types {
       fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         #[allow(clippy::match_single_binding)]
         match self {
-          Self::Http10 => f.write_str("HTTP_1_0"),
-          Self::Http11 => f.write_str("HTTP_1_1"),
-          Self::Http20 => f.write_str("HTTP_2_0"),
+          Self::Http10 => f.write_str("1.0"),
+          Self::Http11 => f.write_str("1.1"),
+          Self::Http20 => f.write_str("2.0"),
         }
       }
     }
     #[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize, PartialEq)]
+    #[doc = "A response from pre-request middleware"]
+    #[serde(untagged)]
+    pub enum RequestMiddlewareResponse {
+      #[doc = "A HttpRequest value."]
+      HttpRequest(HttpRequest),
+      #[doc = "A HttpResponse value."]
+      HttpResponse(HttpResponse),
+    }
+    #[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize, PartialEq)]
     #[doc = "HTTP status code"]
+    #[serde(into = "String", try_from = "wick_component::serde::enum_repr::StringOrNum")]
     pub enum StatusCode {
       #[doc = "Continue status code"]
       Continue,
@@ -430,6 +507,22 @@ pub mod types {
       #[doc = "Indicates an unknown status code"]
       Unknown,
     }
+    impl TryFrom<wick_component::serde::enum_repr::StringOrNum> for StatusCode {
+      type Error = String;
+      fn try_from(value: wick_component::serde::enum_repr::StringOrNum) -> std::result::Result<Self, String> {
+        use std::str::FromStr;
+        match value {
+          wick_component::serde::enum_repr::StringOrNum::String(v) => Self::from_str(&v),
+          wick_component::serde::enum_repr::StringOrNum::Int(v) => Self::from_str(&v.to_string()),
+          wick_component::serde::enum_repr::StringOrNum::Float(v) => Self::from_str(&v.to_string()),
+        }
+      }
+    }
+    impl From<StatusCode> for String {
+      fn from(value: StatusCode) -> Self {
+        value.value().map_or_else(|| value.to_string(), |v| v.to_owned())
+      }
+    }
     impl StatusCode {
       #[allow(unused)]
       #[doc = "Returns the value of the enum variant as a string."]
@@ -501,51 +594,97 @@ pub mod types {
         #[allow(clippy::match_single_binding)]
         match s {
           "100" => Ok(Self::Continue),
+          "Continue" => Ok(Self::Continue),
           "101" => Ok(Self::SwitchingProtocols),
+          "SwitchingProtocols" => Ok(Self::SwitchingProtocols),
           "200" => Ok(Self::Ok),
+          "Ok" => Ok(Self::Ok),
           "201" => Ok(Self::Created),
+          "Created" => Ok(Self::Created),
           "202" => Ok(Self::Accepted),
+          "Accepted" => Ok(Self::Accepted),
           "203" => Ok(Self::NonAuthoritativeInformation),
+          "NonAuthoritativeInformation" => Ok(Self::NonAuthoritativeInformation),
           "204" => Ok(Self::NoContent),
+          "NoContent" => Ok(Self::NoContent),
           "205" => Ok(Self::ResetContent),
+          "ResetContent" => Ok(Self::ResetContent),
           "206" => Ok(Self::PartialContent),
+          "PartialContent" => Ok(Self::PartialContent),
           "300" => Ok(Self::MultipleChoices),
+          "MultipleChoices" => Ok(Self::MultipleChoices),
           "301" => Ok(Self::MovedPermanently),
+          "MovedPermanently" => Ok(Self::MovedPermanently),
           "302" => Ok(Self::Found),
+          "Found" => Ok(Self::Found),
           "303" => Ok(Self::SeeOther),
+          "SeeOther" => Ok(Self::SeeOther),
           "304" => Ok(Self::NotModified),
+          "NotModified" => Ok(Self::NotModified),
           "307" => Ok(Self::TemporaryRedirect),
+          "TemporaryRedirect" => Ok(Self::TemporaryRedirect),
           "308" => Ok(Self::PermanentRedirect),
+          "PermanentRedirect" => Ok(Self::PermanentRedirect),
           "400" => Ok(Self::BadRequest),
+          "BadRequest" => Ok(Self::BadRequest),
           "401" => Ok(Self::Unauthorized),
+          "Unauthorized" => Ok(Self::Unauthorized),
           "402" => Ok(Self::PaymentRequired),
+          "PaymentRequired" => Ok(Self::PaymentRequired),
           "403" => Ok(Self::Forbidden),
+          "Forbidden" => Ok(Self::Forbidden),
           "404" => Ok(Self::NotFound),
+          "NotFound" => Ok(Self::NotFound),
           "405" => Ok(Self::MethodNotAllowed),
+          "MethodNotAllowed" => Ok(Self::MethodNotAllowed),
           "406" => Ok(Self::NotAcceptable),
+          "NotAcceptable" => Ok(Self::NotAcceptable),
           "407" => Ok(Self::ProxyAuthenticationRequired),
+          "ProxyAuthenticationRequired" => Ok(Self::ProxyAuthenticationRequired),
           "408" => Ok(Self::RequestTimeout),
+          "RequestTimeout" => Ok(Self::RequestTimeout),
           "409" => Ok(Self::Conflict),
+          "Conflict" => Ok(Self::Conflict),
           "410" => Ok(Self::Gone),
+          "Gone" => Ok(Self::Gone),
           "411" => Ok(Self::LengthRequired),
+          "LengthRequired" => Ok(Self::LengthRequired),
           "412" => Ok(Self::PreconditionFailed),
+          "PreconditionFailed" => Ok(Self::PreconditionFailed),
           "413" => Ok(Self::PayloadTooLarge),
+          "PayloadTooLarge" => Ok(Self::PayloadTooLarge),
           "414" => Ok(Self::UriTooLong),
+          "UriTooLong" => Ok(Self::UriTooLong),
           "415" => Ok(Self::UnsupportedMediaType),
+          "UnsupportedMediaType" => Ok(Self::UnsupportedMediaType),
           "416" => Ok(Self::RangeNotSatisfiable),
+          "RangeNotSatisfiable" => Ok(Self::RangeNotSatisfiable),
           "417" => Ok(Self::ExpectationFailed),
+          "ExpectationFailed" => Ok(Self::ExpectationFailed),
           "418" => Ok(Self::ImATeapot),
+          "ImATeapot" => Ok(Self::ImATeapot),
           "422" => Ok(Self::UnprocessableEntity),
+          "UnprocessableEntity" => Ok(Self::UnprocessableEntity),
           "423" => Ok(Self::Locked),
+          "Locked" => Ok(Self::Locked),
           "424" => Ok(Self::FailedDependency),
+          "FailedDependency" => Ok(Self::FailedDependency),
           "429" => Ok(Self::TooManyRequests),
+          "TooManyRequests" => Ok(Self::TooManyRequests),
           "500" => Ok(Self::InternalServerError),
+          "InternalServerError" => Ok(Self::InternalServerError),
           "501" => Ok(Self::NotImplemented),
+          "NotImplemented" => Ok(Self::NotImplemented),
           "502" => Ok(Self::BadGateway),
+          "BadGateway" => Ok(Self::BadGateway),
           "503" => Ok(Self::ServiceUnavailable),
+          "ServiceUnavailable" => Ok(Self::ServiceUnavailable),
           "504" => Ok(Self::GatewayTimeout),
+          "GatewayTimeout" => Ok(Self::GatewayTimeout),
           "505" => Ok(Self::HttpVersionNotSupported),
+          "HttpVersionNotSupported" => Ok(Self::HttpVersionNotSupported),
           "-1" => Ok(Self::Unknown),
+          "Unknown" => Ok(Self::Unknown),
           _ => Err(s.to_owned()),
         }
       }
@@ -554,52 +693,52 @@ pub mod types {
       fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         #[allow(clippy::match_single_binding)]
         match self {
-          Self::Continue => f.write_str("Continue"),
-          Self::SwitchingProtocols => f.write_str("SwitchingProtocols"),
-          Self::Ok => f.write_str("OK"),
-          Self::Created => f.write_str("Created"),
-          Self::Accepted => f.write_str("Accepted"),
-          Self::NonAuthoritativeInformation => f.write_str("NonAuthoritativeInformation"),
-          Self::NoContent => f.write_str("NoContent"),
-          Self::ResetContent => f.write_str("ResetContent"),
-          Self::PartialContent => f.write_str("PartialContent"),
-          Self::MultipleChoices => f.write_str("MultipleChoices"),
-          Self::MovedPermanently => f.write_str("MovedPermanently"),
-          Self::Found => f.write_str("Found"),
-          Self::SeeOther => f.write_str("SeeOther"),
-          Self::NotModified => f.write_str("NotModified"),
-          Self::TemporaryRedirect => f.write_str("TemporaryRedirect"),
-          Self::PermanentRedirect => f.write_str("PermanentRedirect"),
-          Self::BadRequest => f.write_str("BadRequest"),
-          Self::Unauthorized => f.write_str("Unauthorized"),
-          Self::PaymentRequired => f.write_str("PaymentRequired"),
-          Self::Forbidden => f.write_str("Forbidden"),
-          Self::NotFound => f.write_str("NotFound"),
-          Self::MethodNotAllowed => f.write_str("MethodNotAllowed"),
-          Self::NotAcceptable => f.write_str("NotAcceptable"),
-          Self::ProxyAuthenticationRequired => f.write_str("ProxyAuthenticationRequired"),
-          Self::RequestTimeout => f.write_str("RequestTimeout"),
-          Self::Conflict => f.write_str("Conflict"),
-          Self::Gone => f.write_str("Gone"),
-          Self::LengthRequired => f.write_str("LengthRequired"),
-          Self::PreconditionFailed => f.write_str("PreconditionFailed"),
-          Self::PayloadTooLarge => f.write_str("PayloadTooLarge"),
-          Self::UriTooLong => f.write_str("URITooLong"),
-          Self::UnsupportedMediaType => f.write_str("UnsupportedMediaType"),
-          Self::RangeNotSatisfiable => f.write_str("RangeNotSatisfiable"),
-          Self::ExpectationFailed => f.write_str("ExpectationFailed"),
-          Self::ImATeapot => f.write_str("ImATeapot"),
-          Self::UnprocessableEntity => f.write_str("UnprocessableEntity"),
-          Self::Locked => f.write_str("Locked"),
-          Self::FailedDependency => f.write_str("FailedDependency"),
-          Self::TooManyRequests => f.write_str("TooManyRequests"),
-          Self::InternalServerError => f.write_str("InternalServerError"),
-          Self::NotImplemented => f.write_str("NotImplemented"),
-          Self::BadGateway => f.write_str("BadGateway"),
-          Self::ServiceUnavailable => f.write_str("ServiceUnavailable"),
-          Self::GatewayTimeout => f.write_str("GatewayTimeout"),
-          Self::HttpVersionNotSupported => f.write_str("HTTPVersionNotSupported"),
-          Self::Unknown => f.write_str("Unknown"),
+          Self::Continue => f.write_str("100"),
+          Self::SwitchingProtocols => f.write_str("101"),
+          Self::Ok => f.write_str("200"),
+          Self::Created => f.write_str("201"),
+          Self::Accepted => f.write_str("202"),
+          Self::NonAuthoritativeInformation => f.write_str("203"),
+          Self::NoContent => f.write_str("204"),
+          Self::ResetContent => f.write_str("205"),
+          Self::PartialContent => f.write_str("206"),
+          Self::MultipleChoices => f.write_str("300"),
+          Self::MovedPermanently => f.write_str("301"),
+          Self::Found => f.write_str("302"),
+          Self::SeeOther => f.write_str("303"),
+          Self::NotModified => f.write_str("304"),
+          Self::TemporaryRedirect => f.write_str("307"),
+          Self::PermanentRedirect => f.write_str("308"),
+          Self::BadRequest => f.write_str("400"),
+          Self::Unauthorized => f.write_str("401"),
+          Self::PaymentRequired => f.write_str("402"),
+          Self::Forbidden => f.write_str("403"),
+          Self::NotFound => f.write_str("404"),
+          Self::MethodNotAllowed => f.write_str("405"),
+          Self::NotAcceptable => f.write_str("406"),
+          Self::ProxyAuthenticationRequired => f.write_str("407"),
+          Self::RequestTimeout => f.write_str("408"),
+          Self::Conflict => f.write_str("409"),
+          Self::Gone => f.write_str("410"),
+          Self::LengthRequired => f.write_str("411"),
+          Self::PreconditionFailed => f.write_str("412"),
+          Self::PayloadTooLarge => f.write_str("413"),
+          Self::UriTooLong => f.write_str("414"),
+          Self::UnsupportedMediaType => f.write_str("415"),
+          Self::RangeNotSatisfiable => f.write_str("416"),
+          Self::ExpectationFailed => f.write_str("417"),
+          Self::ImATeapot => f.write_str("418"),
+          Self::UnprocessableEntity => f.write_str("422"),
+          Self::Locked => f.write_str("423"),
+          Self::FailedDependency => f.write_str("424"),
+          Self::TooManyRequests => f.write_str("429"),
+          Self::InternalServerError => f.write_str("500"),
+          Self::NotImplemented => f.write_str("501"),
+          Self::BadGateway => f.write_str("502"),
+          Self::ServiceUnavailable => f.write_str("503"),
+          Self::GatewayTimeout => f.write_str("504"),
+          Self::HttpVersionNotSupported => f.write_str("505"),
+          Self::Unknown => f.write_str("-1"),
         }
       }
     }
@@ -609,6 +748,7 @@ pub mod types {
     use super::zzz;
     #[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize, PartialEq)]
     #[doc = "HTTP method enum"]
+    #[serde(into = "String", try_from = "wick_component::serde::enum_repr::StringOrNum")]
     pub enum HttpMethod {
       #[doc = "HTTP GET method"]
       Get,
@@ -626,6 +766,22 @@ pub mod types {
       Options,
       #[doc = "HTTP TRACE method"]
       Trace,
+    }
+    impl TryFrom<wick_component::serde::enum_repr::StringOrNum> for HttpMethod {
+      type Error = String;
+      fn try_from(value: wick_component::serde::enum_repr::StringOrNum) -> std::result::Result<Self, String> {
+        use std::str::FromStr;
+        match value {
+          wick_component::serde::enum_repr::StringOrNum::String(v) => Self::from_str(&v),
+          wick_component::serde::enum_repr::StringOrNum::Int(v) => Self::from_str(&v.to_string()),
+          wick_component::serde::enum_repr::StringOrNum::Float(v) => Self::from_str(&v.to_string()),
+        }
+      }
+    }
+    impl From<HttpMethod> for String {
+      fn from(value: HttpMethod) -> Self {
+        value.value().map_or_else(|| value.to_string(), |v| v.to_owned())
+      }
     }
     impl HttpMethod {
       #[allow(unused)]
@@ -659,6 +815,14 @@ pub mod types {
       fn from_str(s: &str) -> Result<Self, Self::Err> {
         #[allow(clippy::match_single_binding)]
         match s {
+          "Get" => Ok(Self::Get),
+          "Post" => Ok(Self::Post),
+          "Put" => Ok(Self::Put),
+          "Delete" => Ok(Self::Delete),
+          "Patch" => Ok(Self::Patch),
+          "Head" => Ok(Self::Head),
+          "Options" => Ok(Self::Options),
+          "Trace" => Ok(Self::Trace),
           _ => Err(s.to_owned()),
         }
       }
@@ -667,14 +831,14 @@ pub mod types {
       fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         #[allow(clippy::match_single_binding)]
         match self {
-          Self::Get => f.write_str("GET"),
-          Self::Post => f.write_str("POST"),
-          Self::Put => f.write_str("PUT"),
-          Self::Delete => f.write_str("DELETE"),
-          Self::Patch => f.write_str("PATCH"),
-          Self::Head => f.write_str("HEAD"),
-          Self::Options => f.write_str("OPTIONS"),
-          Self::Trace => f.write_str("TRACE"),
+          Self::Get => f.write_str("Get"),
+          Self::Post => f.write_str("Post"),
+          Self::Put => f.write_str("Put"),
+          Self::Delete => f.write_str("Delete"),
+          Self::Patch => f.write_str("Patch"),
+          Self::Head => f.write_str("Head"),
+          Self::Options => f.write_str("Options"),
+          Self::Trace => f.write_str("Trace"),
         }
       }
     }
@@ -730,11 +894,28 @@ pub mod types {
     }
     #[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize, PartialEq)]
     #[doc = "HTTP scheme"]
+    #[serde(into = "String", try_from = "wick_component::serde::enum_repr::StringOrNum")]
     pub enum HttpScheme {
       #[doc = "HTTP scheme"]
       Http,
       #[doc = "HTTPS scheme"]
       Https,
+    }
+    impl TryFrom<wick_component::serde::enum_repr::StringOrNum> for HttpScheme {
+      type Error = String;
+      fn try_from(value: wick_component::serde::enum_repr::StringOrNum) -> std::result::Result<Self, String> {
+        use std::str::FromStr;
+        match value {
+          wick_component::serde::enum_repr::StringOrNum::String(v) => Self::from_str(&v),
+          wick_component::serde::enum_repr::StringOrNum::Int(v) => Self::from_str(&v.to_string()),
+          wick_component::serde::enum_repr::StringOrNum::Float(v) => Self::from_str(&v.to_string()),
+        }
+      }
+    }
+    impl From<HttpScheme> for String {
+      fn from(value: HttpScheme) -> Self {
+        value.value().map_or_else(|| value.to_string(), |v| v.to_owned())
+      }
     }
     impl HttpScheme {
       #[allow(unused)]
@@ -762,6 +943,8 @@ pub mod types {
       fn from_str(s: &str) -> Result<Self, Self::Err> {
         #[allow(clippy::match_single_binding)]
         match s {
+          "Http" => Ok(Self::Http),
+          "Https" => Ok(Self::Https),
           _ => Err(s.to_owned()),
         }
       }
@@ -770,13 +953,14 @@ pub mod types {
       fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         #[allow(clippy::match_single_binding)]
         match self {
-          Self::Http => f.write_str("HTTP"),
-          Self::Https => f.write_str("HTTPS"),
+          Self::Http => f.write_str("Http"),
+          Self::Https => f.write_str("Https"),
         }
       }
     }
     #[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize, PartialEq)]
     #[doc = "HTTP version"]
+    #[serde(into = "String", try_from = "wick_component::serde::enum_repr::StringOrNum")]
     pub enum HttpVersion {
       #[doc = "HTTP 1.0 version"]
       Http10,
@@ -784,6 +968,22 @@ pub mod types {
       Http11,
       #[doc = "HTTP 2.0 version"]
       Http20,
+    }
+    impl TryFrom<wick_component::serde::enum_repr::StringOrNum> for HttpVersion {
+      type Error = String;
+      fn try_from(value: wick_component::serde::enum_repr::StringOrNum) -> std::result::Result<Self, String> {
+        use std::str::FromStr;
+        match value {
+          wick_component::serde::enum_repr::StringOrNum::String(v) => Self::from_str(&v),
+          wick_component::serde::enum_repr::StringOrNum::Int(v) => Self::from_str(&v.to_string()),
+          wick_component::serde::enum_repr::StringOrNum::Float(v) => Self::from_str(&v.to_string()),
+        }
+      }
+    }
+    impl From<HttpVersion> for String {
+      fn from(value: HttpVersion) -> Self {
+        value.value().map_or_else(|| value.to_string(), |v| v.to_owned())
+      }
     }
     impl HttpVersion {
       #[allow(unused)]
@@ -813,8 +1013,11 @@ pub mod types {
         #[allow(clippy::match_single_binding)]
         match s {
           "1.0" => Ok(Self::Http10),
+          "Http10" => Ok(Self::Http10),
           "1.1" => Ok(Self::Http11),
+          "Http11" => Ok(Self::Http11),
           "2.0" => Ok(Self::Http20),
+          "Http20" => Ok(Self::Http20),
           _ => Err(s.to_owned()),
         }
       }
@@ -823,14 +1026,24 @@ pub mod types {
       fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         #[allow(clippy::match_single_binding)]
         match self {
-          Self::Http10 => f.write_str("HTTP_1_0"),
-          Self::Http11 => f.write_str("HTTP_1_1"),
-          Self::Http20 => f.write_str("HTTP_2_0"),
+          Self::Http10 => f.write_str("1.0"),
+          Self::Http11 => f.write_str("1.1"),
+          Self::Http20 => f.write_str("2.0"),
         }
       }
     }
     #[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize, PartialEq)]
+    #[doc = "A response from pre-request middleware"]
+    #[serde(untagged)]
+    pub enum RequestMiddlewareResponse {
+      #[doc = "A HttpRequest value."]
+      HttpRequest(HttpRequest),
+      #[doc = "A HttpResponse value."]
+      HttpResponse(HttpResponse),
+    }
+    #[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize, PartialEq)]
     #[doc = "HTTP status code"]
+    #[serde(into = "String", try_from = "wick_component::serde::enum_repr::StringOrNum")]
     pub enum StatusCode {
       #[doc = "Continue status code"]
       Continue,
@@ -925,6 +1138,22 @@ pub mod types {
       #[doc = "Indicates an unknown status code"]
       Unknown,
     }
+    impl TryFrom<wick_component::serde::enum_repr::StringOrNum> for StatusCode {
+      type Error = String;
+      fn try_from(value: wick_component::serde::enum_repr::StringOrNum) -> std::result::Result<Self, String> {
+        use std::str::FromStr;
+        match value {
+          wick_component::serde::enum_repr::StringOrNum::String(v) => Self::from_str(&v),
+          wick_component::serde::enum_repr::StringOrNum::Int(v) => Self::from_str(&v.to_string()),
+          wick_component::serde::enum_repr::StringOrNum::Float(v) => Self::from_str(&v.to_string()),
+        }
+      }
+    }
+    impl From<StatusCode> for String {
+      fn from(value: StatusCode) -> Self {
+        value.value().map_or_else(|| value.to_string(), |v| v.to_owned())
+      }
+    }
     impl StatusCode {
       #[allow(unused)]
       #[doc = "Returns the value of the enum variant as a string."]
@@ -996,51 +1225,97 @@ pub mod types {
         #[allow(clippy::match_single_binding)]
         match s {
           "100" => Ok(Self::Continue),
+          "Continue" => Ok(Self::Continue),
           "101" => Ok(Self::SwitchingProtocols),
+          "SwitchingProtocols" => Ok(Self::SwitchingProtocols),
           "200" => Ok(Self::Ok),
+          "Ok" => Ok(Self::Ok),
           "201" => Ok(Self::Created),
+          "Created" => Ok(Self::Created),
           "202" => Ok(Self::Accepted),
+          "Accepted" => Ok(Self::Accepted),
           "203" => Ok(Self::NonAuthoritativeInformation),
+          "NonAuthoritativeInformation" => Ok(Self::NonAuthoritativeInformation),
           "204" => Ok(Self::NoContent),
+          "NoContent" => Ok(Self::NoContent),
           "205" => Ok(Self::ResetContent),
+          "ResetContent" => Ok(Self::ResetContent),
           "206" => Ok(Self::PartialContent),
+          "PartialContent" => Ok(Self::PartialContent),
           "300" => Ok(Self::MultipleChoices),
+          "MultipleChoices" => Ok(Self::MultipleChoices),
           "301" => Ok(Self::MovedPermanently),
+          "MovedPermanently" => Ok(Self::MovedPermanently),
           "302" => Ok(Self::Found),
+          "Found" => Ok(Self::Found),
           "303" => Ok(Self::SeeOther),
+          "SeeOther" => Ok(Self::SeeOther),
           "304" => Ok(Self::NotModified),
+          "NotModified" => Ok(Self::NotModified),
           "307" => Ok(Self::TemporaryRedirect),
+          "TemporaryRedirect" => Ok(Self::TemporaryRedirect),
           "308" => Ok(Self::PermanentRedirect),
+          "PermanentRedirect" => Ok(Self::PermanentRedirect),
           "400" => Ok(Self::BadRequest),
+          "BadRequest" => Ok(Self::BadRequest),
           "401" => Ok(Self::Unauthorized),
+          "Unauthorized" => Ok(Self::Unauthorized),
           "402" => Ok(Self::PaymentRequired),
+          "PaymentRequired" => Ok(Self::PaymentRequired),
           "403" => Ok(Self::Forbidden),
+          "Forbidden" => Ok(Self::Forbidden),
           "404" => Ok(Self::NotFound),
+          "NotFound" => Ok(Self::NotFound),
           "405" => Ok(Self::MethodNotAllowed),
+          "MethodNotAllowed" => Ok(Self::MethodNotAllowed),
           "406" => Ok(Self::NotAcceptable),
+          "NotAcceptable" => Ok(Self::NotAcceptable),
           "407" => Ok(Self::ProxyAuthenticationRequired),
+          "ProxyAuthenticationRequired" => Ok(Self::ProxyAuthenticationRequired),
           "408" => Ok(Self::RequestTimeout),
+          "RequestTimeout" => Ok(Self::RequestTimeout),
           "409" => Ok(Self::Conflict),
+          "Conflict" => Ok(Self::Conflict),
           "410" => Ok(Self::Gone),
+          "Gone" => Ok(Self::Gone),
           "411" => Ok(Self::LengthRequired),
+          "LengthRequired" => Ok(Self::LengthRequired),
           "412" => Ok(Self::PreconditionFailed),
+          "PreconditionFailed" => Ok(Self::PreconditionFailed),
           "413" => Ok(Self::PayloadTooLarge),
+          "PayloadTooLarge" => Ok(Self::PayloadTooLarge),
           "414" => Ok(Self::UriTooLong),
+          "UriTooLong" => Ok(Self::UriTooLong),
           "415" => Ok(Self::UnsupportedMediaType),
+          "UnsupportedMediaType" => Ok(Self::UnsupportedMediaType),
           "416" => Ok(Self::RangeNotSatisfiable),
+          "RangeNotSatisfiable" => Ok(Self::RangeNotSatisfiable),
           "417" => Ok(Self::ExpectationFailed),
+          "ExpectationFailed" => Ok(Self::ExpectationFailed),
           "418" => Ok(Self::ImATeapot),
+          "ImATeapot" => Ok(Self::ImATeapot),
           "422" => Ok(Self::UnprocessableEntity),
+          "UnprocessableEntity" => Ok(Self::UnprocessableEntity),
           "423" => Ok(Self::Locked),
+          "Locked" => Ok(Self::Locked),
           "424" => Ok(Self::FailedDependency),
+          "FailedDependency" => Ok(Self::FailedDependency),
           "429" => Ok(Self::TooManyRequests),
+          "TooManyRequests" => Ok(Self::TooManyRequests),
           "500" => Ok(Self::InternalServerError),
+          "InternalServerError" => Ok(Self::InternalServerError),
           "501" => Ok(Self::NotImplemented),
+          "NotImplemented" => Ok(Self::NotImplemented),
           "502" => Ok(Self::BadGateway),
+          "BadGateway" => Ok(Self::BadGateway),
           "503" => Ok(Self::ServiceUnavailable),
+          "ServiceUnavailable" => Ok(Self::ServiceUnavailable),
           "504" => Ok(Self::GatewayTimeout),
+          "GatewayTimeout" => Ok(Self::GatewayTimeout),
           "505" => Ok(Self::HttpVersionNotSupported),
+          "HttpVersionNotSupported" => Ok(Self::HttpVersionNotSupported),
           "-1" => Ok(Self::Unknown),
+          "Unknown" => Ok(Self::Unknown),
           _ => Err(s.to_owned()),
         }
       }
@@ -1049,52 +1324,52 @@ pub mod types {
       fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         #[allow(clippy::match_single_binding)]
         match self {
-          Self::Continue => f.write_str("Continue"),
-          Self::SwitchingProtocols => f.write_str("SwitchingProtocols"),
-          Self::Ok => f.write_str("OK"),
-          Self::Created => f.write_str("Created"),
-          Self::Accepted => f.write_str("Accepted"),
-          Self::NonAuthoritativeInformation => f.write_str("NonAuthoritativeInformation"),
-          Self::NoContent => f.write_str("NoContent"),
-          Self::ResetContent => f.write_str("ResetContent"),
-          Self::PartialContent => f.write_str("PartialContent"),
-          Self::MultipleChoices => f.write_str("MultipleChoices"),
-          Self::MovedPermanently => f.write_str("MovedPermanently"),
-          Self::Found => f.write_str("Found"),
-          Self::SeeOther => f.write_str("SeeOther"),
-          Self::NotModified => f.write_str("NotModified"),
-          Self::TemporaryRedirect => f.write_str("TemporaryRedirect"),
-          Self::PermanentRedirect => f.write_str("PermanentRedirect"),
-          Self::BadRequest => f.write_str("BadRequest"),
-          Self::Unauthorized => f.write_str("Unauthorized"),
-          Self::PaymentRequired => f.write_str("PaymentRequired"),
-          Self::Forbidden => f.write_str("Forbidden"),
-          Self::NotFound => f.write_str("NotFound"),
-          Self::MethodNotAllowed => f.write_str("MethodNotAllowed"),
-          Self::NotAcceptable => f.write_str("NotAcceptable"),
-          Self::ProxyAuthenticationRequired => f.write_str("ProxyAuthenticationRequired"),
-          Self::RequestTimeout => f.write_str("RequestTimeout"),
-          Self::Conflict => f.write_str("Conflict"),
-          Self::Gone => f.write_str("Gone"),
-          Self::LengthRequired => f.write_str("LengthRequired"),
-          Self::PreconditionFailed => f.write_str("PreconditionFailed"),
-          Self::PayloadTooLarge => f.write_str("PayloadTooLarge"),
-          Self::UriTooLong => f.write_str("URITooLong"),
-          Self::UnsupportedMediaType => f.write_str("UnsupportedMediaType"),
-          Self::RangeNotSatisfiable => f.write_str("RangeNotSatisfiable"),
-          Self::ExpectationFailed => f.write_str("ExpectationFailed"),
-          Self::ImATeapot => f.write_str("ImATeapot"),
-          Self::UnprocessableEntity => f.write_str("UnprocessableEntity"),
-          Self::Locked => f.write_str("Locked"),
-          Self::FailedDependency => f.write_str("FailedDependency"),
-          Self::TooManyRequests => f.write_str("TooManyRequests"),
-          Self::InternalServerError => f.write_str("InternalServerError"),
-          Self::NotImplemented => f.write_str("NotImplemented"),
-          Self::BadGateway => f.write_str("BadGateway"),
-          Self::ServiceUnavailable => f.write_str("ServiceUnavailable"),
-          Self::GatewayTimeout => f.write_str("GatewayTimeout"),
-          Self::HttpVersionNotSupported => f.write_str("HTTPVersionNotSupported"),
-          Self::Unknown => f.write_str("Unknown"),
+          Self::Continue => f.write_str("100"),
+          Self::SwitchingProtocols => f.write_str("101"),
+          Self::Ok => f.write_str("200"),
+          Self::Created => f.write_str("201"),
+          Self::Accepted => f.write_str("202"),
+          Self::NonAuthoritativeInformation => f.write_str("203"),
+          Self::NoContent => f.write_str("204"),
+          Self::ResetContent => f.write_str("205"),
+          Self::PartialContent => f.write_str("206"),
+          Self::MultipleChoices => f.write_str("300"),
+          Self::MovedPermanently => f.write_str("301"),
+          Self::Found => f.write_str("302"),
+          Self::SeeOther => f.write_str("303"),
+          Self::NotModified => f.write_str("304"),
+          Self::TemporaryRedirect => f.write_str("307"),
+          Self::PermanentRedirect => f.write_str("308"),
+          Self::BadRequest => f.write_str("400"),
+          Self::Unauthorized => f.write_str("401"),
+          Self::PaymentRequired => f.write_str("402"),
+          Self::Forbidden => f.write_str("403"),
+          Self::NotFound => f.write_str("404"),
+          Self::MethodNotAllowed => f.write_str("405"),
+          Self::NotAcceptable => f.write_str("406"),
+          Self::ProxyAuthenticationRequired => f.write_str("407"),
+          Self::RequestTimeout => f.write_str("408"),
+          Self::Conflict => f.write_str("409"),
+          Self::Gone => f.write_str("410"),
+          Self::LengthRequired => f.write_str("411"),
+          Self::PreconditionFailed => f.write_str("412"),
+          Self::PayloadTooLarge => f.write_str("413"),
+          Self::UriTooLong => f.write_str("414"),
+          Self::UnsupportedMediaType => f.write_str("415"),
+          Self::RangeNotSatisfiable => f.write_str("416"),
+          Self::ExpectationFailed => f.write_str("417"),
+          Self::ImATeapot => f.write_str("418"),
+          Self::UnprocessableEntity => f.write_str("422"),
+          Self::Locked => f.write_str("423"),
+          Self::FailedDependency => f.write_str("424"),
+          Self::TooManyRequests => f.write_str("429"),
+          Self::InternalServerError => f.write_str("500"),
+          Self::NotImplemented => f.write_str("501"),
+          Self::BadGateway => f.write_str("502"),
+          Self::ServiceUnavailable => f.write_str("503"),
+          Self::GatewayTimeout => f.write_str("504"),
+          Self::HttpVersionNotSupported => f.write_str("505"),
+          Self::Unknown => f.write_str("-1"),
         }
       }
     }
@@ -1104,6 +1379,7 @@ pub mod types {
     use super::http;
     #[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize, PartialEq)]
     #[doc = "HTTP method enum"]
+    #[serde(into = "String", try_from = "wick_component::serde::enum_repr::StringOrNum")]
     pub enum HttpMethod {
       #[doc = "HTTP GET method"]
       Get,
@@ -1121,6 +1397,22 @@ pub mod types {
       Options,
       #[doc = "HTTP TRACE method"]
       Trace,
+    }
+    impl TryFrom<wick_component::serde::enum_repr::StringOrNum> for HttpMethod {
+      type Error = String;
+      fn try_from(value: wick_component::serde::enum_repr::StringOrNum) -> std::result::Result<Self, String> {
+        use std::str::FromStr;
+        match value {
+          wick_component::serde::enum_repr::StringOrNum::String(v) => Self::from_str(&v),
+          wick_component::serde::enum_repr::StringOrNum::Int(v) => Self::from_str(&v.to_string()),
+          wick_component::serde::enum_repr::StringOrNum::Float(v) => Self::from_str(&v.to_string()),
+        }
+      }
+    }
+    impl From<HttpMethod> for String {
+      fn from(value: HttpMethod) -> Self {
+        value.value().map_or_else(|| value.to_string(), |v| v.to_owned())
+      }
     }
     impl HttpMethod {
       #[allow(unused)]
@@ -1154,6 +1446,14 @@ pub mod types {
       fn from_str(s: &str) -> Result<Self, Self::Err> {
         #[allow(clippy::match_single_binding)]
         match s {
+          "Get" => Ok(Self::Get),
+          "Post" => Ok(Self::Post),
+          "Put" => Ok(Self::Put),
+          "Delete" => Ok(Self::Delete),
+          "Patch" => Ok(Self::Patch),
+          "Head" => Ok(Self::Head),
+          "Options" => Ok(Self::Options),
+          "Trace" => Ok(Self::Trace),
           _ => Err(s.to_owned()),
         }
       }
@@ -1162,14 +1462,14 @@ pub mod types {
       fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         #[allow(clippy::match_single_binding)]
         match self {
-          Self::Get => f.write_str("GET"),
-          Self::Post => f.write_str("POST"),
-          Self::Put => f.write_str("PUT"),
-          Self::Delete => f.write_str("DELETE"),
-          Self::Patch => f.write_str("PATCH"),
-          Self::Head => f.write_str("HEAD"),
-          Self::Options => f.write_str("OPTIONS"),
-          Self::Trace => f.write_str("TRACE"),
+          Self::Get => f.write_str("Get"),
+          Self::Post => f.write_str("Post"),
+          Self::Put => f.write_str("Put"),
+          Self::Delete => f.write_str("Delete"),
+          Self::Patch => f.write_str("Patch"),
+          Self::Head => f.write_str("Head"),
+          Self::Options => f.write_str("Options"),
+          Self::Trace => f.write_str("Trace"),
         }
       }
     }
@@ -1225,11 +1525,28 @@ pub mod types {
     }
     #[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize, PartialEq)]
     #[doc = "HTTP scheme"]
+    #[serde(into = "String", try_from = "wick_component::serde::enum_repr::StringOrNum")]
     pub enum HttpScheme {
       #[doc = "HTTP scheme"]
       Http,
       #[doc = "HTTPS scheme"]
       Https,
+    }
+    impl TryFrom<wick_component::serde::enum_repr::StringOrNum> for HttpScheme {
+      type Error = String;
+      fn try_from(value: wick_component::serde::enum_repr::StringOrNum) -> std::result::Result<Self, String> {
+        use std::str::FromStr;
+        match value {
+          wick_component::serde::enum_repr::StringOrNum::String(v) => Self::from_str(&v),
+          wick_component::serde::enum_repr::StringOrNum::Int(v) => Self::from_str(&v.to_string()),
+          wick_component::serde::enum_repr::StringOrNum::Float(v) => Self::from_str(&v.to_string()),
+        }
+      }
+    }
+    impl From<HttpScheme> for String {
+      fn from(value: HttpScheme) -> Self {
+        value.value().map_or_else(|| value.to_string(), |v| v.to_owned())
+      }
     }
     impl HttpScheme {
       #[allow(unused)]
@@ -1257,6 +1574,8 @@ pub mod types {
       fn from_str(s: &str) -> Result<Self, Self::Err> {
         #[allow(clippy::match_single_binding)]
         match s {
+          "Http" => Ok(Self::Http),
+          "Https" => Ok(Self::Https),
           _ => Err(s.to_owned()),
         }
       }
@@ -1265,13 +1584,14 @@ pub mod types {
       fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         #[allow(clippy::match_single_binding)]
         match self {
-          Self::Http => f.write_str("HTTP"),
-          Self::Https => f.write_str("HTTPS"),
+          Self::Http => f.write_str("Http"),
+          Self::Https => f.write_str("Https"),
         }
       }
     }
     #[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize, PartialEq)]
     #[doc = "HTTP version"]
+    #[serde(into = "String", try_from = "wick_component::serde::enum_repr::StringOrNum")]
     pub enum HttpVersion {
       #[doc = "HTTP 1.0 version"]
       Http10,
@@ -1279,6 +1599,22 @@ pub mod types {
       Http11,
       #[doc = "HTTP 2.0 version"]
       Http20,
+    }
+    impl TryFrom<wick_component::serde::enum_repr::StringOrNum> for HttpVersion {
+      type Error = String;
+      fn try_from(value: wick_component::serde::enum_repr::StringOrNum) -> std::result::Result<Self, String> {
+        use std::str::FromStr;
+        match value {
+          wick_component::serde::enum_repr::StringOrNum::String(v) => Self::from_str(&v),
+          wick_component::serde::enum_repr::StringOrNum::Int(v) => Self::from_str(&v.to_string()),
+          wick_component::serde::enum_repr::StringOrNum::Float(v) => Self::from_str(&v.to_string()),
+        }
+      }
+    }
+    impl From<HttpVersion> for String {
+      fn from(value: HttpVersion) -> Self {
+        value.value().map_or_else(|| value.to_string(), |v| v.to_owned())
+      }
     }
     impl HttpVersion {
       #[allow(unused)]
@@ -1308,8 +1644,11 @@ pub mod types {
         #[allow(clippy::match_single_binding)]
         match s {
           "1.0" => Ok(Self::Http10),
+          "Http10" => Ok(Self::Http10),
           "1.1" => Ok(Self::Http11),
+          "Http11" => Ok(Self::Http11),
           "2.0" => Ok(Self::Http20),
+          "Http20" => Ok(Self::Http20),
           _ => Err(s.to_owned()),
         }
       }
@@ -1318,14 +1657,24 @@ pub mod types {
       fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         #[allow(clippy::match_single_binding)]
         match self {
-          Self::Http10 => f.write_str("HTTP_1_0"),
-          Self::Http11 => f.write_str("HTTP_1_1"),
-          Self::Http20 => f.write_str("HTTP_2_0"),
+          Self::Http10 => f.write_str("1.0"),
+          Self::Http11 => f.write_str("1.1"),
+          Self::Http20 => f.write_str("2.0"),
         }
       }
     }
     #[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize, PartialEq)]
+    #[doc = "A response from pre-request middleware"]
+    #[serde(untagged)]
+    pub enum RequestMiddlewareResponse {
+      #[doc = "A HttpRequest value."]
+      HttpRequest(HttpRequest),
+      #[doc = "A HttpResponse value."]
+      HttpResponse(HttpResponse),
+    }
+    #[derive(Debug, Clone, serde :: Serialize, serde :: Deserialize, PartialEq)]
     #[doc = "HTTP status code"]
+    #[serde(into = "String", try_from = "wick_component::serde::enum_repr::StringOrNum")]
     pub enum StatusCode {
       #[doc = "Continue status code"]
       Continue,
@@ -1420,6 +1769,22 @@ pub mod types {
       #[doc = "Indicates an unknown status code"]
       Unknown,
     }
+    impl TryFrom<wick_component::serde::enum_repr::StringOrNum> for StatusCode {
+      type Error = String;
+      fn try_from(value: wick_component::serde::enum_repr::StringOrNum) -> std::result::Result<Self, String> {
+        use std::str::FromStr;
+        match value {
+          wick_component::serde::enum_repr::StringOrNum::String(v) => Self::from_str(&v),
+          wick_component::serde::enum_repr::StringOrNum::Int(v) => Self::from_str(&v.to_string()),
+          wick_component::serde::enum_repr::StringOrNum::Float(v) => Self::from_str(&v.to_string()),
+        }
+      }
+    }
+    impl From<StatusCode> for String {
+      fn from(value: StatusCode) -> Self {
+        value.value().map_or_else(|| value.to_string(), |v| v.to_owned())
+      }
+    }
     impl StatusCode {
       #[allow(unused)]
       #[doc = "Returns the value of the enum variant as a string."]
@@ -1491,51 +1856,97 @@ pub mod types {
         #[allow(clippy::match_single_binding)]
         match s {
           "100" => Ok(Self::Continue),
+          "Continue" => Ok(Self::Continue),
           "101" => Ok(Self::SwitchingProtocols),
+          "SwitchingProtocols" => Ok(Self::SwitchingProtocols),
           "200" => Ok(Self::Ok),
+          "Ok" => Ok(Self::Ok),
           "201" => Ok(Self::Created),
+          "Created" => Ok(Self::Created),
           "202" => Ok(Self::Accepted),
+          "Accepted" => Ok(Self::Accepted),
           "203" => Ok(Self::NonAuthoritativeInformation),
+          "NonAuthoritativeInformation" => Ok(Self::NonAuthoritativeInformation),
           "204" => Ok(Self::NoContent),
+          "NoContent" => Ok(Self::NoContent),
           "205" => Ok(Self::ResetContent),
+          "ResetContent" => Ok(Self::ResetContent),
           "206" => Ok(Self::PartialContent),
+          "PartialContent" => Ok(Self::PartialContent),
           "300" => Ok(Self::MultipleChoices),
+          "MultipleChoices" => Ok(Self::MultipleChoices),
           "301" => Ok(Self::MovedPermanently),
+          "MovedPermanently" => Ok(Self::MovedPermanently),
           "302" => Ok(Self::Found),
+          "Found" => Ok(Self::Found),
           "303" => Ok(Self::SeeOther),
+          "SeeOther" => Ok(Self::SeeOther),
           "304" => Ok(Self::NotModified),
+          "NotModified" => Ok(Self::NotModified),
           "307" => Ok(Self::TemporaryRedirect),
+          "TemporaryRedirect" => Ok(Self::TemporaryRedirect),
           "308" => Ok(Self::PermanentRedirect),
+          "PermanentRedirect" => Ok(Self::PermanentRedirect),
           "400" => Ok(Self::BadRequest),
+          "BadRequest" => Ok(Self::BadRequest),
           "401" => Ok(Self::Unauthorized),
+          "Unauthorized" => Ok(Self::Unauthorized),
           "402" => Ok(Self::PaymentRequired),
+          "PaymentRequired" => Ok(Self::PaymentRequired),
           "403" => Ok(Self::Forbidden),
+          "Forbidden" => Ok(Self::Forbidden),
           "404" => Ok(Self::NotFound),
+          "NotFound" => Ok(Self::NotFound),
           "405" => Ok(Self::MethodNotAllowed),
+          "MethodNotAllowed" => Ok(Self::MethodNotAllowed),
           "406" => Ok(Self::NotAcceptable),
+          "NotAcceptable" => Ok(Self::NotAcceptable),
           "407" => Ok(Self::ProxyAuthenticationRequired),
+          "ProxyAuthenticationRequired" => Ok(Self::ProxyAuthenticationRequired),
           "408" => Ok(Self::RequestTimeout),
+          "RequestTimeout" => Ok(Self::RequestTimeout),
           "409" => Ok(Self::Conflict),
+          "Conflict" => Ok(Self::Conflict),
           "410" => Ok(Self::Gone),
+          "Gone" => Ok(Self::Gone),
           "411" => Ok(Self::LengthRequired),
+          "LengthRequired" => Ok(Self::LengthRequired),
           "412" => Ok(Self::PreconditionFailed),
+          "PreconditionFailed" => Ok(Self::PreconditionFailed),
           "413" => Ok(Self::PayloadTooLarge),
+          "PayloadTooLarge" => Ok(Self::PayloadTooLarge),
           "414" => Ok(Self::UriTooLong),
+          "UriTooLong" => Ok(Self::UriTooLong),
           "415" => Ok(Self::UnsupportedMediaType),
+          "UnsupportedMediaType" => Ok(Self::UnsupportedMediaType),
           "416" => Ok(Self::RangeNotSatisfiable),
+          "RangeNotSatisfiable" => Ok(Self::RangeNotSatisfiable),
           "417" => Ok(Self::ExpectationFailed),
+          "ExpectationFailed" => Ok(Self::ExpectationFailed),
           "418" => Ok(Self::ImATeapot),
+          "ImATeapot" => Ok(Self::ImATeapot),
           "422" => Ok(Self::UnprocessableEntity),
+          "UnprocessableEntity" => Ok(Self::UnprocessableEntity),
           "423" => Ok(Self::Locked),
+          "Locked" => Ok(Self::Locked),
           "424" => Ok(Self::FailedDependency),
+          "FailedDependency" => Ok(Self::FailedDependency),
           "429" => Ok(Self::TooManyRequests),
+          "TooManyRequests" => Ok(Self::TooManyRequests),
           "500" => Ok(Self::InternalServerError),
+          "InternalServerError" => Ok(Self::InternalServerError),
           "501" => Ok(Self::NotImplemented),
+          "NotImplemented" => Ok(Self::NotImplemented),
           "502" => Ok(Self::BadGateway),
+          "BadGateway" => Ok(Self::BadGateway),
           "503" => Ok(Self::ServiceUnavailable),
+          "ServiceUnavailable" => Ok(Self::ServiceUnavailable),
           "504" => Ok(Self::GatewayTimeout),
+          "GatewayTimeout" => Ok(Self::GatewayTimeout),
           "505" => Ok(Self::HttpVersionNotSupported),
+          "HttpVersionNotSupported" => Ok(Self::HttpVersionNotSupported),
           "-1" => Ok(Self::Unknown),
+          "Unknown" => Ok(Self::Unknown),
           _ => Err(s.to_owned()),
         }
       }
@@ -1544,52 +1955,52 @@ pub mod types {
       fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         #[allow(clippy::match_single_binding)]
         match self {
-          Self::Continue => f.write_str("Continue"),
-          Self::SwitchingProtocols => f.write_str("SwitchingProtocols"),
-          Self::Ok => f.write_str("OK"),
-          Self::Created => f.write_str("Created"),
-          Self::Accepted => f.write_str("Accepted"),
-          Self::NonAuthoritativeInformation => f.write_str("NonAuthoritativeInformation"),
-          Self::NoContent => f.write_str("NoContent"),
-          Self::ResetContent => f.write_str("ResetContent"),
-          Self::PartialContent => f.write_str("PartialContent"),
-          Self::MultipleChoices => f.write_str("MultipleChoices"),
-          Self::MovedPermanently => f.write_str("MovedPermanently"),
-          Self::Found => f.write_str("Found"),
-          Self::SeeOther => f.write_str("SeeOther"),
-          Self::NotModified => f.write_str("NotModified"),
-          Self::TemporaryRedirect => f.write_str("TemporaryRedirect"),
-          Self::PermanentRedirect => f.write_str("PermanentRedirect"),
-          Self::BadRequest => f.write_str("BadRequest"),
-          Self::Unauthorized => f.write_str("Unauthorized"),
-          Self::PaymentRequired => f.write_str("PaymentRequired"),
-          Self::Forbidden => f.write_str("Forbidden"),
-          Self::NotFound => f.write_str("NotFound"),
-          Self::MethodNotAllowed => f.write_str("MethodNotAllowed"),
-          Self::NotAcceptable => f.write_str("NotAcceptable"),
-          Self::ProxyAuthenticationRequired => f.write_str("ProxyAuthenticationRequired"),
-          Self::RequestTimeout => f.write_str("RequestTimeout"),
-          Self::Conflict => f.write_str("Conflict"),
-          Self::Gone => f.write_str("Gone"),
-          Self::LengthRequired => f.write_str("LengthRequired"),
-          Self::PreconditionFailed => f.write_str("PreconditionFailed"),
-          Self::PayloadTooLarge => f.write_str("PayloadTooLarge"),
-          Self::UriTooLong => f.write_str("URITooLong"),
-          Self::UnsupportedMediaType => f.write_str("UnsupportedMediaType"),
-          Self::RangeNotSatisfiable => f.write_str("RangeNotSatisfiable"),
-          Self::ExpectationFailed => f.write_str("ExpectationFailed"),
-          Self::ImATeapot => f.write_str("ImATeapot"),
-          Self::UnprocessableEntity => f.write_str("UnprocessableEntity"),
-          Self::Locked => f.write_str("Locked"),
-          Self::FailedDependency => f.write_str("FailedDependency"),
-          Self::TooManyRequests => f.write_str("TooManyRequests"),
-          Self::InternalServerError => f.write_str("InternalServerError"),
-          Self::NotImplemented => f.write_str("NotImplemented"),
-          Self::BadGateway => f.write_str("BadGateway"),
-          Self::ServiceUnavailable => f.write_str("ServiceUnavailable"),
-          Self::GatewayTimeout => f.write_str("GatewayTimeout"),
-          Self::HttpVersionNotSupported => f.write_str("HTTPVersionNotSupported"),
-          Self::Unknown => f.write_str("Unknown"),
+          Self::Continue => f.write_str("100"),
+          Self::SwitchingProtocols => f.write_str("101"),
+          Self::Ok => f.write_str("200"),
+          Self::Created => f.write_str("201"),
+          Self::Accepted => f.write_str("202"),
+          Self::NonAuthoritativeInformation => f.write_str("203"),
+          Self::NoContent => f.write_str("204"),
+          Self::ResetContent => f.write_str("205"),
+          Self::PartialContent => f.write_str("206"),
+          Self::MultipleChoices => f.write_str("300"),
+          Self::MovedPermanently => f.write_str("301"),
+          Self::Found => f.write_str("302"),
+          Self::SeeOther => f.write_str("303"),
+          Self::NotModified => f.write_str("304"),
+          Self::TemporaryRedirect => f.write_str("307"),
+          Self::PermanentRedirect => f.write_str("308"),
+          Self::BadRequest => f.write_str("400"),
+          Self::Unauthorized => f.write_str("401"),
+          Self::PaymentRequired => f.write_str("402"),
+          Self::Forbidden => f.write_str("403"),
+          Self::NotFound => f.write_str("404"),
+          Self::MethodNotAllowed => f.write_str("405"),
+          Self::NotAcceptable => f.write_str("406"),
+          Self::ProxyAuthenticationRequired => f.write_str("407"),
+          Self::RequestTimeout => f.write_str("408"),
+          Self::Conflict => f.write_str("409"),
+          Self::Gone => f.write_str("410"),
+          Self::LengthRequired => f.write_str("411"),
+          Self::PreconditionFailed => f.write_str("412"),
+          Self::PayloadTooLarge => f.write_str("413"),
+          Self::UriTooLong => f.write_str("414"),
+          Self::UnsupportedMediaType => f.write_str("415"),
+          Self::RangeNotSatisfiable => f.write_str("416"),
+          Self::ExpectationFailed => f.write_str("417"),
+          Self::ImATeapot => f.write_str("418"),
+          Self::UnprocessableEntity => f.write_str("422"),
+          Self::Locked => f.write_str("423"),
+          Self::FailedDependency => f.write_str("424"),
+          Self::TooManyRequests => f.write_str("429"),
+          Self::InternalServerError => f.write_str("500"),
+          Self::NotImplemented => f.write_str("501"),
+          Self::BadGateway => f.write_str("502"),
+          Self::ServiceUnavailable => f.write_str("503"),
+          Self::GatewayTimeout => f.write_str("504"),
+          Self::HttpVersionNotSupported => f.write_str("505"),
+          Self::Unknown => f.write_str("-1"),
         }
       }
     }


### PR DESCRIPTION
The previous middleware solution required operations to have two outputs, one request & one response, and used a "first-wins" approach to deciding how to act. This changes the output signature to be a union of either/or.

This also fixes encoding of enums which was breaking building composite middleware.