### PR TITLE
Fixed root config from being generated with raw packets when codegenning with `raw(true)`

### DIFF
--- a/crates/wick/wick-component-codegen/src/generate/f.rs
+++ b/crates/wick/wick-component-codegen/src/generate/f.rs
@@ -22,11 +22,13 @@ pub(crate) fn field_pair(
   config: &mut config::Config,
   imported: bool,
   serde: bool,
+  dir: Direction,
 ) -> impl FnMut(&Field) -> TokenStream + '_ {
   move |field: &Field| {
     let name = &field.name;
     let id = id(&snake(name));
-    let ty = expand_type(config, Direction::In, imported, &field.ty);
+
+    let ty = expand_type(config, dir, imported, &field.ty);
     let desc = field
       .description
       .as_ref()

--- a/crates/wick/wick-component-codegen/src/generate/templates/type_def.rs
+++ b/crates/wick/wick-component-codegen/src/generate/templates/type_def.rs
@@ -208,7 +208,7 @@ pub(crate) fn gen_struct<'a>(
   let fields = ty
     .fields
     .iter()
-    .map(f::field_pair(config, imported, true))
+    .map(f::field_pair(config, imported, true, Direction::Out))
     .collect_vec();
 
   let (derive, default_impl) = if ty.fields.is_empty() {


### PR DESCRIPTION
If you build the codegen with `raw(true)` to get access to unprocessed packets, it will generate `RootConfig` with Packets instead of decoded values. This wouldn't be a deal breaker if `RootConfig` didn't need to be default-capable.

This needs a better solution in the long run. This is a bit of a hack but highlights more of how codegen needs to be refactored to account for new usage.