### PR TITLE
Decoupled telemetry from log output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6348,6 +6348,7 @@ dependencies = [
  "jaq-core",
  "markup-converter",
  "nkeys",
+ "once_cell",
  "openssl",
  "option-utils",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6648,6 +6648,7 @@ dependencies = [
  "console-subscriber",
  "opentelemetry",
  "opentelemetry-otlp",
+ "rstest",
  "thiserror",
  "time 0.3.25",
  "tokio",

--- a/crates/bins/wick/Cargo.toml
+++ b/crates/bins/wick/Cargo.toml
@@ -54,6 +54,7 @@ option-utils = { workspace = true }
 structured-output = { workspace = true }
 regex = { workspace = true }
 dhat = { workspace = true, optional = true }
+once_cell = { workspace = true }
 
 [dev-dependencies]
 test_bin = { workspace = true }

--- a/crates/bins/wick/src/main.rs
+++ b/crates/bins/wick/src/main.rs
@@ -201,9 +201,6 @@ async fn async_start() -> Result<(GlobalOptions, StructuredOutput), (GlobalOptio
   let mut cli = Cli::parse_from(args);
   let options = cli.output.clone();
 
-  // Do a preliminary logger init to catch any logs from the local settings.
-  // let log_options: wick_logger::LoggingOptions = cli.logging.name(BIN_NAME).into();
-  // let settings = wick_logger::with_default(&log_options, Box::new(wick_settings::Settings::new));
   let settings = wick_settings::Settings::new();
   apply_log_settings(&settings, &mut cli.logging);
 

--- a/crates/misc/test-logger/src/lib.rs
+++ b/crates/misc/test-logger/src/lib.rs
@@ -98,11 +98,10 @@ fn expand_logging_init() -> Tokens {
   match found_crate {
     FoundCrate::Itself => quote! {
       let __guard = crate::init_test(&crate::LoggingOptions {
-        level: crate::LogLevel::Trace,
-        silly: true,
         app_name: "test".to_owned(),
         otlp_endpoint: std::env::var("OTLP_ENDPOINT").ok(),
         global:true,
+        levels: crate::LogFilters::with_level(crate::LogLevel::Trace),
         ..Default::default()
       });
     },
@@ -112,11 +111,10 @@ fn expand_logging_init() -> Tokens {
       quote! {
         let __guard =
           #ident::init_test(&#ident::LoggingOptions {
-            level: #ident::LogLevel::Trace,
-            silly: true,
             app_name: "test".to_owned(),
             otlp_endpoint: std::env::var("OTLP_ENDPOINT").ok(),
             global:true,
+            levels: #ident::LogFilters::with_level(#ident::LogLevel::Trace),
             ..Default::default()
           });
 

--- a/crates/wick/flow-graph-interpreter/src/interpreter/executor/context.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/executor/context.rs
@@ -123,6 +123,10 @@ impl ExecutionContext {
     channel.dispatch_start(Box::new(self));
   }
 
+  pub fn in_scope<F: FnOnce() -> T, T>(&self, f: F) -> T {
+    self.span.in_scope(f)
+  }
+
   pub fn id(&self) -> Uuid {
     self.id
   }
@@ -250,6 +254,8 @@ impl ExecutionContext {
     // print stats if we're in tests.
     #[cfg(test)]
     self.stats.print();
+
+    self.span.in_scope(|| trace!(statistics=?self.stats));
 
     Ok(&self.stats)
   }

--- a/crates/wick/flow-graph-interpreter/src/interpreter/executor/context/operation.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/executor/context/operation.rs
@@ -241,7 +241,6 @@ impl InstanceHandler {
         port.set_status(new_status);
       }
     }
-    trace!(ports=?changed_statuses,"updated downstream ports");
     changed_statuses
   }
 

--- a/crates/wick/wick-logger/Cargo.toml
+++ b/crates/wick/wick-logger/Cargo.toml
@@ -34,3 +34,7 @@ opentelemetry-otlp = { workspace = true, features = [
   "grpc-tonic",
   "trace",
 ] }
+
+
+[dev-dependencies]
+rstest = { workspace = true }

--- a/crates/wick/wick-logger/src/lib.rs
+++ b/crates/wick/wick-logger/src/lib.rs
@@ -93,7 +93,7 @@ pub mod error;
 /// Logger options.
 mod options;
 
-pub use options::{LogLevel, LoggingOptions};
+pub use options::{FilterOptions, LogFilters, LogLevel, LoggingOptions, TargetLevel};
 
 /// The main Logger module.
 mod logger;

--- a/crates/wick/wick-logger/src/lib.rs
+++ b/crates/wick/wick-logger/src/lib.rs
@@ -93,7 +93,7 @@ pub mod error;
 /// Logger options.
 mod options;
 
-pub use options::{FilterOptions, LogFilters, LogLevel, LoggingOptions, TargetLevel};
+pub use options::{FilterOptions, LogFilters, LogLevel, LogModifier, LoggingOptions, TargetLevel};
 
 /// The main Logger module.
 mod logger;

--- a/crates/wick/wick-logger/src/options.rs
+++ b/crates/wick/wick-logger/src/options.rs
@@ -113,7 +113,7 @@ where
 }
 
 /// The log level for specific targets.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, PartialEq, Clone)]
 pub struct TargetLevel {
   /// The target (module name).
   pub target: String,

--- a/crates/wick/wick-logger/src/options.rs
+++ b/crates/wick/wick-logger/src/options.rs
@@ -1,16 +1,14 @@
+use std::cmp;
 use std::path::PathBuf;
+
+use tracing::{Level, Metadata};
+use tracing_subscriber::layer::Context;
 
 #[derive(Debug, Default, Clone)]
 /// Logging options.
 pub struct LoggingOptions {
   /// Turns on verbose logging.
   pub verbose: bool,
-
-  /// Greatly increases logging.
-  pub silly: bool,
-
-  /// Turns on debug logging.
-  pub level: LogLevel,
 
   /// Log as JSON.
   pub log_json: bool,
@@ -26,6 +24,112 @@ pub struct LoggingOptions {
 
   /// Whether to install the global logger.
   pub global: bool,
+
+  /// Log filtering options
+  pub levels: LogFilters,
+}
+
+#[derive(Debug, Default, Clone)]
+/// The filter configuration per log event destination.
+pub struct LogFilters {
+  /// The log level for the open telemetry events.
+  pub telemetry: FilterOptions,
+  /// The log level for the events printed to STDERR.
+  pub stderr: FilterOptions,
+}
+
+impl LogFilters {
+  /// Create a new filter configuration with the given log level.
+  #[must_use]
+  pub fn with_level(level: LogLevel) -> Self {
+    Self {
+      telemetry: FilterOptions {
+        level,
+        ..Default::default()
+      },
+      stderr: FilterOptions {
+        level,
+        ..Default::default()
+      },
+    }
+  }
+}
+
+/// Options for filtering logs.
+#[derive(Debug, Clone)]
+pub struct FilterOptions {
+  /// The default log level for anything that does not match an include or exclude filter.
+  pub level: LogLevel,
+  /// The targets and their log levels to include.
+  pub include: Vec<TargetLevel>,
+  /// The targets and their log levels to exclude.
+  pub exclude: Vec<TargetLevel>,
+}
+
+impl Default for FilterOptions {
+  fn default() -> Self {
+    Self {
+      level: LogLevel::Info,
+      include: vec![],
+      exclude: vec![],
+    }
+  }
+}
+
+impl<S> tracing_subscriber::layer::Filter<S> for FilterOptions
+where
+  S: tracing::Subscriber + for<'lookup> tracing_subscriber::registry::LookupSpan<'lookup>,
+{
+  fn enabled(&self, metadata: &Metadata<'_>, _cx: &Context<'_, S>) -> bool {
+    metadata.target().starts_with("wick")
+      || metadata.target().starts_with("flow")
+      || metadata.target().starts_with("wasmrs")
+  }
+
+  fn event_enabled(&self, event: &tracing::Event<'_>, _cx: &Context<'_, S>) -> bool {
+    let module = event.metadata().target().split("::").next().unwrap_or_default();
+    let level = event.metadata().level();
+
+    let excluded = self
+      .exclude
+      .iter()
+      .find(|config| module.starts_with(&config.target) || config.target == "*")
+      .map(|excluded| excluded.level < *level);
+
+    let included = self
+      .include
+      .iter()
+      .find(|config| module.starts_with(&config.target) || config.target == "*")
+      .map(|included| included.level >= (*level));
+
+    if included == Some(true) {
+      true
+    } else if excluded == Some(true) {
+      return false;
+    } else {
+      self.level >= *level
+    }
+  }
+}
+
+/// The log level for specific targets.
+#[derive(Debug, Default, Clone)]
+pub struct TargetLevel {
+  /// The target (module name).
+  pub target: String,
+  /// The level to log at.
+  pub level: LogLevel,
+}
+
+impl TargetLevel {
+  /// Create a new instance for the given target and log level.
+  #[must_use]
+  pub fn new(target: impl AsRef<str>, level: LogLevel) -> Self {
+    Self {
+      target: target.as_ref().to_owned(),
+      level,
+    }
+  }
 }
 
 impl LoggingOptions {
@@ -38,25 +142,107 @@ impl LoggingOptions {
   }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq)]
 /// The log levels.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[repr(usize)]
 pub enum LogLevel {
   /// No logging.
-  Quiet,
+  Quiet = 0,
   /// Only log errors.
-  Error,
+  Error = 1,
   /// Only log warnings and errors.
-  Warn,
+  Warn = 2,
   /// The default log level.
-  Info,
+  Info = 3,
   /// Log debug messages.
-  Debug,
+  Debug = 4,
   /// Log trace messages.
-  Trace,
+  Trace = 5,
 }
 
 impl Default for LogLevel {
   fn default() -> Self {
     Self::Info
   }
+}
+
+impl std::str::FromStr for LogLevel {
+  type Err = String;
+
+  fn from_str(s: &str) -> Result<Self, Self::Err> {
+    match s.to_lowercase().as_str() {
+      "quiet" => Ok(LogLevel::Quiet),
+      "error" => Ok(LogLevel::Error),
+      "warn" => Ok(LogLevel::Warn),
+      "info" => Ok(LogLevel::Info),
+      "debug" => Ok(LogLevel::Debug),
+      "trace" => Ok(LogLevel::Trace),
+      _ => Err(format!("Unknown log level: {}", s)),
+    }
+  }
+}
+
+impl std::fmt::Display for LogLevel {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      LogLevel::Quiet => write!(f, "QUIET"),
+      LogLevel::Error => write!(f, "ERROR"),
+      LogLevel::Warn => write!(f, "WARN"),
+      LogLevel::Info => write!(f, "INFO"),
+      LogLevel::Debug => write!(f, "DEBUG"),
+      LogLevel::Trace => write!(f, "TRACE"),
+    }
+  }
+}
+
+impl PartialEq<Level> for LogLevel {
+  #[inline(always)]
+  fn eq(&self, other: &Level) -> bool {
+    match self {
+      LogLevel::Quiet => false,
+      LogLevel::Error => other.eq(&Level::ERROR),
+      LogLevel::Warn => other.eq(&Level::WARN),
+      LogLevel::Info => other.eq(&Level::INFO),
+      LogLevel::Debug => other.eq(&Level::DEBUG),
+      LogLevel::Trace => other.eq(&Level::TRACE),
+    }
+  }
+}
+
+impl PartialOrd<Level> for LogLevel {
+  #[inline(always)]
+  fn partial_cmp(&self, other: &Level) -> Option<cmp::Ordering> {
+    Some((*self as usize).cmp(&filter_as_usize(other)))
+  }
+
+  #[inline(always)]
+  fn lt(&self, other: &Level) -> bool {
+    (*self as usize) < filter_as_usize(other)
+  }
+
+  #[inline(always)]
+  fn le(&self, other: &Level) -> bool {
+    (*self as usize) <= filter_as_usize(other)
+  }
+
+  #[inline(always)]
+  fn gt(&self, other: &Level) -> bool {
+    (*self as usize) > filter_as_usize(other)
+  }
+
+  #[inline(always)]
+  fn ge(&self, other: &Level) -> bool {
+    (*self as usize) >= filter_as_usize(other)
+  }
+}
+
+#[inline(always)]
+fn filter_as_usize(x: &Level) -> usize {
+  (match *x {
+    Level::ERROR => 0,
+    Level::WARN => 1,
+    Level::INFO => 2,
+    Level::DEBUG => 3,
+    Level::TRACE => 4,
+  } + 1)
 }

--- a/crates/wick/wick-packet/src/packet_stream.rs
+++ b/crates/wick/wick-packet/src/packet_stream.rs
@@ -126,7 +126,9 @@ impl Stream for PacketStream {
                   .decode_value()
                   .map_or_else(|_| format!("{:?}", packet.payload()), |j| j.to_string());
                 let until = std::cmp::min(debug_packet.len(), 2048);
-                tracing::trace!(flags=packet.flags(), port=packet.port(), packet=%&debug_packet[..until], "packet");
+                self.span.in_scope(|| {
+                  tracing::trace!(flags=packet.flags(), port=packet.port(), packet=%&debug_packet[..until], "packet");
+                });
               }
             });
           }
