### PR TITLE
Ensured spans don't get filtered out by the logger.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6335,7 +6335,7 @@ dependencies = [
 
 [[package]]
 name = "wick-cli"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "atty",

--- a/crates/wick/wick-logger/src/logger.rs
+++ b/crates/wick/wick-logger/src/logger.rs
@@ -111,7 +111,11 @@ where
         return false;
       }
       if silly_modules(module) {
-        matches!(*metadata.level(), tracing::Level::ERROR | tracing::Level::WARN)
+        if metadata.is_span() {
+          true
+        } else {
+          matches!(*metadata.level(), tracing::Level::ERROR | tracing::Level::WARN)
+        }
       } else {
         true
       }


### PR DESCRIPTION
The logger's filter function was inadvertently blocking spans which would cause an error down the line if an event was triggered for a span that had been filtered out. This PR ensures that spans don't get filtered.