### PR TITLE
Made `wick run` the default subcommand if the first arg is a file that exists

### DIFF
--- a/examples/http/staticfile-router.wick
+++ b/examples/http/staticfile-router.wick
@@ -1,3 +1,4 @@
+#!/usr/bin/env wick
 ---
 kind: wick/app@v1
 name: static_file_server


### PR DESCRIPTION
Rather than error out with help text if `wick` is run without an invalid subcommand, this PR makes the default subcommand `wick run` if the first argument ~contains a dot (`.`), forward slash (`/`), or a back slash(`\`)~ is invalid and is a filename that exists.


This was made largely to support hashbang syntax ( .g. `#!/bin/bash`) for executable files on *nix environments. There are still environments that don't support anything other than a hashbang and two, space-separated strings as the command to execute. Reducing `wick run` to `wick` makes it possible to have the executable line be the somewhat-standard: 

```bash
#!/usr/bin/env wick
```

So now we can make executable `.wick` files as easy as bash or perl scripts  🎉

Edit: changed the behavior of defaulting to `wick run` to also work with filenames that don't have slashes or dots.