### PR TITLE
Converted all level spans to info_spans

### DIFF
--- a/crates/bins/wick/src/main.rs
+++ b/crates/bins/wick/src/main.rs
@@ -230,7 +230,7 @@ async fn async_start() -> Result<(GlobalOptions, StructuredOutput), (GlobalOptio
 }
 
 async fn async_main(cli: Cli, settings: wick_settings::Settings) -> Result<StructuredOutput> {
-  let span = trace_span!(target:"cli","cli");
+  let span = info_span!(target:"cli","cli");
 
   span.in_scope(|| trace!(cli_options=?cli, settings=?settings,"starting cli"));
 

--- a/crates/misc/test-logger/src/lib.rs
+++ b/crates/misc/test-logger/src/lib.rs
@@ -169,7 +169,7 @@ fn expand_wrapper(inner_test: Tokens, wrappee: &ItemFn) -> TokenStream {
         #body
       }
       #logging_init
-      let span = tracing::trace_span!(stringify!(#test_name));
+      let span = tracing::info_span!(stringify!(#test_name));
       #enter_
       let result = test_impl()#await_;
       if let Err(e) = &result {

--- a/crates/wick/flow-graph-interpreter/src/interpreter.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 use flow_component::{Component, ComponentError, RuntimeCallback};
 use futures::{FutureExt, TryFutureExt};
 use parking_lot::Mutex;
-use tracing::{trace_span, Span};
+use tracing::{info_span, Span};
 use tracing_futures::Instrument;
 use wick_interface_types::ComponentSignature;
 use wick_packet::{Entity, Invocation, PacketStream, RuntimeConfig};
@@ -66,7 +66,7 @@ impl Interpreter {
     callback: Arc<RuntimeCallback>,
     parent_span: &Span,
   ) -> Result<Self, Error> {
-    let span = trace_span!(parent: parent_span, "interpreter");
+    let span = info_span!(parent: parent_span, "interpreter");
 
     let _guard = span.enter();
     let mut handlers = components.unwrap_or_default();

--- a/crates/wick/flow-graph-interpreter/src/interpreter/components/core/switch.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/components/core/switch.rs
@@ -521,7 +521,7 @@ impl Operation for Op {
                 (CaseId::Match(CaseValue(&case.case)), &case.case_do, case.with.clone())
               },
             );
-            let span = trace_span!(parent:&invocation.span,"switch:case:handler",otel.name=format!("case:{}",condition),%condition);
+            let span = info_span!(parent:&invocation.span,"switch:case:handler",otel.name=format!("case:{}",condition),%condition);
             router.push(Condition::new(
               condition,
               condition_level,

--- a/crates/wick/flow-graph-interpreter/src/interpreter/event_loop.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/event_loop.rs
@@ -27,7 +27,7 @@ impl EventLoop {
   pub(crate) const SLOW_TX_TIMEOUT: Duration = Duration::from_secs(15);
 
   pub(super) fn new(channel: InterpreterChannel, span: &Span) -> Self {
-    let event_span = debug_span!("event_loop");
+    let event_span = info_span!("event_loop");
     event_span.follows_from(span);
     let dispatcher = channel.dispatcher(Some(event_span.clone()));
 

--- a/crates/wick/flow-graph-interpreter/src/interpreter/executor/context.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/executor/context.rs
@@ -95,7 +95,7 @@ impl ExecutionContext {
 
     let stats = ExecutionStatistics::new(invocation.id);
     stats.mark("new");
-    let span = trace_span!(parent:&invocation.span,"execution_flow",ctx_id=%id);
+    let span = info_span!(parent:&invocation.span,"execution_flow",ctx_id=%id);
     let channel = channel.with_span(span.clone());
 
     let (tx, rx) = invocation.make_response();

--- a/crates/wick/flow-graph-interpreter/src/interpreter/executor/context/operation.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/executor/context/operation.rs
@@ -119,7 +119,7 @@ impl InstanceHandler {
     let outputs = op_node.outputs().to_vec();
     let reference: Reference = op_node.kind().cref().into();
 
-    // let span = debug_span!(parent:&invocation.span,"interpreter:op:instance", entity = %invocation.target);
+    // let span = info_span!(parent:&invocation.span,"interpreter:op:instance", entity = %invocation.target);
 
     Self {
       schematic,
@@ -276,7 +276,8 @@ impl InstanceHandler {
       return Err(StateError::InvocationMissing(identifier).into());
     };
     let mut invocation: Invocation = invocation.into();
-    let span = debug_span!(parent:&invocation.span,"interpreter:op:instance", otel.name=format!("starting:{}",invocation.target));
+    let span =
+      info_span!(parent:&invocation.span,"interpreter:op:instance", otel.name=format!("starting:{}",invocation.target));
 
     let entity = self.entity();
     let namespace = self.namespace().to_owned();

--- a/crates/wick/wick-component-wasm/src/wasm_host.rs
+++ b/crates/wick/wick-component-wasm/src/wasm_host.rs
@@ -155,7 +155,7 @@ impl WasmHost {
     debug!(duration_μs = ?time.elapsed().as_micros(), "wasmtime initialize");
     if let Some(callback) = callback {
       let index = host.register_request_channel("wick", "__callback", make_host_callback(callback));
-      let cb_span = debug_span!(parent:&span,"wasmrs:event");
+      let cb_span = info_span!(parent:&span,"wasmrs:event");
 
       host.register_fire_and_forget("wick", "__event", make_event_callback(cb_span));
       trace!(index, "wasmrs callback index");

--- a/crates/wick/wick-component/src/adapters/binary/interleaved_pairs.rs
+++ b/crates/wick/wick-component/src/adapters/binary/interleaved_pairs.rs
@@ -1,24 +1,22 @@
+use crate::runtime::BoxFuture;
 use tokio_stream::StreamExt;
-use wasmrs_runtime::BoxFuture;
 use wick_packet::Packet;
+
+use crate::runtime as wasmrs_runtime;
 
 use crate::adapters::encode;
 use crate::{
-  await_next_ok_or,
-  if_done_close_then,
-  make_substream_window,
-  propagate_if_error,
-  SingleOutput,
-  WickStream,
+  await_next_ok_or, if_done_close_then, make_substream_window, propagate_if_error, SingleOutput, WickStream,
 };
 
 #[macro_export]
 /// This macro will generate the implementations for simple binary operations, operations that take two inputs, produce one output, and are largely want to remain ignorant of stream state.
 macro_rules! binary_interleaved_pairs {
   ($name:ident) => {
-    #[async_trait::async_trait(?Send)]
+    #[cfg_attr(target_family = "wasm",async_trait::async_trait(?Send))]
+    #[cfg_attr(not(target_family = "wasm"), async_trait::async_trait)]
     impl $name::Operation for Component {
-      type Error = Box<dyn std::error::Error + 'static>;
+      type Error = Box<dyn std::error::Error + Send + Sync + 'static>;
       type Outputs = $name::Outputs;
       type Config = $name::Config;
 

--- a/crates/wick/wick-host/src/app_host.rs
+++ b/crates/wick/wick-host/src/app_host.rs
@@ -72,7 +72,7 @@ impl AppHost {
           let loader = loader()?;
           let inner = loader.clone();
           let resources = resources.clone();
-          let span = debug_span!("trigger", kind=%trigger_config.kind());
+          let span = info_span!("trigger", kind=%trigger_config.kind());
           span.follows_from(&self.span);
 
           let task = tokio::spawn(async move {

--- a/crates/wick/wick-host/src/component_host.rs
+++ b/crates/wick/wick-host/src/component_host.rs
@@ -104,7 +104,7 @@ impl ComponentHost {
     );
 
     let mut rt_builder = RuntimeBuilder::from_definition(self.manifest.clone());
-    let span = debug_span!(parent: &self.span, "component_host");
+    let span = info_span!(parent: &self.span, "component_host");
 
     rt_builder = rt_builder.span(span);
     rt_builder = rt_builder.namespace(self.get_host_id());

--- a/crates/wick/wick-runtime/src/components/component_service.rs
+++ b/crates/wick/wick-runtime/src/components/component_service.rs
@@ -48,7 +48,7 @@ impl InvocationHandler for NativeComponentService {
   ) -> Result<BoxFuture<Result<InvocationResponse>>> {
     let tx_id = invocation.tx_id;
 
-    let span = debug_span!(parent:&invocation.span,"runtime:handle");
+    let span = info_span!(parent:&invocation.span,"runtime:handle");
     let fut = self.handle(invocation, config, panic_callback());
 
     let task = async move {

--- a/crates/wick/wick-runtime/src/runtime_service/child_init.rs
+++ b/crates/wick/wick-runtime/src/runtime_service/child_init.rs
@@ -41,7 +41,7 @@ pub(crate) fn init_child(
   namespace: Option<String>,
   opts: ChildInit,
 ) -> BoxFuture<'static, Result<Arc<RuntimeService>, EngineError>> {
-  let child_span = debug_span!(parent:opts.span,"runtime:child",id=%uid);
+  let child_span = info_span!(parent:opts.span,"runtime:child",id=%uid);
 
   let config = RuntimeInit {
     manifest,

--- a/crates/wick/wick-runtime/src/triggers/http.rs
+++ b/crates/wick/wick-runtime/src/triggers/http.rs
@@ -124,7 +124,7 @@ struct HttpInstance {
 
 impl HttpInstance {
   async fn new(engine: Runtime, routers: Vec<HttpRouter>, initiating_span: &Span, socket: &SocketAddr) -> Self {
-    let span = debug_span!(parent:initiating_span,"http:server", %socket);
+    let span = info_span!(parent:initiating_span,"http:server", %socket);
 
     span.in_scope(|| trace!(%socket,"http server starting"));
     let (tx, rx) = tokio::sync::oneshot::channel::<()>();
@@ -242,7 +242,7 @@ impl Http {
   ) -> Result<HttpInstance, RuntimeError> {
     let mut rt = build_trigger_runtime(&app_config, span.clone())?;
 
-    let span = debug_span!(parent: &span,"trigger:http:routers");
+    let span = info_span!(parent: &span,"trigger:http:routers");
 
     let routers = span.in_scope(|| {
       let mut routers = Vec::new();

--- a/crates/wick/wick-runtime/src/triggers/time.rs
+++ b/crates/wick/wick-runtime/src/triggers/time.rs
@@ -52,7 +52,7 @@ async fn create_schedule(
 ) -> tokio::task::JoinHandle<()> {
   // Create a scheduler loop
   tokio::spawn(async move {
-    let span = debug_span!("trigger:schedule", schedule = ?schedule);
+    let span = info_span!("trigger:schedule", schedule = ?schedule);
     let schedule_component = match resolve_ref(&app_config, config.operation().component()) {
       Ok(component) => component,
       Err(err) => panic!("Unable to resolve component: {}", err),

--- a/crates/wick/wick-settings/src/settings.rs
+++ b/crates/wick/wick-settings/src/settings.rs
@@ -122,7 +122,7 @@ impl Default for LogModifier {
 
 impl Settings {
   pub fn new() -> Self {
-    let _span = tracing::debug_span!("settings").entered();
+    let _span = tracing::info_span!("settings").entered();
     let extensions = vec!["yaml", "yml"];
 
     let xdg = wick_xdg::Settings::new();

--- a/crates/wick/wick-test/src/runner.rs
+++ b/crates/wick/wick-test/src/runner.rs
@@ -60,7 +60,7 @@ async fn run_unit<'a>(
   component: SharedComponent,
   root_config: Option<RuntimeConfig>,
 ) -> Result<TestBlock, TestError> {
-  let span = debug_span!("unit test", name = def.test.name());
+  let span = info_span!("unit test", name = def.test.name());
 
   let op_config = render_config(def.test.config(), None)?;
   let signature = get_operation(&component, def.test.operation())?;
@@ -119,8 +119,8 @@ async fn run_unit<'a>(
         TestError::Assertion(_ex, _act, assertion) => match assertion {
           crate::error::AssertionFailure::Payload(exv, acv) => {
             let diagnostic = assert_json_diff::assert_json_matches_no_panic(
-              &exv,
               &acv,
+              &exv,
               assert_json_diff::Config::new(assert_json_diff::CompareMode::Inclusive),
             );
             let diagnostic = Some(split_and_indent(&diagnostic.err().unwrap_or_default(), 3));


### PR DESCRIPTION
This PR converts all `debug_span!()` and `trace_span!()` macros to `info_span!()` because an `info_span!()` inside a `trace_span!()` will fail if trace_spans are turned off.