@@ -147,7 +149,9 @@ impl Stream for PacketStream {
                 .decode_value()
                 .map_or_else(|_| format!("{:?}", packet.payload()), |j| j.to_string());
               let until = std::cmp::min(debug_packet.len(), 2048);
-              tracing::trace!(flags=packet.flags(), port=packet.port(), packet=%&debug_packet[..until], "packet");
+              self.span.in_scope(|| {
+                tracing::trace!(flags=packet.flags(), port=packet.port(), packet=%&debug_packet[..until], "packet");
+              });
             }
           });
         }

--- a/crates/wick/wick-settings/src/settings.rs
+++ b/crates/wick/wick-settings/src/settings.rs
@@ -36,6 +36,23 @@ pub struct TraceSettings {
   /// Logging modifier.
   #[serde(default)]
   pub modifier: LogModifier,
+  /// Telemetry filter settings.
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub telemetry: Option<LogSettings>,
+  /// STDERR logging settings.
+  #[serde(default, skip_serializing_if = "Option::is_none")]
+  pub stderr: Option<LogSettings>,
+}
+
+#[derive(Debug, Default, Deserialize, Serialize, Clone)]
+#[serde(rename_all = "snake_case")]
+#[serde(deny_unknown_fields)]
+/// Log filter settings
+pub struct LogSettings {
+  /// Inclusion filter.
+  pub include: Option<String>,
+  /// Exclusion filter.
+  pub exclude: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -110,8 +127,6 @@ pub enum LogModifier {
   None,
   /// Additional location and file data.
   Verbose,
-  /// Include all logging possible.
-  Silly,
 }
 
 impl Default for LogModifier {

--- a/crates/wick/wick-settings/src/settings.rs
+++ b/crates/wick/wick-settings/src/settings.rs
@@ -49,10 +49,8 @@ pub struct TraceSettings {
 #[serde(deny_unknown_fields)]
 /// Log filter settings
 pub struct LogSettings {
-  /// Inclusion filter.
-  pub include: Option<String>,
-  /// Exclusion filter.
-  pub exclude: Option<String>,
+  /// Log event filter.
+  pub filter: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/tests/codegen-bin/src/main.rs
+++ b/tests/codegen-bin/src/main.rs
@@ -10,8 +10,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 fn gen(spec: &str, dir: &str) -> Result<(), Box<dyn std::error::Error>> {
   let _guard = wick_logger::init(&LoggingOptions {
     verbose: true,
-    silly: true,
-    level: wick_logger::LogLevel::Trace,
+    levels: wick_logger::LogFilters::with_level(wick_logger::LogLevel::Trace),
     log_json: false,
     log_dir: None,
     otlp_endpoint: None,


### PR DESCRIPTION
This PR separates log and telemetry filter and levels configuration to be more granular. You can specify what modules you want logged to STDERR separately from what is sent to telemetry.

The default is similar to what exists now. Most of the `wick` namespace is logged at an `Info` level, `flow*` is logged at `Warn`, everything else is squelched. You can change it from command line settings, ENV vars, or the settings file.

*Updates*
- 2023-08-15: consolidated include/exclude to a single filter string.

**CLI args**

`wick run [file...] --log-filter='wick<=trace,flow<=trace' --otel-filter=flow=trace`

**ENV**

`LOG_FILTER="wick<=trace,flow<=trace" wick run ...`

**~/.wick/config/config.yaml**

```yaml
trace:
  level: info
  otlp: http://nas.glhf.lan:4317
  telemetry:
    filter: 'wick<=trace,flow<=trace'
  stderr:
    filter: 'wick_packet<=trace,wick<=trace,flow<=debug'
```

<details>
<summary>Original proposal</summary>

**CLI args**

`wick run [file...] --log-keep=wick=debug --otel-keep=flow=trace`

**ENV**

`LOG_INCLUDE="wick=debug" wick run ...`

**~/.wick/config/config.yaml**

```yaml
trace:
  level: info
  modifier: verbose
  otlp: http://nas.glhf.lan:4317
  telemetry:
    include: 'wick=debug,flow=debug'
  stderr:
    include: 'wick_packet=trace,wick=info,flow=trace'
    exclude: 'flow=debug'
```

Note: The CLI args are `xxx-keep` and `xxx-filter` where the settings and env are `include`/`exclude`. I'm open to suggestions one, the other, or something else.

One other option is to merge both into one string, e.g. `wick=trace,!flow=debug,wasmrs=info`

</details>
