### PR TITLE
Better http client substream support.

### DIFF
--- a/crates/bins/wick/src/utils.rs
+++ b/crates/bins/wick/src/utils.rs
@@ -82,8 +82,6 @@ pub(crate) async fn print_stream_json(
   while let Some(packet) = stream.next().await {
     match packet {
       Ok(packet) => {
-        trace!(message = ?packet, "cli:output");
-
         if (packet.is_done()) && !raw {
           continue;
         }

--- a/crates/wick/wick-component-cli/src/error.rs
+++ b/crates/wick/wick-component-cli/src/error.rs
@@ -43,11 +43,28 @@ pub enum CliError {
   /// A general configuration error.
   Configuration(String),
 
-  #[error("Could not convert data '{1}' to a format suitable for port {0}'s type {2}")]
+  #[error("Could not convert data '{data}' to a format suitable for port {port}'s type {ty}")]
   /// Could not convert passed argument to a suitable intermediary format.
-  Encoding(String, String, Type),
+  Encoding {
+    /// The data that could not be converted.
+    data: String,
+    /// The port that the data was being passed to.
+    port: String,
+    /// The type of the port.
+    ty: Type,
+  },
 
   #[error("Found argument '{0}' which requires a value but no value was supplied")]
   /// Dangling arguments (e.g. --arg instead of --arg value or --arg=value)
   MissingArgumentValue(String),
+}
+
+impl CliError {
+  pub(crate) fn encoding(port: impl AsRef<str>, data: impl AsRef<str>, ty: Type) -> Self {
+    Self::Encoding {
+      data: data.as_ref().to_owned(),
+      port: port.as_ref().to_owned(),
+      ty,
+    }
+  }
 }

--- a/crates/wick/wick-packet/src/packet_stream.rs
+++ b/crates/wick/wick-packet/src/packet_stream.rs
@@ -3,7 +3,7 @@ use std::task::Poll;
 
 use pin_project_lite::pin_project;
 use tokio_stream::Stream;
-use tracing::Span;
+use tracing::{span_enabled, Span};
 use wasmrs_rx::FluxChannel;
 
 use crate::{BoxError, ContextTransport, InherentData, Packet, Result, RuntimeConfig};
@@ -118,12 +118,18 @@ impl Stream for PacketStream {
               .into(),
           );
           tracing::trace!("attached context to packet on port '{}'", packet.port());
-          // if cfg!(debug_assertions) {
-          //   self.span.in_scope(|| {
-          //     tracing::trace!(flags=packet.flags(),port=packet.port(),packet=%packet.clone().decode_value().map_or_else(|_| format!("{:?}", packet.payload()),|j|j.to_string())
-          //     , "packetstream:packet");
-          //   });
-          // }
+          if cfg!(debug_assertions) {
+            self.span.in_scope(|| {
+              if span_enabled!(tracing::Level::TRACE) {
+                let debug_packet = packet
+                  .clone()
+                  .decode_value()
+                  .map_or_else(|_| format!("{:?}", packet.payload()), |j| j.to_string());
+                let until = std::cmp::min(debug_packet.len(), 2048);
+                tracing::trace!(flags=packet.flags(), port=packet.port(), packet=%&debug_packet[..until], "packet");
+              }
+            });
+          }
           Poll::Ready(Some(Ok(packet)))
         }
         x => {
@@ -132,14 +138,20 @@ impl Stream for PacketStream {
         }
       }
     } else {
-      // if let Poll::Ready(Some(Ok(packet))) = &poll {
-      // if cfg!(debug_assertions) {
-      //   self.span.in_scope(|| {
-      //       tracing::trace!(flags=packet.flags(),port=packet.port(),packet=%packet.clone().decode_value().map_or_else(|_| format!("{:?}", packet.payload()),|j|j.to_string())
-      //         , "packetstream:packet");
-      //     });
-      // }
-      // }
+      if let Poll::Ready(Some(Ok(packet))) = &poll {
+        if cfg!(debug_assertions) {
+          self.span.in_scope(|| {
+            if span_enabled!(tracing::Level::TRACE) {
+              let debug_packet = packet
+                .clone()
+                .decode_value()
+                .map_or_else(|_| format!("{:?}", packet.payload()), |j| j.to_string());
+              let until = std::cmp::min(debug_packet.len(), 2048);
+              tracing::trace!(flags=packet.flags(), port=packet.port(), packet=%&debug_packet[..until], "packet");
+            }
+          });
+        }
+      }
       poll
     }
   }


### PR DESCRIPTION
This PR makes the HTTP client a better streaming citizen. Previously the client would send a `done` for both body & response as soon as one request is complete. This changes it to complete only when the input stream and all output tasks are complete.

This PR also re-enables tracel-level packet logs because they were pretty handy.