### PR TITLE
Fixed infinite loop on sql server queries with no inputs

### DIFF
--- a/crates/components/wick-sql/src/mssql_tiberius/component.rs
+++ b/crates/components/wick-sql/src/mssql_tiberius/component.rs
@@ -267,6 +267,10 @@ async fn handle_stream(
         return Err(Error::OperationFailed(e.to_string()));
       }
     };
+
+    if opdef.inputs().len() == 0 {
+      break 'outer;
+    }
   }
   Ok(())
 }


### PR DESCRIPTION
The sql server op implementation didn't have an escape hatch to stop executing queries if they didn't have any inputs. This PR fixes it. 