### PR TITLE
Fixed "refusing to overwrite ..." errors on application runs.

### DIFF
--- a/crates/bins/wick/src/commands/install.rs
+++ b/crates/bins/wick/src/commands/install.rs
@@ -45,9 +45,7 @@ pub(crate) async fn handle(
   };
 
   let path = package.path();
-  let config = WickConfiguration::fetch(path.to_string_lossy(), Default::default())
-    .await?
-    .into_inner();
+  let config = WickConfiguration::fetch(path, Default::default()).await?.into_inner();
 
   let config = match config {
     WickConfiguration::App(config) => config,

--- a/crates/bins/wick/src/options.rs
+++ b/crates/bins/wick/src/options.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use clap::Args;
-use wick_oci_utils::OciOptions;
+use wick_oci_utils::{OciOptions, OnExisting};
 use wick_settings::Credential;
 
 #[derive(Args, Debug, Default, Clone)]
@@ -147,7 +147,11 @@ pub(crate) fn reconcile_fetch_options(
     .set_allow_latest(true)
     .set_username(username)
     .set_password(password)
-    .set_overwrite(force);
+    .set_on_existing(if force {
+      OnExisting::Overwrite
+    } else {
+      OnExisting::Error
+    });
   if let Some(output) = output {
     oci_opts.set_cache_dir(output);
   }

--- a/crates/wick/wick-config/src/config.rs
+++ b/crates/wick/wick-config/src/config.rs
@@ -112,7 +112,7 @@ impl WickConfiguration {
   /// # });
   /// ```
   pub async fn fetch_all(
-    path: impl Into<String> + Send,
+    path: impl Into<AssetReference> + Send,
     options: FetchOptions,
   ) -> Result<UninitializedConfiguration, Error> {
     let config = Self::fetch(path, options.clone()).await?;
@@ -137,16 +137,13 @@ impl WickConfiguration {
   /// ```
   ///
   pub async fn fetch(
-    path: impl Into<String> + Send,
+    asset: impl Into<AssetReference> + Send,
     options: FetchOptions,
   ) -> Result<UninitializedConfiguration, Error> {
-    let path = path.into();
-    let location = AssetReference::new(&path);
+    let asset: AssetReference = asset.into();
 
-    let bytes = location.fetch(options.clone()).await?;
-    let source = location
-      .path()
-      .unwrap_or_else(|e| PathBuf::from(format!("<ERROR:{}>", e)));
+    let bytes = asset.fetch(options.clone()).await?;
+    let source = asset.path().unwrap_or_else(|e| PathBuf::from(format!("<ERROR:{}>", e)));
     let config = WickConfiguration::load_from_bytes(&bytes, &Some(source))?;
     config.manifest.update_baseurls();
     match &config.manifest {

--- a/crates/wick/wick-oci-utils/src/lib.rs
+++ b/crates/wick/wick-oci-utils/src/lib.rs
@@ -105,7 +105,13 @@ pub use options::*;
 pub use pull::*;
 pub use push::*;
 use serde::{Deserialize, Serialize};
-pub use utils::{is_oci_reference, is_wick_package_reference, parse_reference, parse_reference_and_protocol};
+pub use utils::{
+  get_cache_directory,
+  is_oci_reference,
+  is_wick_package_reference,
+  parse_reference,
+  parse_reference_and_protocol,
+};
 
 use crate::error::OciError;
 

--- a/crates/wick/wick-oci-utils/src/options.rs
+++ b/crates/wick/wick-oci-utils/src/options.rs
@@ -2,6 +2,13 @@ use std::path::PathBuf;
 
 use oci_distribution::secrets::RegistryAuth;
 
+#[derive(Clone, Debug, Copy, serde::Serialize)]
+pub enum OnExisting {
+  Ignore,
+  Overwrite,
+  Error,
+}
+
 #[derive(getset::Getters, getset::Setters, Clone, serde::Serialize)]
 #[must_use]
 pub struct OciOptions {
@@ -16,7 +23,7 @@ pub struct OciOptions {
   #[getset(get = "pub", set = "pub")]
   pub(crate) cache_dir: PathBuf,
   #[getset(get = "pub", set = "pub")]
-  pub(crate) overwrite: bool,
+  pub(crate) on_existing: OnExisting,
 }
 
 impl Default for OciOptions {
@@ -28,7 +35,7 @@ impl Default for OciOptions {
       username: None,
       password: None,
       cache_dir: xdg.global().cache().clone(),
-      overwrite: false,
+      on_existing: OnExisting::Ignore,
     }
   }
 }

--- a/crates/wick/wick-oci-utils/src/utils.rs
+++ b/crates/wick/wick-oci-utils/src/utils.rs
@@ -79,7 +79,7 @@ pub fn parse_reference_and_protocol(
   ))
 }
 
-pub(crate) fn get_cache_directory(input: &str, basedir: impl AsRef<Path>) -> Result<PathBuf, Error> {
+pub fn get_cache_directory(input: &str, basedir: impl AsRef<Path>) -> Result<PathBuf, Error> {
   let image_ref = parse_reference(input)?;
 
   let registry = image_ref

--- a/crates/wick/wick-package/src/package.rs
+++ b/crates/wick/wick-package/src/package.rs
@@ -51,7 +51,7 @@ fn process_assets(
 
       match relative_path.extension().and_then(|os_str| os_str.to_str()) {
         Some("yaml" | "yml" | "wick") => {
-          let config = WickConfiguration::fetch(asset_path.to_string_lossy(), options.clone())
+          let config = WickConfiguration::fetch((*asset).clone(), options.clone())
             .await
             .map(|b| b.into_inner());
           match config {
@@ -95,7 +95,7 @@ fn process_assets(
         }
       }
 
-      if asset.exists_locally() {
+      if asset.exists_outside_cache() {
         let file_bytes = asset.bytes(&options).await?;
         let hash = format!("sha256:{}", digest(file_bytes.as_ref()));
         let wick_file = PackageFile::new(relative_path.to_path_buf(), hash, media_type.to_owned(), file_bytes);
@@ -134,9 +134,7 @@ impl WickPackage {
     }
 
     let options = wick_config::FetchOptions::default();
-    let config = WickConfiguration::fetch(path.to_string_lossy(), options)
-      .await?
-      .into_inner();
+    let config = WickConfiguration::fetch(path, options).await?.into_inner();
     if !matches!(
       config,
       WickConfiguration::App(_) | WickConfiguration::Component(_) | WickConfiguration::Types(_)

--- a/crates/wick/wick-package/tests/wick_package_integration.rs
+++ b/crates/wick/wick-package/tests/wick_package_integration.rs
@@ -21,7 +21,7 @@ mod integration_test {
     println!("Using tempdir: {:?}", tempdir);
     let mut options = OciOptions::default();
     options
-      .set_overwrite(true)
+      .set_on_existing(wick_oci_utils::OnExisting::Overwrite)
       .set_cache_dir(tempdir.clone())
       .set_allow_insecure(vec![host.to_owned()]);
 

--- a/crates/wick/wick-package/tests/wick_package_types_integration.rs
+++ b/crates/wick/wick-package/tests/wick_package_types_integration.rs
@@ -21,7 +21,7 @@ mod integration_test {
     println!("Using tempdir: {:?}", tempdir);
     let mut options = OciOptions::default();
     options
-      .set_overwrite(true)
+      .set_on_existing(wick_oci_utils::OnExisting::Overwrite)
       .set_cache_dir(tempdir.clone())
       .set_allow_insecure(vec![host.to_owned()]);
 

--- a/crates/wick/wick-runtime/src/components.rs
+++ b/crates/wick/wick-runtime/src/components.rs
@@ -121,7 +121,7 @@ pub(crate) async fn init_manifest_component(
     .set_allow_latest(opts.allow_latest)
     .set_allow_insecure(opts.allowed_insecure.clone());
 
-  let mut builder = WickConfiguration::fetch(kind.reference().path()?.to_string_lossy(), options)
+  let mut builder = WickConfiguration::fetch(kind.reference().clone(), options)
     .instrument(span.clone())
     .await?;
   builder.set_root_config(opts.root_config.clone());

--- a/crates/wick/wick-runtime/src/runtime_service/utils.rs
+++ b/crates/wick/wick-runtime/src/runtime_service/utils.rs
@@ -49,7 +49,9 @@ pub(crate) async fn instantiate_import(
   binding: &config::ImportBinding,
   opts: ChildInit,
 ) -> Result<Option<NamespaceHandler>, EngineError> {
-  opts.span.in_scope(|| debug!(?binding, ?opts, "instantiating import"));
+  opts
+    .span
+    .in_scope(|| debug!(id = binding.id(), ?opts, "instantiating import"));
   let id = binding.id().to_owned();
   match binding.kind() {
     config::ImportDefinition::Component(c) => instantiate_imported_component(id, c, opts).await,

--- a/crates/wick/wick-runtime/src/test.rs
+++ b/crates/wick/wick-runtime/src/test.rs
@@ -30,7 +30,7 @@ pub(crate) async fn load_test_manifest(name: &str) -> Result<WickConfiguration> 
   let crate_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
   let manifest_dir = crate_dir.join("tests/manifests/v1");
   let yaml = manifest_dir.join(name);
-  let mut config = wick_config::config::WickConfiguration::fetch(yaml.to_string_lossy(), Default::default()).await?;
+  let mut config = wick_config::config::WickConfiguration::fetch(&yaml, Default::default()).await?;
 
   config.set_env(Some(std::env::vars().collect()));
 
@@ -41,7 +41,7 @@ pub(crate) async fn load_example(name: &str) -> Result<WickConfiguration> {
   let crate_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
   let manifest_dir = crate_dir.join("../../../examples");
   let yaml = manifest_dir.join(name);
-  let mut config = wick_config::config::WickConfiguration::fetch(yaml.to_string_lossy(), Default::default()).await?;
+  let mut config = wick_config::config::WickConfiguration::fetch(&yaml, Default::default()).await?;
   config.set_env(Some(std::env::vars().collect()));
 
   Ok(config.finish()?)

--- a/crates/wick/wick-runtime/src/triggers/time.rs
+++ b/crates/wick/wick-runtime/src/triggers/time.rs
@@ -49,21 +49,17 @@ async fn create_schedule(
   schedule: Schedule,
   app_config: AppConfiguration,
   config: TimeTriggerConfig,
-) -> tokio::task::JoinHandle<()> {
+) -> Result<tokio::task::JoinHandle<()>, RuntimeError> {
+  let span = info_span!("trigger:schedule", schedule = ?schedule);
+  let schedule_component = resolve_ref(&app_config, config.operation().component())?;
+  let mut runtime = build_trigger_runtime(&app_config, span.clone())?;
+  let schedule_binding = config::ImportBinding::component("0", schedule_component);
+  runtime.add_import(schedule_binding);
+  // needed for invoke command
+  let runtime = runtime.build(None).await?;
+
   // Create a scheduler loop
-  tokio::spawn(async move {
-    let span = info_span!("trigger:schedule", schedule = ?schedule);
-    let schedule_component = match resolve_ref(&app_config, config.operation().component()) {
-      Ok(component) => component,
-      Err(err) => panic!("Unable to resolve component: {}", err),
-    };
-
-    let mut runtime = build_trigger_runtime(&app_config, span.clone()).unwrap();
-    let schedule_binding = config::ImportBinding::component("0", schedule_component);
-    runtime.add_import(schedule_binding);
-    // needed for invoke command
-    let runtime = runtime.build(None).await.unwrap();
-
+  let handle = tokio::spawn(async move {
     let runtime = Arc::new(runtime);
     let operation = Arc::new(config.operation().name().to_owned());
     let payload = Arc::new(config.payload().to_vec());
@@ -100,7 +96,8 @@ async fn create_schedule(
         }
       });
     }
-  })
+  });
+  Ok(handle)
 }
 
 #[derive(Debug)]
@@ -141,7 +138,7 @@ impl Time {
       }
     };
 
-    let scheduler_task = create_schedule(schedule, app_config, config).await;
+    let scheduler_task = create_schedule(schedule, app_config, config).await?;
 
     self.handler.lock().replace(scheduler_task);
 

--- a/crates/wick/wick-runtime/src/triggers/time.rs
+++ b/crates/wick/wick-runtime/src/triggers/time.rs
@@ -173,7 +173,10 @@ impl Trigger for Time {
   }
 
   async fn wait_for_done(&self) {
-    let handler = self.handler.lock().take().unwrap();
+    let Some(handler) = self.handler.lock().take() else {
+      return;
+    };
+
     match handler.await {
       Ok(_) => {
         info!("cron done");
@@ -205,7 +208,7 @@ mod test {
     let manifest_dir = crate_dir.join("../../../examples/time/");
 
     let yaml = manifest_dir.join("time.wick");
-    let app_config = config::WickConfiguration::fetch(yaml.to_string_lossy(), Default::default())
+    let app_config = config::WickConfiguration::fetch(&yaml, Default::default())
       .await?
       .finish()?
       .try_app_config()?;

--- a/examples/time/time.wick
+++ b/examples/time/time.wick
@@ -14,7 +14,9 @@ import:
   - name: comp
     component:
       kind: wick/component/manifest@v1
-      ref: ../../integration/test-baseline-component/component.yaml
+      ref: ../../crates/integration/test-baseline-component/component.yaml
+      with:
+        default_err: 'Error from time trigger'
 triggers:
   - kind: wick/trigger/time@v1
     schedule:

--- a/tests/integration/src/test/wick_test.rs
+++ b/tests/integration/src/test/wick_test.rs
@@ -17,7 +17,7 @@ async fn baseline_component() -> Result<()> {
 
   let fetch_options = wick_config::FetchOptions::default();
 
-  let mut root_manifest = WickConfiguration::fetch(manifest.to_string_lossy(), fetch_options).await?;
+  let mut root_manifest = WickConfiguration::fetch(&manifest, fetch_options).await?;
   root_manifest.set_root_config(Some(RuntimeConfig::from(HashMap::from([(
     "default_err".into(),
     "err".into(),


### PR DESCRIPTION
There were instances where two fetches of the same resource (file/OCI reference) could overlap and cause an error if they both tried to update the cache.

This PR fixes it two ways, one: by locking an `AssetReference` until a remote fetch is finished and two: by adding in more granular behavior controls for what to do when the situation occurs since it can't be prevented altogether. By default, the behavior is `Ignore`, and when you pull/run initially it is `Error` or `Overwrite` depending on CLI settings.

This PR also fixes a bug in the `Time` trigger that prevented errors from surfacing during the trigger init process. 