### PR TITLE
Fixed path for rest-router example and tests

### DIFF
--- a/crates/wick/wick-runtime/src/triggers/http.rs
+++ b/crates/wick/wick-runtime/src/triggers/http.rs
@@ -712,7 +712,7 @@ mod test {
         )
         .await?;
 
-      let res: serde_json::Value = get("/this/FIRST_VALUE/some/222?third=third_a&fourth=true")
+      let res: serde_json::Value = get("/api/this/FIRST_VALUE/some/222?third=third_a&fourth=true")
         .await?
         .json()
         .await?;
@@ -723,7 +723,7 @@ mod test {
         json!({"first":"FIRST_VALUE", "second": 222,"third":["third_a"], "fourth":true })
       );
 
-      let res: serde_json::Value = get("/this/FIRST_VALUE/some/222?third=third_a&third=third_b&fourth=true")
+      let res: serde_json::Value = get("/api/this/FIRST_VALUE/some/222?third=third_a&third=third_b&fourth=true")
         .await?
         .json()
         .await?;

--- a/examples/http/rest-router.wick
+++ b/examples/http/rest-router.wick
@@ -26,9 +26,9 @@ import:
   - name: openapi
     component:
       kind: wick/component/manifest@v1
-      ref: registry.candle.dev/common/openapi-ui:4
+      ref: registry.candle.dev/common/openapi-ui:0.4.0
       with:
-        schema_url: /openapi.json
+        schema_url: /api/openapi.json
 triggers:
   - kind: wick/trigger/http@v1
     resource: http
@@ -38,7 +38,7 @@ triggers:
         codec: Raw
         operation: openapi::serve
       - kind: wick/router/rest@v1
-        path: /
+        path: /api
         tools:
           openapi: true
         info:


### PR DESCRIPTION
Simple change to the rest-router example that sidesteps an issue appending the `openapi.json` path to the root.

That bug is capture in https://github.com/candlecorp/wick/issues/390 and needs its own fix, but this keeps the demo working in the meantime.