### PR TITLE
Removed protoc as a root dev dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3226,7 +3226,7 @@ dependencies = [
  "opentelemetry",
  "prost",
  "tonic 0.8.3",
- "tonic-build 0.8.4",
+ "tonic-build",
 ]
 
 [[package]]
@@ -5312,19 +5312,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tonic-build"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6fdaae4c2c638bb70fe42803a26fbd6fc6ac8c72f5c59f67ecc2a2dcabf4b07"
-dependencies = [
- "prettyplease",
- "proc-macro2",
- "prost-build",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "tonic-reflection"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6837,7 +6824,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tonic 0.9.2",
- "tonic-build 0.9.2",
  "tracing",
  "uuid",
  "wick-interface-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
   "tests/*"
 ]
 exclude = [
+  "crates/wick/wick-rpc/codegen",
   "crates/integration/test-baseline-component",
   "crates/integration/test-cli-trigger-component",
   "crates/integration/test-cli-with-db",
@@ -188,7 +189,6 @@ tokio-postgres = "0.7"
 tokio-stream = { version = "0.1", default-features = false }
 tokio-util = "0.7"
 tonic = "0.9"
-tonic-build = { version = "0.9", default-features = false }
 tonic-reflection = { version = "0.9", default-features = false }
 tracing = "0.1"
 tracing-futures = "0.2"

--- a/Justfile
+++ b/Justfile
@@ -43,6 +43,7 @@ clean:
   cargo clean
   rm -rf node_modules
   just crates/wick/wick-config/clean
+  just crates/wick/wick-rpc/clean
   just wasm-clean
 
 # Run the basic suite of tests
@@ -89,6 +90,7 @@ integration-teardown:
 
 # Run codegen-related tasks
 codegen:
+  just crates/wick/wick-rpc/codegen
   just crates/wick/wick-config/codegen
   cp crates/wick/wick-config/docs/v*.md docs/content/configuration/reference/
 

--- a/crates/wick/wick-rpc/Cargo.toml
+++ b/crates/wick/wick-rpc/Cargo.toml
@@ -23,10 +23,4 @@ thiserror = { workspace = true }
 uuid = { workspace = true }
 option-utils = { workspace = true }
 
-[build-dependencies]
-tonic-build = { workspace = true, default-features = false, features = [
-  "prost",
-  "transport"
-] }
-
 [dev-dependencies]

--- a/crates/wick/wick-rpc/Justfile
+++ b/crates/wick/wick-rpc/Justfile
@@ -1,0 +1,6 @@
+
+clean:
+  rm -f src/generated/*
+
+codegen:
+  cargo run --manifest-path=./codegen/Cargo.toml

--- a/crates/wick/wick-rpc/README.md
+++ b/crates/wick/wick-rpc/README.md
@@ -2,4 +2,4 @@
 
 Wick RPC SDK
 
-License: BSD-3-Clause
+License: Elastic-2.0

--- a/crates/wick/wick-rpc/codegen/Cargo.toml
+++ b/crates/wick/wick-rpc/codegen/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "wick-rpc-codegen"
+version = "0.1.0"
+edition = "2021"
+license = "Elastic-2.0"
+repository = "https://github.com/candlecorp/wick"
+description = "Library for generating protobuf code for the wick runtime"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+
+[dependencies]
+tonic-build = { version = "0.9", default-features = false, features = [
+  "prost",
+  "transport"
+] }

--- a/crates/wick/wick-rpc/codegen/src/main.rs
+++ b/crates/wick/wick-rpc/codegen/src/main.rs
@@ -1,8 +1,6 @@
 use std::process::Command;
 
 fn main() {
-  println!("cargo:rerun-if-changed=proto/wick.proto");
-  println!("cargo:rustc-env=OUT_DIR=generated");
   tonic_build::configure()
     .out_dir("src/generated")
     .file_descriptor_set_path("src/generated/descriptors.bin")


### PR DESCRIPTION
This PR removes the protobuf build script and moves it to a justfile task and a workspace-separate crate.

This means that codegen needs to happen manually (via `just codegen`) when the `.proto` file changes, but it also means that you don't need `protoc` installed locally unless you're actively editing the `.proto` files.