### PR TITLE
Fixed "Too many connections to input port 'input'" errors for pluck path syntax

### DIFF
--- a/crates/wick/flow-graph-interpreter/src/graph.rs
+++ b/crates/wick/flow-graph-interpreter/src/graph.rs
@@ -233,13 +233,13 @@ fn expand_port_paths(
   schematic: &mut Schematic,
   expressions: &mut [FlowExpression],
 ) -> Result<(), flow_graph::error::Error> {
-  for expression in expressions.iter_mut() {
+  for (i, expression) in expressions.iter_mut().enumerate() {
     if let FlowExpression::ConnectionExpression(expr) = expression {
       let (from, to) = expr.clone().into_parts();
       let (from_inst, from_port, _) = from.into_parts();
       let (to_inst, to_port, _) = to.into_parts();
       if let InstancePort::Path(name, parts) = from_port {
-        let id = format!("{}_pluck_{}_[{}]", schematic.name(), name, parts.join(","));
+        let id = format!("{}_pluck_{}_{}_[{}]", schematic.name(), i, name, parts.join(","));
         let config = HashMap::from([(
           "path".to_owned(),
           Value::Array(parts.into_iter().map(Value::String).collect()),

--- a/crates/wick/flow-graph-interpreter/tests/core.rs
+++ b/crates/wick/flow-graph-interpreter/tests/core.rs
@@ -25,6 +25,35 @@ async fn test_pluck() -> Result<()> {
 }
 
 #[test_logger::test(tokio::test)]
+async fn test_pluck_substreams() -> Result<()> {
+  test_config(
+    "./tests/manifests/v1/core-pluck-streams.yaml",
+    None,
+    None,
+    vec![
+      Packet::open_bracket("input"),
+      Packet::encode("input", json!({"value": "value1!"})),
+      Packet::encode("input", json!({"value": "value2!"})),
+      Packet::close_bracket("input"),
+      Packet::done("input"),
+    ],
+    vec![
+      Packet::open_bracket("pluck1"),
+      Packet::encode("pluck1", "value1!"),
+      Packet::encode("pluck1", "value2!"),
+      Packet::close_bracket("pluck1"),
+      Packet::done("pluck1"),
+      Packet::open_bracket("pluck2"),
+      Packet::encode("pluck2", "value1!"),
+      Packet::encode("pluck2", "value2!"),
+      Packet::close_bracket("pluck2"),
+      Packet::done("pluck2"),
+    ],
+  )
+  .await
+}
+
+#[test_logger::test(tokio::test)]
 async fn test_pluck_shorthand() -> Result<()> {
   first_packet_test(
     "./tests/manifests/v1/core-pluck-shorthand.yaml",

--- a/crates/wick/flow-graph-interpreter/tests/manifests/v1/core-pluck-streams.yaml
+++ b/crates/wick/flow-graph-interpreter/tests/manifests/v1/core-pluck-streams.yaml
@@ -8,4 +8,5 @@ component:
   operations:
     - name: test
       flow:
-        - <>.request.headers.cookie.0 -> <>.output
+        - <>.input.value -> <>.pluck1
+        - <>.input.value -> <>.pluck2


### PR DESCRIPTION
The generated pluck IDs didn't account for plucking multiple of the same path. This PR better differentiates them.