### PR TITLE
Improved how forgiving `wick test` is

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6958,12 +6958,14 @@ dependencies = [
 name = "wick-test"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "assert-json-diff",
  "flow-component",
  "serde",
  "serde-value",
  "serde_json",
  "tap-harness",
+ "test-logger",
  "thiserror",
  "tokio",
  "tokio-stream",
@@ -6971,6 +6973,7 @@ dependencies = [
  "wasmrs-codec",
  "wick-config",
  "wick-interface-types",
+ "wick-logger",
  "wick-packet",
 ]
 

--- a/crates/wick/wick-config/definitions/v1/manifest.apex
+++ b/crates/wick/wick-config/definitions/v1/manifest.apex
@@ -729,8 +729,11 @@ type SuccessPacket {
   "The name of the input or output this packet is going to or coming from."
   name: string @required
 
-  "Any flags set on the packet."
-  flags: PacketFlags?
+  "Any flags set on the packet. Deprecated, use 'flag:' instead"
+  flags: PacketFlags? @deprecated
+
+  "The flag set on the packet."
+  flag: PacketFlag?
 
   "The data to send."
   value: LiquidJsonValue? @alias("data")
@@ -740,8 +743,11 @@ type ErrorPacket {
   "The name of the input or output this packet is going to or coming from."
   name: string @required
 
-  "Any flags set on the packet."
-  flags: PacketFlags?
+  "Any flags set on the packet. Deprecated, use 'flag:' instead"
+  flags: PacketFlags? @deprecated
+
+  "The flag set on the packet."
+  flag: PacketFlag?
 
   "The error message."
   error: LiquidTemplate @required
@@ -757,6 +763,16 @@ type PacketFlags {
 
   "Indicates the closing of a substream context within the parent stream."
   close: bool
+}
+
+"Possible flags that can be set on a packet."
+enum PacketFlag {
+  "Indicates the port should be considered closed."
+  Done = 0 as "done",
+  "Indicates the opening of a new substream context within the parent stream."
+  Open = 1 as "open",
+  "Indicates the closing of a substream context within the parent stream."
+  Close = 2 as "close",
 }
 
 "A dynamic component whose operations are SQL queries to a database."

--- a/crates/wick/wick-config/docs/v1.md
+++ b/crates/wick/wick-config/docs/v1.md
@@ -1451,7 +1451,8 @@ Any one of the following types:
 | Field name | Type | Description | Required? | Shortform? |
 |------------|------|-------------|-----------|------------|
 | `name` | <code>`string`</code> |The name of the input or output this packet is going to or coming from.|Yes||
-| `flags` | <code>[`PacketFlags`](#packetflags)</code> |Any flags set on the packet.|||
+| `flags` | <code>[`PacketFlags`](#packetflags)</code> |Any flags set on the packet. Deprecated, use 'flag:' instead|||
+| `flag` | <code>[`PacketFlag`](#packetflag)</code> |The flag set on the packet.|||
 | `value` | <code>[`LiquidJsonValue`](#liquidjsonvalue)</code> |The data to send.|||
 
 
@@ -1466,7 +1467,8 @@ Any one of the following types:
 | Field name | Type | Description | Required? | Shortform? |
 |------------|------|-------------|-----------|------------|
 | `name` | <code>`string`</code> |The name of the input or output this packet is going to or coming from.|Yes||
-| `flags` | <code>[`PacketFlags`](#packetflags)</code> |Any flags set on the packet.|||
+| `flags` | <code>[`PacketFlags`](#packetflags)</code> |Any flags set on the packet. Deprecated, use 'flag:' instead|||
+| `flag` | <code>[`PacketFlag`](#packetflag)</code> |The flag set on the packet.|||
 | `error` | <code>[`LiquidTemplate`](#liquidtemplate)</code> |The error message.|Yes||
 
 
@@ -1487,6 +1489,25 @@ Any one of the following types:
 | `open` | <code>`bool`</code> |Indicates the opening of a new substream context within the parent stream.|||
 | `close` | <code>`bool`</code> |Indicates the closing of a substream context within the parent stream.|||
 
+
+
+--------
+
+## PacketFlag
+
+  <p>
+    <div style="font-style:italic">Possible flags that can be set on a packet.</div>
+  </p>
+
+
+
+
+
+| Field name | Type | Description |
+|------------|------|-------------|
+| Done | unknown type | Indicates the port should be considered closed. |
+| Open | unknown type | Indicates the opening of a new substream context within the parent stream. |
+| Close | unknown type | Indicates the closing of a substream context within the parent stream. |
 
 
 --------

--- a/crates/wick/wick-config/json-schema/manifest.json
+++ b/crates/wick/wick-config/json-schema/manifest.json
@@ -2458,9 +2458,14 @@
             "type": "string"
           },
           "flags": {
-            "description": "Any flags set on the packet.",
+            "description": "Any flags set on the packet. Deprecated, use &#x27;flag:&#x27; instead",
             "required": false,
             "$ref": "#/$defs/v1/PacketFlags"
+          },
+          "flag": {
+            "description": "The flag set on the packet.",
+            "required": false,
+            "$ref": "#/$defs/v1/PacketFlag"
           },
           "value": {
             "description": "The data to send.",
@@ -2482,9 +2487,14 @@
             "type": "string"
           },
           "flags": {
-            "description": "Any flags set on the packet.",
+            "description": "Any flags set on the packet. Deprecated, use &#x27;flag:&#x27; instead",
             "required": false,
             "$ref": "#/$defs/v1/PacketFlags"
+          },
+          "flag": {
+            "description": "The flag set on the packet.",
+            "required": false,
+            "$ref": "#/$defs/v1/PacketFlag"
           },
           "error": {
             "description": "The error message.",
@@ -2515,6 +2525,14 @@
           }
         },
         "required": []
+      },
+      "PacketFlag": {
+        "$anchor": "#v1/PacketFlag",
+        "enum": [
+          "Done",
+          "Open",
+          "Close"
+        ]
       },
       "SqlComponent": {
         "$anchor": "#v1/SqlComponent",

--- a/crates/wick/wick-config/json-schema/v1/manifest.json
+++ b/crates/wick/wick-config/json-schema/v1/manifest.json
@@ -1993,10 +1993,16 @@
           "type": "string"
         },
         "flags": {
-          "description": "Any flags set on the packet.",
+          "description": "Any flags set on the packet. Deprecated, use &#x27;flag:&#x27; instead",
           "required": false,
 
           "$ref": "#/$defs/v1/PacketFlags"
+        },
+        "flag": {
+          "description": "The flag set on the packet.",
+          "required": false,
+
+          "$ref": "#/$defs/v1/PacketFlag"
         },
         "value": {
           "description": "The data to send.",
@@ -2019,10 +2025,16 @@
           "type": "string"
         },
         "flags": {
-          "description": "Any flags set on the packet.",
+          "description": "Any flags set on the packet. Deprecated, use &#x27;flag:&#x27; instead",
           "required": false,
 
           "$ref": "#/$defs/v1/PacketFlags"
+        },
+        "flag": {
+          "description": "The flag set on the packet.",
+          "required": false,
+
+          "$ref": "#/$defs/v1/PacketFlag"
         },
         "error": {
           "description": "The error message.",
@@ -2055,6 +2067,11 @@
         }
       },
       "required": []
+    },
+
+    "PacketFlag": {
+      "$anchor": "#v1/PacketFlag",
+      "enum": ["Done", "Open", "Close"]
     },
 
     "SqlComponent": {

--- a/crates/wick/wick-config/src/config/common/test_case.rs
+++ b/crates/wick/wick-config/src/config/common/test_case.rs
@@ -3,31 +3,39 @@ use liquid_json::LiquidJsonValue;
 
 use crate::config::{LiquidJsonConfig, TemplateConfig};
 
-#[derive(Debug, Clone, PartialEq, property::Property)]
+#[derive(Debug, Clone, PartialEq, property::Property, Builder)]
 #[property(get(public), set(private), mut(disable))]
 /// A test case for a component.
 pub struct TestCase {
   /// The name of the test.
+  #[builder(default)]
   pub(crate) name: Option<String>,
   /// The operaton to test.
+  #[builder(default, setter(into))]
   pub(crate) operation: String,
   /// The configuration for the operation being tested, if any.
+  #[builder(default)]
   pub(crate) config: Option<LiquidJsonConfig>,
   /// Inherent data to use for the test.
+  #[builder(default)]
   pub(crate) inherent: Option<InherentConfig>,
   /// The inputs to the test.
+  #[builder(default)]
   pub(crate) inputs: Vec<TestPacket>,
   /// The expected outputs of the operation.
+  #[builder(default)]
   pub(crate) outputs: Vec<TestPacket>,
 }
 
-#[derive(Debug, Clone, PartialEq, Copy, property::Property)]
+#[derive(Debug, Default, Clone, PartialEq, Copy, property::Property, Builder)]
 #[property(get(public), set(private), mut(disable))]
 /// Data inherent to transactions.
 pub struct InherentConfig {
   /// An RNG seed.
+  #[builder(default)]
   pub(crate) seed: Option<u64>,
   /// A timestamp.
+  #[builder(default)]
   pub(crate) timestamp: Option<u64>,
 }
 
@@ -41,6 +49,56 @@ pub enum TestPacket {
 }
 
 impl TestPacket {
+  /// Create a new success packet.
+  #[must_use]
+  pub fn success(port: impl Into<String>, data: Option<LiquidJsonValue>) -> Self {
+    Self::SuccessPacket(SuccessPayload {
+      port: port.into(),
+      flag: None,
+      data,
+    })
+  }
+
+  /// Create a new error packet.
+  #[must_use]
+  pub fn error(port: impl Into<String>, error: impl Into<String>) -> Self {
+    Self::ErrorPacket(ErrorPayload {
+      port: port.into(),
+      flag: None,
+      error: TemplateConfig::new_template(error.into()),
+    })
+  }
+
+  /// Create a new done packet.
+  #[must_use]
+  pub fn done(port: impl Into<String>) -> Self {
+    Self::SuccessPacket(SuccessPayload {
+      port: port.into(),
+      flag: Some(PacketFlag::Done),
+      data: None,
+    })
+  }
+
+  /// Create a new open packet.
+  #[must_use]
+  pub fn open(port: impl Into<String>) -> Self {
+    Self::SuccessPacket(SuccessPayload {
+      port: port.into(),
+      flag: Some(PacketFlag::Open),
+      data: None,
+    })
+  }
+
+  /// Create a new close packet.
+  #[must_use]
+  pub fn close(port: impl Into<String>) -> Self {
+    Self::SuccessPacket(SuccessPayload {
+      port: port.into(),
+      flag: Some(PacketFlag::Close),
+      data: None,
+    })
+  }
+
   /// Get the port name for the packet.
   #[must_use]
   pub fn port(&self) -> &str {
@@ -52,11 +110,11 @@ impl TestPacket {
 
   /// Get the flags for the packet.
   #[must_use]
-  pub fn flags(&self) -> Option<PacketFlags> {
-    match self {
-      TestPacket::SuccessPacket(data) => data.flags,
-      TestPacket::ErrorPacket(data) => data.flags,
-    }
+  pub fn flag(&self) -> MaybePacketFlag {
+    MaybePacketFlag(match self {
+      TestPacket::SuccessPacket(data) => data.flag,
+      TestPacket::ErrorPacket(data) => data.flag,
+    })
   }
 
   /// Get the data for the packet.
@@ -69,14 +127,46 @@ impl TestPacket {
   }
 }
 
+/// A utility wrapper for an [Option<PacketFlag>] that allows for more ergonomic assertions.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MaybePacketFlag(Option<PacketFlag>);
+
+impl std::ops::Deref for MaybePacketFlag {
+  type Target = Option<PacketFlag>;
+
+  fn deref(&self) -> &Self::Target {
+    &self.0
+  }
+}
+
+impl MaybePacketFlag {
+  /// Check if the flag is set to `Done`.
+  #[must_use]
+  pub fn is_done(&self) -> bool {
+    matches!(self.0, Some(PacketFlag::Done))
+  }
+
+  /// Check if the flag is set to `Open`.
+  #[must_use]
+  pub fn is_open(&self) -> bool {
+    matches!(self.0, Some(PacketFlag::Open))
+  }
+
+  /// Check if the flag is set to `Close`.
+  #[must_use]
+  pub fn is_close(&self) -> bool {
+    matches!(self.0, Some(PacketFlag::Close))
+  }
+}
+
 #[derive(Debug, Clone, PartialEq, property::Property)]
 #[property(get(public), set(private), mut(disable))]
 /// A simplified representation of a Wick data packet & payload, used to write tests.
 pub struct SuccessPayload {
   /// The name of the port to send the data to.
   pub(crate) port: String,
-  /// Any flags set on the packet.
-  pub(crate) flags: Option<PacketFlags>,
+  /// The flag set on the packet.
+  pub(crate) flag: Option<PacketFlag>,
   /// The data to send.
   pub(crate) data: Option<LiquidJsonValue>,
 }
@@ -87,20 +177,19 @@ pub struct SuccessPayload {
 pub struct ErrorPayload {
   /// The name of the port to send the data to.
   pub(crate) port: String,
-  /// Any flags set on the packet.
-  pub(crate) flags: Option<PacketFlags>,
+  /// The flag set on the packet.
+  pub(crate) flag: Option<PacketFlag>,
   /// The error message.
   pub(crate) error: TemplateConfig<String>,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, property::Property)]
-#[property(get(public), set(private), mut(disable))]
-/// Flags set on a packet.
-pub struct PacketFlags {
-  /// When set, indicates the port should be considered closed.
-  pub(crate) done: bool,
-  /// When set, indicates the opening of a new substream context within the parent stream.
-  pub(crate) open: bool,
-  /// When set, indicates the closing of a substream context within the parent stream.
-  pub(crate) close: bool,
+#[derive(Debug, Clone, Copy, PartialEq)]
+/// Possible flags that can be set on a packet.
+pub enum PacketFlag {
+  /// Indicates the port should be considered closed.
+  Done = 0,
+  /// Indicates the opening of a new substream context within the parent stream.
+  Open = 1,
+  /// Indicates the closing of a substream context within the parent stream.
+  Close = 2,
 }

--- a/crates/wick/wick-config/src/config/test_config.rs
+++ b/crates/wick/wick-config/src/config/test_config.rs
@@ -16,25 +16,29 @@ use crate::error::ManifestError;
 ///
 /// A tests configuration is a collection of shareable and reusable unit tests against wick components and operations.
 pub struct TestConfiguration {
-  #[asset(skip)]
   /// The name of the tests configuration.
+  #[asset(skip)]
+  #[builder(default)]
   pub(crate) name: Option<String>,
 
+  /// The source (i.e. url or file on disk) of the configuration.
   #[asset(skip)]
   #[property(skip)]
-  /// The source (i.e. url or file on disk) of the configuration.
+  #[builder(default)]
   pub(crate) source: Option<PathBuf>,
 
-  #[asset(skip)]
   /// The configuration with which to initialize the component before running tests.
+  #[asset(skip)]
+  #[builder(default)]
   pub(crate) config: Option<LiquidJsonConfig>,
 
-  #[asset(skip)]
   /// A suite of test cases to run against component operations.
+  #[asset(skip)]
+  #[builder(default)]
   pub(crate) cases: Vec<config::TestCase>,
 
-  #[asset(skip)]
   /// The environment this configuration has access to.
+  #[asset(skip)]
   #[builder(default)]
   pub(crate) env: Option<HashMap<String, String>>,
 }

--- a/crates/wick/wick-config/src/error.rs
+++ b/crates/wick/wick-config/src/error.rs
@@ -113,6 +113,10 @@ pub enum ManifestError {
   /// Error building a configuration
   #[error(transparent)]
   Builder(#[from] BuilderError),
+
+  /// Error converting configured Packet flags.
+  #[error("Error converting configured Packet flags, use the singular version instead")]
+  InvalidPacketFlags,
 }
 
 #[derive(Error, Debug, Clone, Copy)]

--- a/crates/wick/wick-config/src/v1.rs
+++ b/crates/wick/wick-config/src/v1.rs
@@ -1440,11 +1440,17 @@ pub(crate) enum PacketData {
 pub(crate) struct SuccessPacket {
   /// The name of the input or output this packet is going to or coming from.
   pub(crate) name: String,
-  /// Any flags set on the packet.
+  /// Any flags set on the packet. Deprecated, use &#x27;flag:&#x27; instead
 
+  #[deprecated()]
   #[serde(default)]
   #[serde(skip_serializing_if = "Option::is_none")]
   pub(crate) flags: Option<PacketFlags>,
+  /// The flag set on the packet.
+
+  #[serde(default)]
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub(crate) flag: Option<PacketFlag>,
   /// The data to send.
 
   #[serde(default)]
@@ -1458,11 +1464,17 @@ pub(crate) struct SuccessPacket {
 pub(crate) struct ErrorPacket {
   /// The name of the input or output this packet is going to or coming from.
   pub(crate) name: String,
-  /// Any flags set on the packet.
+  /// Any flags set on the packet. Deprecated, use &#x27;flag:&#x27; instead
 
+  #[deprecated()]
   #[serde(default)]
   #[serde(skip_serializing_if = "Option::is_none")]
   pub(crate) flags: Option<PacketFlags>,
+  /// The flag set on the packet.
+
+  #[serde(default)]
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub(crate) flag: Option<PacketFlag>,
   /// The error message.
   pub(crate) error: LiquidTemplate,
 }
@@ -1483,6 +1495,48 @@ pub(crate) struct PacketFlags {
 
   #[serde(default)]
   pub(crate) close: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Copy, PartialEq)]
+#[serde(deny_unknown_fields)]
+/// Possible flags that can be set on a packet.
+pub(crate) enum PacketFlag {
+  /// Indicates the port should be considered closed.
+  Done = 0,
+  /// Indicates the opening of a new substream context within the parent stream.
+  Open = 1,
+  /// Indicates the closing of a substream context within the parent stream.
+  Close = 2,
+}
+
+impl Default for PacketFlag {
+  fn default() -> Self {
+    Self::from_u16(0).unwrap()
+  }
+}
+
+impl FromPrimitive for PacketFlag {
+  fn from_i64(n: i64) -> Option<Self> {
+    Some(match n {
+      0 => Self::Done,
+      1 => Self::Open,
+      2 => Self::Close,
+      _ => {
+        return None;
+      }
+    })
+  }
+
+  fn from_u64(n: u64) -> Option<Self> {
+    Some(match n {
+      0 => Self::Done,
+      1 => Self::Open,
+      2 => Self::Close,
+      _ => {
+        return None;
+      }
+    })
+  }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/wick/wick-test/Cargo.toml
+++ b/crates/wick/wick-test/Cargo.toml
@@ -9,7 +9,7 @@ description = "Test runner for Wick components"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
 # Wick
-flow-component = { workspace = true }
+flow-component = { workspace = true, features = ["invocation"] }
 wick-packet = { workspace = true }
 wick-config = { workspace = true }
 wick-interface-types = { workspace = true }
@@ -28,3 +28,7 @@ tracing = { workspace = true }
 assert-json-diff = { workspace = true }
 
 [dev-dependencies]
+wick-logger = { workspace = true }
+test-logger = { workspace = true }
+tokio = { workspace = true, features = ["macros"] }
+anyhow = { workspace = true }

--- a/crates/wick/wick-test/src/error.rs
+++ b/crates/wick/wick-test/src/error.rs
@@ -1,4 +1,6 @@
+use serde_value::Value;
 use thiserror::Error;
+use wick_packet::Packet;
 
 #[derive(Error, Debug, PartialEq)]
 pub enum TestError {
@@ -22,4 +24,24 @@ pub enum TestError {
   OpNotFound(String),
   #[error(transparent)]
   ConfigUnsatisfied(wick_packet::Error),
+  #[error("Test input sent packets after marking input '{0}' as done")]
+  PacketsAfterDone(String),
+  #[error("Got an output packet for a port '{0}' we've never seen")]
+  InvalidPort(String),
+  #[error("Assertion failed")]
+  Assertion(Packet, Packet, AssertionFailure),
+}
+
+#[derive(Error, Debug, PartialEq)]
+pub enum AssertionFailure {
+  #[error("Payload mismatch")]
+  Payload(Value, Value),
+  #[error("Expected data in packet but got none")]
+  ActualNoData,
+  #[error("Expected no data in packet but got some")]
+  ExpectedNoData,
+  #[error("Flag mismatch")]
+  Flags(u8, u8),
+  #[error("Port name mismatch")]
+  Name(String, String),
 }

--- a/crates/wick/wick-test/src/lib.rs
+++ b/crates/wick/wick-test/src/lib.rs
@@ -87,14 +87,24 @@
 
 mod error;
 mod runner;
+mod test_group;
 mod test_suite;
 mod unit_test;
 mod utils;
 
 pub use error::TestError;
 pub use runner::*;
+pub use test_group::*;
 pub use test_suite::*;
 pub use unit_test::*;
+
+pub type ComponentFactory<'a> = Box<
+  dyn Fn(Option<wick_packet::RuntimeConfig>) -> flow_component::BoxFuture<'a, Result<SharedComponent, TestError>>
+    + Sync
+    + Send,
+>;
+
+pub use flow_component::SharedComponent;
 
 #[macro_use]
 extern crate tracing;

--- a/crates/wick/wick-test/src/test_group.rs
+++ b/crates/wick/wick-test/src/test_group.rs
@@ -1,0 +1,64 @@
+use flow_component::SharedComponent;
+use tap_harness::TestRunner;
+use wick_config::config::TestCase;
+use wick_packet::RuntimeConfig;
+
+use crate::{run_test, TestError, UnitTest};
+
+#[derive(Debug)]
+#[must_use]
+pub struct TestGroup<'a> {
+  pub(crate) tests: Vec<UnitTest<'a>>,
+  pub(crate) root_config: Option<RuntimeConfig>,
+  pub(crate) name: String,
+}
+
+impl<'a> TestGroup<'a> {
+  pub fn from_test_cases<'b>(root_config: Option<RuntimeConfig>, tests: &'b [TestCase]) -> Self
+  where
+    'b: 'a,
+  {
+    let defs: Vec<UnitTest<'b>> = tests.iter().map(UnitTest::new).collect();
+    Self {
+      tests: defs,
+      root_config,
+      name: "Test".to_owned(),
+    }
+  }
+
+  pub fn get_tests<'b>(&'a mut self) -> Vec<&'a mut UnitTest<'b>>
+  where
+    'a: 'b,
+  {
+    self.tests.iter_mut().collect()
+  }
+
+  pub fn name(mut self, name: String) -> Self {
+    self.name = name;
+    self
+  }
+
+  pub async fn run(
+    &'a mut self,
+    component_id: Option<&str>,
+    component: SharedComponent,
+    filter: &[String],
+  ) -> Result<TestRunner, TestError> {
+    let name = self.name.clone();
+    let config = self.root_config.clone();
+    let tests = self
+      .get_tests()
+      .into_iter()
+      .filter(|test| {
+        if filter.is_empty() {
+          return true;
+        }
+        test
+          .test
+          .name()
+          .map_or(false, |name| filter.iter().any(|f| name.contains(f)))
+      })
+      .collect();
+    run_test(name, tests, component_id, component, config).await
+  }
+}

--- a/crates/wick/wick-test/src/test_suite.rs
+++ b/crates/wick/wick-test/src/test_suite.rs
@@ -1,15 +1,8 @@
-use flow_component::BoxFuture;
 use tap_harness::TestRunner;
-use wick_config::config::{TestCase, TestConfiguration};
-use wick_packet::RuntimeConfig;
+use wick_config::config::TestConfiguration;
 
 use crate::utils::render_config;
-use crate::{run_test, TestError, UnitTest};
-
-pub type ComponentFactory<'a> =
-  Box<dyn Fn(Option<RuntimeConfig>) -> BoxFuture<'a, Result<SharedComponent, TestError>> + Sync + Send>;
-
-pub use flow_component::SharedComponent;
+use crate::{ComponentFactory, TestError, TestGroup};
 
 #[derive(Debug, Default)]
 #[must_use]
@@ -57,69 +50,5 @@ impl<'a> TestSuite<'a> {
       runners.push(group.run(None, component.await?, &filter).await?);
     }
     Ok(runners)
-  }
-}
-
-#[derive(Debug)]
-#[must_use]
-pub struct TestGroup<'a> {
-  tests: Vec<UnitTest<'a>>,
-  root_config: Option<RuntimeConfig>,
-  name: String,
-}
-
-impl<'a> TestGroup<'a> {
-  pub fn from_test_cases<'b>(root_config: Option<RuntimeConfig>, tests: &'b [TestCase]) -> Self
-  where
-    'b: 'a,
-  {
-    let defs: Vec<UnitTest<'b>> = tests
-      .iter()
-      .map(|test| UnitTest {
-        test,
-        actual: Vec::new(),
-      })
-      .collect();
-    Self {
-      tests: defs,
-      root_config,
-      name: "Test".to_owned(),
-    }
-  }
-
-  pub fn get_tests<'b>(&'a mut self) -> Vec<&'a mut UnitTest<'b>>
-  where
-    'a: 'b,
-  {
-    self.tests.iter_mut().collect()
-  }
-
-  pub fn name(mut self, name: String) -> Self {
-    self.name = name;
-    self
-  }
-
-  pub async fn run(
-    &'a mut self,
-    component_id: Option<&str>,
-    component: SharedComponent,
-    filter: &[String],
-  ) -> Result<TestRunner, TestError> {
-    let name = self.name.clone();
-    let config = self.root_config.clone();
-    let tests = self
-      .get_tests()
-      .into_iter()
-      .filter(|test| {
-        if filter.is_empty() {
-          return true;
-        }
-        test
-          .test
-          .name()
-          .map_or(false, |name| filter.iter().any(|f| name.contains(f)))
-      })
-      .collect();
-    run_test(name, tests, component_id, component, config).await
   }
 }

--- a/crates/wick/wick-test/src/unit_test.rs
+++ b/crates/wick/wick-test/src/unit_test.rs
@@ -1,40 +1,166 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::time::{SystemTime, UNIX_EPOCH};
 
+use serde_value::Value;
 use wick_config::config::TestCase;
 use wick_packet::{InherentData, Packet, PacketStream, RuntimeConfig};
 
+use crate::error::AssertionFailure;
 use crate::utils::gen_packet;
 use crate::TestError;
 
 #[derive(Debug, Clone)]
 pub struct UnitTest<'a> {
   pub test: &'a TestCase,
-  pub actual: Vec<Packet>,
+  actual: HashMap<String, VecDeque<Packet>>,
+}
+
+impl<'a> UnitTest<'a> {
+  pub(crate) fn new(test: &'a TestCase) -> Self {
+    Self {
+      test,
+      actual: HashMap::new(),
+    }
+  }
+
+  pub fn set_actual(&mut self, actual: Vec<Packet>) {
+    for packet in actual {
+      self
+        .actual
+        .entry(packet.port().to_owned())
+        .or_default()
+        .push_back(packet);
+    }
+  }
+
+  pub(crate) fn check_next(&mut self, expected: Packet) -> Result<(), TestError> {
+    let packets = self
+      .actual
+      .get_mut(expected.port())
+      .ok_or(TestError::InvalidPort(expected.port().to_owned()))?;
+
+    #[allow(clippy::never_loop)]
+    while let Some(actual) = packets.pop_front() {
+      if actual.port() != expected.port() {
+        let a = AssertionFailure::Name(expected.port().to_owned(), actual.port().to_owned());
+        return Err(TestError::Assertion(expected, actual, a));
+      }
+
+      if actual.flags() != expected.flags() {
+        let a = AssertionFailure::Flags(expected.flags(), actual.flags());
+        return Err(TestError::Assertion(expected, actual, a));
+      }
+
+      match (actual.has_data(), expected.has_data()) {
+        (true, false) => return Err(TestError::Assertion(expected, actual, AssertionFailure::ExpectedNoData)),
+        (false, true) => return Err(TestError::Assertion(expected, actual, AssertionFailure::ActualNoData)),
+        (false, false) => return Ok(()),
+        _ => {}
+      }
+
+      let actual_value: Value = actual
+        .clone()
+        .decode()
+        .map_err(|e| TestError::Deserialization(e.to_string()))?;
+      let expected_value: Value = expected
+        .clone()
+        .decode()
+        .map_err(|e| TestError::Deserialization(e.to_string()))?;
+
+      debug!(actual=?actual_value, expected=?expected_value, "test:packet");
+      if !eq(&actual_value, &expected_value) {
+        let a = AssertionFailure::Payload(expected_value, actual_value);
+        return Err(TestError::Assertion(actual, expected, a));
+      }
+
+      return Ok(());
+    }
+    Ok(())
+  }
+
+  pub(crate) fn finalize(&mut self, _explicit_done: &HashSet<String>) -> Result<(), Vec<Packet>> {
+    let mut with_data = Vec::new();
+    let packets = self.actual.drain().collect::<Vec<_>>();
+    for (port, packets) in packets {
+      for packet in packets {
+        if packet.is_done() {
+          debug!(port, "test: received done packet without assertion, ignoring");
+          continue;
+        }
+        with_data.push(packet);
+        break;
+      }
+    }
+    if with_data.is_empty() {
+      Ok(())
+    } else {
+      Err(with_data)
+    }
+  }
+}
+
+fn eq(left: &Value, right: &Value) -> bool {
+  promote_val(left) == promote_val(right)
+}
+
+fn promote_val(val: &Value) -> Value {
+  match val {
+    Value::U8(n) => Value::U64((*n).into()),
+    Value::U16(n) => Value::U64((*n).into()),
+    Value::U32(n) => Value::U64((*n).into()),
+    Value::I8(n) => Value::I64((*n).into()),
+    Value::I16(n) => Value::I64((*n).into()),
+    Value::I32(n) => Value::I64((*n).into()),
+    Value::F32(n) => Value::F64((*n).into()),
+    Value::Char(n) => Value::String((*n).into()),
+    x => x.clone(),
+  }
 }
 
 pub(crate) fn get_payload(
   test: &UnitTest,
   root_config: Option<&RuntimeConfig>,
   op_config: Option<&RuntimeConfig>,
-) -> Result<(PacketStream, InherentData), TestError> {
+) -> Result<(PacketStream, InherentData, HashSet<String>), TestError> {
   let mut packets = Vec::new();
-  let mut not_done = HashSet::new();
+  let mut open_streams = HashSet::new();
+
+  // need a Vec to store the order of seen ports so we can have repeatable tests.
+  // HashSet doesn't guarantee order.
+  let mut order = Vec::new();
+
+  for packet in test.test.inputs() {
+    // if we've never seen this port before, push it onto the order Vec.
+    if !open_streams.contains(packet.port()) {
+      order.push(packet.port().to_owned());
+    }
+    open_streams.insert(packet.port().to_owned());
+  }
+
+  let mut explicit_done = HashSet::new();
+
   if test.test.inputs().is_empty() {
     packets.push(Packet::no_input());
   } else {
     for packet in test.test.inputs() {
-      let done = packet.flags().map_or(false, |f| f.done());
+      let done = packet.flag().is_done();
       if done {
-        not_done.remove(packet.port());
-      } else {
-        not_done.insert(packet.port());
+        explicit_done.insert(packet.port().to_owned());
+        open_streams.remove(packet.port());
+      } else if !open_streams.contains(packet.port()) {
+        return Err(TestError::PacketsAfterDone(packet.port().to_owned()));
       }
-      debug!("Test input for port {:?}", packet);
+      debug!(?packet, "test packet");
       packets.push(gen_packet(packet, root_config, op_config)?);
     }
-    for port in not_done {
-      packets.push(Packet::done(port));
+
+    // Add any missing "done" packets as a convenience to the test writer.
+    // (in the order we saw the ports)
+    for port in order {
+      if open_streams.contains(&port) {
+        debug!(input = port, "adding missing done packet for input");
+        packets.push(Packet::done(port));
+      }
     }
   }
 
@@ -64,5 +190,5 @@ pub(crate) fn get_payload(
     },
   );
 
-  Ok((packets.into(), InherentData::new(seed, timestamp)))
+  Ok((packets.into(), InherentData::new(seed, timestamp), explicit_done))
 }

--- a/crates/wick/wick-test/src/utils.rs
+++ b/crates/wick/wick-test/src/utils.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 
 use wasmrs_codec::messagepack;
-use wick_config::config::{LiquidJsonConfig, PacketFlags, TestPacket};
+use wick_config::config::{LiquidJsonConfig, PacketFlag, TestPacket};
 use wick_packet::{
   InherentData,
   Packet,
@@ -46,7 +46,7 @@ pub(crate) fn gen_packet(
         }
         None => None,
       }),
-      convert_flags(data.flags()),
+      convert_flags(data.flag()),
     ),
     TestPacket::ErrorPacket(data) => Packet::new_for_port(
       data.port(),
@@ -56,23 +56,19 @@ pub(crate) fn gen_packet(
           .render(None, Some(&std::env::vars().collect()))
           .map_err(config_error)?,
       )),
-      convert_flags(data.flags()),
+      convert_flags(data.flag()),
     ),
   };
   Ok(packet)
 }
 
-fn convert_flags(flags: Option<&PacketFlags>) -> u8 {
+fn convert_flags(flag: Option<&PacketFlag>) -> u8 {
   let mut byte = 0;
-  if let Some(flags) = flags {
-    if flags.done() {
-      byte |= DONE_FLAG;
-    }
-    if flags.open() {
-      byte |= OPEN_BRACKET;
-    }
-    if flags.close() {
-      byte |= CLOSE_BRACKET;
+  if let Some(flag) = flag {
+    match flag {
+      PacketFlag::Done => byte |= DONE_FLAG,
+      PacketFlag::Open => byte |= OPEN_BRACKET,
+      PacketFlag::Close => byte |= CLOSE_BRACKET,
     }
   }
   byte

--- a/crates/wick/wick-test/tests/done_tolerance.rs
+++ b/crates/wick/wick-test/tests/done_tolerance.rs
@@ -1,0 +1,176 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use anyhow::Result;
+use flow_component::{Component, RuntimeCallback, SharedComponent};
+use serde_json::json;
+use tokio_stream::StreamExt;
+use wick_config::config::{TestCaseBuilder, TestConfigurationBuilder, TestPacket};
+use wick_interface_types::{component, ComponentSignature};
+use wick_packet::{Invocation, Packet, PacketStream, RuntimeConfig};
+use wick_test::{ComponentFactory, TestSuite};
+
+struct TestComponent {
+  signature: ComponentSignature,
+}
+
+impl TestComponent {
+  fn new() -> Self {
+    Self {
+      signature: component! {
+        name: "test",
+        version: Some("0.0.1"),
+        operations: {
+          "echo" => {
+            inputs: {
+              "in" => "object",
+            },
+            outputs: {
+              "out" => "object",
+            },
+          },
+        }
+      },
+    }
+  }
+}
+
+impl Component for TestComponent {
+  fn handle(
+    &self,
+    mut invocation: Invocation,
+    _data: Option<RuntimeConfig>,
+    _callback: Arc<RuntimeCallback>,
+  ) -> flow_component::BoxFuture<std::result::Result<PacketStream, flow_component::ComponentError>> {
+    Box::pin(async move {
+      let stream = invocation.eject_stream();
+      let packets = stream.collect::<Vec<_>>().await;
+      let mut packets = packets
+        .into_iter()
+        .collect::<Result<Vec<_>, wick_packet::Error>>()
+        .map_err(flow_component::ComponentError::new)?;
+      let names = packets.iter().map(|p| p.port().to_owned()).collect::<HashSet<_>>();
+      let which_done = packets
+        .iter()
+        .filter_map(|p| if p.is_done() { Some(p.port().to_owned()) } else { None })
+        .collect::<HashSet<_>>();
+
+      for name in names {
+        if !which_done.contains(&name) {
+          packets.push(Packet::done(name));
+        }
+      }
+
+      Ok(PacketStream::from(packets))
+    })
+  }
+
+  fn signature(&self) -> &ComponentSignature {
+    &self.signature
+  }
+}
+
+#[test_logger::test(tokio::test)]
+async fn test_done_tolerance() -> Result<()> {
+  let config = vec![TestConfigurationBuilder::default()
+    .cases(vec![
+      TestCaseBuilder::default()
+        .operation("echo")
+        .inputs(vec![TestPacket::success("a1", None), TestPacket::success("a2", None)])
+        .outputs(vec![TestPacket::success("a1", None), TestPacket::success("a2", None)])
+        .build()?,
+      TestCaseBuilder::default()
+        .operation("echo")
+        .inputs(vec![TestPacket::success("b1", None), TestPacket::success("b2", None)])
+        .outputs(vec![
+          TestPacket::success("b1", None),
+          TestPacket::success("b2", None),
+          TestPacket::done("b1"),
+          TestPacket::done("b2"),
+        ])
+        .build()?,
+      TestCaseBuilder::default()
+        .operation("echo")
+        .inputs(vec![TestPacket::success("c1", None), TestPacket::success("c2", None)])
+        .outputs(vec![
+          TestPacket::success("c1", None),
+          TestPacket::success("c2", None),
+          TestPacket::done("c2"),
+          TestPacket::done("c1"),
+        ])
+        .build()?,
+      TestCaseBuilder::default()
+        .operation("echo")
+        .inputs(vec![
+          TestPacket::success("d1", None),
+          TestPacket::done("d1"),
+          TestPacket::success("d2", None),
+        ])
+        .outputs(vec![
+          TestPacket::success("d1", None),
+          TestPacket::success("d2", None),
+          TestPacket::done("d1"),
+        ])
+        .build()?,
+      TestCaseBuilder::default()
+        .operation("echo")
+        .inputs(vec![
+          TestPacket::success("e1", None),
+          TestPacket::done("e1"),
+          TestPacket::success("e2", None),
+        ])
+        .outputs(vec![
+          TestPacket::success("e1", None),
+          TestPacket::success("e2", None),
+          TestPacket::done("e1"),
+        ])
+        .build()?,
+      TestCaseBuilder::default()
+        .operation("echo")
+        .inputs(vec![
+          TestPacket::success("f1", None),
+          TestPacket::done("f1"),
+          TestPacket::success("f2", None),
+        ])
+        .outputs(vec![TestPacket::success("f1", None), TestPacket::success("f2", None)])
+        .build()?,
+      TestCaseBuilder::default()
+        .operation("echo")
+        .inputs(vec![
+          TestPacket::success("e1", Some(json!({ "a": 1 }).into())),
+          TestPacket::success("e1", Some(json!({ "a": 2 }).into())),
+          TestPacket::success("e1", Some(json!({ "a": 3 }).into())),
+          TestPacket::success("e2", Some(json!({ "b": 1 }).into())),
+          TestPacket::success("e2", Some(json!({ "b": 2 }).into())),
+          TestPacket::success("e2", Some(json!({ "b": 3 }).into())),
+        ])
+        .outputs(vec![
+          TestPacket::success("e1", Some(json!({ "a": 1 }).into())),
+          TestPacket::success("e2", Some(json!({ "b": 1 }).into())),
+          TestPacket::success("e2", Some(json!({ "b": 2 }).into())),
+          TestPacket::success("e2", Some(json!({ "b": 3 }).into())),
+          TestPacket::success("e1", Some(json!({ "a": 2 }).into())),
+          TestPacket::success("e1", Some(json!({ "a": 3 }).into())),
+        ])
+        .build()?,
+    ])
+    .build()?];
+  let mut suite = TestSuite::from_configuration(&config)?;
+
+  let factory: ComponentFactory = Box::new(move |_config| {
+    let task = async move {
+      let component = TestComponent::new();
+      let component: SharedComponent = Arc::new(component);
+      Ok(component)
+    };
+    Box::pin(task)
+  });
+  let runners = suite.run(factory, Default::default()).await?;
+  for runner in runners {
+    runner.print();
+    if runner.num_failed() > 0 {
+      panic!("Test failed");
+    }
+  }
+  Ok(())
+}

--- a/docs/content/configuration/reference/v1.md
+++ b/docs/content/configuration/reference/v1.md
@@ -1451,7 +1451,8 @@ Any one of the following types:
 | Field name | Type | Description | Required? | Shortform? |
 |------------|------|-------------|-----------|------------|
 | `name` | <code>`string`</code> |The name of the input or output this packet is going to or coming from.|Yes||
-| `flags` | <code>[`PacketFlags`](#packetflags)</code> |Any flags set on the packet.|||
+| `flags` | <code>[`PacketFlags`](#packetflags)</code> |Any flags set on the packet. Deprecated, use 'flag:' instead|||
+| `flag` | <code>[`PacketFlag`](#packetflag)</code> |The flag set on the packet.|||
 | `value` | <code>[`LiquidJsonValue`](#liquidjsonvalue)</code> |The data to send.|||
 
 
@@ -1466,7 +1467,8 @@ Any one of the following types:
 | Field name | Type | Description | Required? | Shortform? |
 |------------|------|-------------|-----------|------------|
 | `name` | <code>`string`</code> |The name of the input or output this packet is going to or coming from.|Yes||
-| `flags` | <code>[`PacketFlags`](#packetflags)</code> |Any flags set on the packet.|||
+| `flags` | <code>[`PacketFlags`](#packetflags)</code> |Any flags set on the packet. Deprecated, use 'flag:' instead|||
+| `flag` | <code>[`PacketFlag`](#packetflag)</code> |The flag set on the packet.|||
 | `error` | <code>[`LiquidTemplate`](#liquidtemplate)</code> |The error message.|Yes||
 
 
@@ -1487,6 +1489,25 @@ Any one of the following types:
 | `open` | <code>`bool`</code> |Indicates the opening of a new substream context within the parent stream.|||
 | `close` | <code>`bool`</code> |Indicates the closing of a substream context within the parent stream.|||
 
+
+
+--------
+
+## PacketFlag
+
+  <p>
+    <div style="font-style:italic">Possible flags that can be set on a packet.</div>
+  </p>
+
+
+
+
+
+| Field name | Type | Description |
+|------------|------|-------------|
+| Done | unknown type | Indicates the port should be considered closed. |
+| Open | unknown type | Indicates the opening of a new substream context within the parent stream. |
+| Close | unknown type | Indicates the closing of a substream context within the parent stream. |
 
 
 --------

--- a/tests/codegen-tests/tests/testdata/import-types.wick
+++ b/tests/codegen-tests/tests/testdata/import-types.wick
@@ -104,11 +104,5 @@ tests:
               path: '/'
               uri: 'http://localhost:8080/'
               remote_addr: 0.0.0.0
-          - name: output
-            flags:
-              done: true
           - name: time
             value: '2020-07-05T11:39:39.352802472Z'
-          - name: time
-            flags:
-              done: true


### PR DESCRIPTION
The initial `wick test` implementation tested a single stream of packets against a flat array of output packets. If there was any difference in order then the whole test would break.

This PR treats each named output as a separate stream (like the rest of wick does) so packets in varying order in relation to each other don't break tests. It is also more forgiving with `done` packets. Any done packets remaining from the stream won't break tests.