### PR TITLE
Updated openAPI path + REST router modification

### DIFF
--- a/crates/wick/wick-config/definitions/v1/manifest.apex
+++ b/crates/wick/wick-config/definitions/v1/manifest.apex
@@ -232,8 +232,8 @@ type Route {
   operation: ComponentOperationExpression @required @shortform @custom_serializer("crate::v1::helpers::serialize_component_expression")
   "The HTTP methods to serve this route for."
   methods: [HttpMethod]
-  "The name of the route, used for documentation and tooling."
-  name: string?
+  "The unique ID of the route, used for documentation and tooling."
+  id: string?
   "A short description of the route."
   description: string?
   "A longer description of the route."

--- a/crates/wick/wick-config/docs/v1.md
+++ b/crates/wick/wick-config/docs/v1.md
@@ -453,7 +453,7 @@ Any one of the following types:
 | `sub_path` | <code>`string`</code> |The path to serve this route from. See [URI documentation](/docs/configuration/uri) for more information on specifying query and path parameters.|Yes||
 | `operation` | <code>[`ComponentOperationExpression`](#componentoperationexpression)</code> |The operation that will act as the main entrypoint for this route.|Yes|[Yes](/docs/configuration/v1/shortform#componentoperationexpression)|
 | `methods` | <code>[`HttpMethod`](#httpmethod)[]</code> |The HTTP methods to serve this route for.|||
-| `name` | <code>`string`</code> |The name of the route, used for documentation and tooling.|||
+| `id` | <code>`string`</code> |The unique ID of the route, used for documentation and tooling.|||
 | `description` | <code>`string`</code> |A short description of the route.|||
 | `summary` | <code>`string`</code> |A longer description of the route.|||
 

--- a/crates/wick/wick-config/json-schema/manifest.json
+++ b/crates/wick/wick-config/json-schema/manifest.json
@@ -1049,8 +1049,8 @@
               "$ref": "#/$defs/v1/HttpMethod"
             }
           },
-          "name": {
-            "description": "The name of the route, used for documentation and tooling.",
+          "id": {
+            "description": "The unique ID of the route, used for documentation and tooling.",
             "required": false,
             "type": "string"
           },

--- a/crates/wick/wick-config/json-schema/v1/manifest.json
+++ b/crates/wick/wick-config/json-schema/v1/manifest.json
@@ -603,8 +603,8 @@
             "$ref": "#/$defs/v1/HttpMethod"
           }
         },
-        "name": {
-          "description": "The name of the route, used for documentation and tooling.",
+        "id": {
+          "description": "The unique ID of the route, used for documentation and tooling.",
           "required": false,
 
           "type": "string"

--- a/crates/wick/wick-config/src/config/app_config/triggers/http/rest_router.rs
+++ b/crates/wick/wick-config/src/config/app_config/triggers/http/rest_router.rs
@@ -101,7 +101,7 @@ pub struct Contact {
 pub struct RestRoute {
   /// The name of the route, used for documentation and tooling.
   #[asset(skip)]
-  pub(crate) name: Option<String>,
+  pub(crate) id: Option<String>,
   /// The HTTP methods to serve this route for.
   #[asset(skip)]
   pub(crate) methods: Vec<HttpMethod>,

--- a/crates/wick/wick-config/src/v1.rs
+++ b/crates/wick/wick-config/src/v1.rs
@@ -439,11 +439,11 @@ pub(crate) struct Route {
   #[serde(default)]
   #[serde(skip_serializing_if = "Vec::is_empty")]
   pub(crate) methods: Vec<HttpMethod>,
-  /// The name of the route, used for documentation and tooling.
+  /// The unique ID of the route, used for documentation and tooling.
 
   #[serde(default)]
   #[serde(skip_serializing_if = "Option::is_none")]
-  pub(crate) name: Option<String>,
+  pub(crate) id: Option<String>,
   /// A short description of the route.
 
   #[serde(default)]

--- a/crates/wick/wick-config/src/v1/conversions.rs
+++ b/crates/wick/wick-config/src/v1/conversions.rs
@@ -589,7 +589,7 @@ impl TryFrom<v1::Route> for config::RestRoute {
 
   fn try_from(value: v1::Route) -> std::result::Result<Self, Self::Error> {
     Ok(Self {
-      name: value.name,
+      id: value.id,
       methods: value.methods.map_into(),
       sub_path: value.sub_path,
       operation: value.operation.try_into()?,
@@ -604,7 +604,7 @@ impl TryFrom<config::RestRoute> for v1::Route {
 
   fn try_from(value: config::RestRoute) -> std::result::Result<Self, Self::Error> {
     Ok(Self {
-      name: value.name,
+      id: value.id,
       methods: value.methods.map_into(),
       sub_path: value.sub_path,
       operation: value.operation.try_into()?,

--- a/crates/wick/wick-runtime/src/triggers/http/rest_router.rs
+++ b/crates/wick/wick-runtime/src/triggers/http/rest_router.rs
@@ -25,7 +25,7 @@ use super::{HttpError, RawRouter};
 use crate::triggers::http::component_utils::stream_to_json;
 use crate::Runtime;
 
-pub(crate) const OPENAPI_PATH: &str = "openapi.json";
+pub(crate) const OPENAPI_PATH: &str = "/openapi.json";
 
 #[derive()]
 #[must_use]

--- a/crates/wick/wick-runtime/src/triggers/http/rest_router/openapi.rs
+++ b/crates/wick/wick-runtime/src/triggers/http/rest_router/openapi.rs
@@ -151,10 +151,10 @@ fn route_to_path_item(route: &RestRoute, named: &mut HashSet<String>) -> PathIte
   }
   let oapi_operation = Operation {
     tags: Default::default(),
-    summary: route.config.summary().cloned(),
-    description: route.config.description().cloned(),
+    operation_id: route.config.id().cloned(),
+    summary: None,
+    description: None,
     external_docs: Default::default(),
-    operation_id: Default::default(),
     parameters: Default::default(),
     request_body: Default::default(),
     responses: Responses::default(),

--- a/docs/content/configuration/reference/v1.md
+++ b/docs/content/configuration/reference/v1.md
@@ -453,7 +453,7 @@ Any one of the following types:
 | `sub_path` | <code>`string`</code> |The path to serve this route from. See [URI documentation](/docs/configuration/uri) for more information on specifying query and path parameters.|Yes||
 | `operation` | <code>[`ComponentOperationExpression`](#componentoperationexpression)</code> |The operation that will act as the main entrypoint for this route.|Yes|[Yes](/docs/configuration/v1/shortform#componentoperationexpression)|
 | `methods` | <code>[`HttpMethod`](#httpmethod)[]</code> |The HTTP methods to serve this route for.|||
-| `name` | <code>`string`</code> |The name of the route, used for documentation and tooling.|||
+| `id` | <code>`string`</code> |The unique ID of the route, used for documentation and tooling.|||
 | `description` | <code>`string`</code> |A short description of the route.|||
 | `summary` | <code>`string`</code> |A longer description of the route.|||
 


### PR DESCRIPTION
In this PR:

- updated the openapi path to work as intended.
- replaced `name` with `id` in REST router config.