### PR TITLE
Misc cli fixes

### DIFF
--- a/crates/bins/wick/Cargo.toml
+++ b/crates/bins/wick/Cargo.toml
@@ -44,7 +44,7 @@ dialoguer = { workspace = true, features = ["password"] }
 human-panic = { workspace = true }
 futures = { workspace = true }
 thiserror = { workspace = true }
-clap = { workspace = true, features = ["derive", "std"] }
+clap = { workspace = true, default-features = true, features = ["derive"] }
 nkeys = { workspace = true }
 atty = { workspace = true }
 jaq-core = { workspace = true, features = ["serde_json"] }

--- a/crates/bins/wick/src/commands/config/expand.rs
+++ b/crates/bins/wick/src/commands/config/expand.rs
@@ -15,10 +15,6 @@ pub(crate) struct Options {
   #[clap(action)]
   pub(crate) path: String,
 
-  /// Operation to render.
-  #[clap(action)]
-  pub(crate) operation: String,
-
   #[clap(flatten)]
   pub(crate) oci: crate::oci::Options,
 

--- a/crates/bins/wick/src/commands/install.rs
+++ b/crates/bins/wick/src/commands/install.rs
@@ -108,9 +108,9 @@ esac
 app_path="{}"
 
 if [ -x "$basedir/wick" ]; then
-  exec "$basedir/wick" "run" "$app_path" "$@"
+  exec "$basedir/wick" "run" "$app_path" "--" "$@"
 else
-  exec wick "run" "$app_path" "$@"
+  exec wick "run" "$app_path" "--" "$@"
 fi
   "#,
     target

--- a/crates/bins/wick/src/main.rs
+++ b/crates/bins/wick/src/main.rs
@@ -185,11 +185,6 @@ async fn async_start() -> Result<(GlobalOptions, StructuredOutput), (GlobalOptio
   panic::setup(human_panic::PanicStyle::Human);
 
   let mut args = std::env::args().collect::<Vec<_>>();
-  // first arg is always the command name, so get the first argument after.
-  if let Some(first) = args.get(1) {
-    // If the first real argument contains a dot or any slash, make the default subcommand `wick run`
-    if first.contains('.') || first.contains('/') || first.contains('\\') {}
-  }
 
   let matches = <Cli as clap::CommandFactory>::command().try_get_matches_from(&args);
   if let Err(e) = matches {
@@ -201,6 +196,7 @@ async fn async_start() -> Result<(GlobalOptions, StructuredOutput), (GlobalOptio
       }
     }
   }
+
   let mut cli = Cli::parse_from(args);
   let options = cli.output.clone();
 

--- a/crates/wick/flow-graph-interpreter/src/interpreter/executor/transaction.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/executor/transaction.rs
@@ -212,7 +212,7 @@ impl Transaction {
         } else if packet.is_noop() {
           // TODO: propagate this and/or its context if it becomes an issue.
         } else {
-          warn!(port = packet.port(), "dropping packet for unconnected port");
+          debug!(port = packet.port(), "dropping packet for unconnected port");
         }
       }
     });

--- a/crates/wick/flow-graph-interpreter/src/interpreter/program/validator.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/program/validator.rs
@@ -106,7 +106,7 @@ impl Validator {
                 let mut walker = SchematicWalker::from_port(schematic, port.detached(), WalkDirection::Down);
                 let next = walker.nth(1);
                 if next.is_none() {
-                  warn!(id=node.name.clone(), operation = %reference, port = %field.name, "unhandled downstream connection");
+                  debug!(id=node.name.clone(), operation = %reference, port = %field.name, "unhandled downstream connection");
                   // validation_errors.push(ValidationError::UnusedOutput {
                   //   port: field.name.clone(),
                   //   id: node.name.clone(),


### PR DESCRIPTION
This PR
- fixes argument passing to `wick install`-ed scripts on *nix environments
- moves a chatty `warn` event to `debug`
- removes an unused cli argument from `wick config expand`
- fixes the missing help and usage text on invalid CLI commands