### PR TITLE
Support provides/requires relationship in composite components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6563,7 +6563,6 @@ dependencies = [
  "flow-component",
  "futures 0.3.28",
  "liquid-json",
- "parking_lot",
  "pretty_assertions",
  "reqwest",
  "serde",

--- a/Justfile
+++ b/Justfile
@@ -233,6 +233,8 @@ _wick-component-tests:
   {{wick}} test ./examples/components/hello-world.wick
   {{wick}} test ./examples/components/composite-db-import.wick
   {{wick}} test ./examples/components/wasi-fs/component.wick
+  {{wick}} test ./examples/components/composite-imports.wick
+  {{wick}} test ./examples/components/composite-provides.wick
 
 # Run component-codegen unit tests
 _codegen-tests:

--- a/crates/bins/wick/src/commands/new/app.rs
+++ b/crates/bins/wick/src/commands/new/app.rs
@@ -54,18 +54,15 @@ pub(crate) async fn handle(
       match trigger {
         TriggerType::Time => {
           let comp_name = "COMPONENT";
-          config.import_mut().insert(
-            comp_name.to_owned(),
-            ImportBinding::component(
-              comp_name,
-              config::ComponentDefinition::Manifest(
-                ManifestComponentBuilder::default()
-                  .reference("path/to/component.wick")
-                  .build()
-                  .unwrap(),
-              ),
+          config.import_mut().push(ImportBinding::component(
+            comp_name,
+            config::ComponentDefinition::Manifest(
+              ManifestComponentBuilder::default()
+                .reference("path/to/component.wick")
+                .build()
+                .unwrap(),
             ),
-          );
+          ));
 
           config.triggers_mut().push(config::TriggerDefinition::Time(
             config::TimeTriggerConfigBuilder::default()
@@ -87,8 +84,7 @@ pub(crate) async fn handle(
         }
         TriggerType::Http => {
           let port_name = "HTTP_PORT";
-          config.resources_mut().insert(
-            port_name.to_owned(),
+          config.resources_mut().push(
             ResourceBindingBuilder::default()
               .id(port_name)
               .kind(config::ResourceDefinition::TcpPort(TcpPort::new("0.0.0.0", 8080)))
@@ -104,18 +100,15 @@ pub(crate) async fn handle(
         }
         TriggerType::Cli => {
           let comp_name = "MAIN_COMPONENT";
-          config.import_mut().insert(
-            comp_name.to_owned(),
-            ImportBinding::component(
-              comp_name,
-              config::ComponentDefinition::Manifest(
-                ManifestComponentBuilder::default()
-                  .reference("path/to/component.wick")
-                  .build()
-                  .unwrap(),
-              ),
+          config.import_mut().push(ImportBinding::component(
+            comp_name,
+            config::ComponentDefinition::Manifest(
+              ManifestComponentBuilder::default()
+                .reference("path/to/component.wick")
+                .build()
+                .unwrap(),
             ),
-          );
+          ));
 
           config.triggers_mut().push(config::TriggerDefinition::Cli(
             config::CliConfigBuilder::default()

--- a/crates/bins/wick/src/commands/new/component/http.rs
+++ b/crates/bins/wick/src/commands/new/component/http.rs
@@ -34,13 +34,10 @@ pub(crate) async fn handle(
     let mut config = ComponentConfiguration::default();
     config.set_name(name.clone());
 
-    config.resources_mut().insert(
-      resource_name.to_owned(),
-      ResourceBinding::new(
-        resource_name,
-        ResourceDefinition::Url(UrlResource::new("http://localhost:8080".parse().unwrap())),
-      ),
-    );
+    config.resources_mut().push(ResourceBinding::new(
+      resource_name,
+      ResourceDefinition::Url(UrlResource::new("http://localhost:8080".parse().unwrap())),
+    ));
 
     config.set_metadata(crate::commands::new::generic_metadata("New HTTP Client wick component"));
 

--- a/crates/bins/wick/src/commands/new/component/sql.rs
+++ b/crates/bins/wick/src/commands/new/component/sql.rs
@@ -32,15 +32,12 @@ pub(crate) async fn handle(
     let mut config = ComponentConfiguration::default();
     config.set_name(name.clone());
     let resource_name = "DB_URL";
-    config.resources_mut().insert(
-      resource_name.to_owned(),
-      config::ResourceBinding::new(
-        resource_name,
-        config::ResourceDefinition::Url(config::UrlResource::new(
-          "postgres://postgres:postgres@localhost:5432/db_name".parse().unwrap(),
-        )),
-      ),
-    );
+    config.resources_mut().push(config::ResourceBinding::new(
+      resource_name,
+      config::ResourceDefinition::Url(config::UrlResource::new(
+        "postgres://postgres:postgres@localhost:5432/db_name".parse().unwrap(),
+      )),
+    ));
 
     config.set_metadata(crate::commands::new::generic_metadata("New SQL wick component"));
 

--- a/crates/components/wick-http-client/Cargo.toml
+++ b/crates/components/wick-http-client/Cargo.toml
@@ -27,7 +27,6 @@ serde = { workspace = true, features = ["derive"] }
 #
 futures = { workspace = true }
 thiserror = { workspace = true }
-parking_lot = { workspace = true }
 serde_json = { workspace = true }
 
 #

--- a/crates/components/wick-sql/src/component.rs
+++ b/crates/components/wick-sql/src/component.rs
@@ -546,9 +546,7 @@ mod integration_test {
       ),
     );
 
-    let mut component = SqlComponent::new(config, None, None, &app_config.resolver()).await?;
-
-    component.init().await?;
+    let component = SqlComponent::new(config, None, None, &app_config.resolver()).await?;
 
     Ok(component)
   }
@@ -604,9 +602,7 @@ mod integration_test {
       ),
     );
 
-    let mut component = SqlComponent::new(config, None, None, &app_config.resolver()).await?;
-
-    component.init().await.unwrap();
+    let component = SqlComponent::new(config, None, None, &app_config.resolver()).await?;
 
     Ok(component)
   }
@@ -653,9 +649,7 @@ mod integration_test {
       ResourceDefinition::Url(format!("sqlite://{}", db).try_into().unwrap()),
     );
 
-    let mut component = SqlComponent::new(config, None, None, &app_config.resolver()).await?;
-
-    component.init().await.unwrap();
+    let component = SqlComponent::new(config, None, None, &app_config.resolver()).await?;
 
     Ok(component)
   }

--- a/crates/wick/flow-component/src/traits.rs
+++ b/crates/wick/flow-component/src/traits.rs
@@ -24,12 +24,6 @@ pub trait Component {
   /// The `signature` method returns the [ComponentSignature] for the component.
   fn signature(&self) -> &ComponentSignature;
 
-  /// The `init` method is called when the component is initialized.
-  fn init(&mut self) -> BoxFuture<Result<(), ComponentError>> {
-    // Override if you need a more explicit init.
-    Box::pin(async move { Ok(()) })
-  }
-
   /// The `shutdown` method is called when the component is shutdown.
   fn shutdown(&self) -> BoxFuture<Result<(), ComponentError>> {
     // Override if you need a more explicit shutdown.

--- a/crates/wick/flow-graph-interpreter/src/interpreter/components.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/components.rs
@@ -130,6 +130,14 @@ impl NamespaceHandler {
     }
   }
 
+  pub fn new_from_shared<T: AsRef<str>>(namespace: T, component: Arc<Box<dyn Component + Send + Sync>>) -> Self {
+    Self {
+      namespace: namespace.as_ref().to_owned(),
+      component,
+      exposed: Arc::new(AtomicBool::new(false)),
+    }
+  }
+
   #[must_use]
   pub fn namespace(&self) -> &str {
     &self.namespace

--- a/crates/wick/flow-graph-interpreter/src/interpreter/error.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/error.rs
@@ -21,6 +21,9 @@ pub enum Error {
   #[error("Could not find component '{}' ({0}). Namespaces handled by this resource are: {}", .0.component_id(), .1.join(", "))]
   TargetNotFound(Entity, Vec<String>),
 
+  #[error("Can not invoke non-operation entity: {0}")]
+  InvalidEntity(Entity),
+
   #[error("Error shutting down component: {0}")]
   ComponentShutdown(String),
 

--- a/crates/wick/flow-graph-interpreter/src/interpreter/executor/context/operation.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/executor/context/operation.rs
@@ -103,7 +103,7 @@ impl std::fmt::Debug for InstanceHandler {
 
 impl std::fmt::Display for InstanceHandler {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(f, "{}::{}", self.namespace(), self.id())
+    write!(f, "{} ({})", self.entity(), self.id())
   }
 }
 

--- a/crates/wick/wick-component-codegen/src/generate.rs
+++ b/crates/wick/wick-component-codegen/src/generate.rs
@@ -97,7 +97,7 @@ fn codegen(wick_config: WickConfiguration, gen_config: &mut config::Config) -> R
         .sorted_by(|a, b| a.name().cmp(b.name()))
         .collect();
       let root_config = comp.config().to_owned();
-      let requires = comp.requires().values().cloned().collect_vec();
+      let requires = comp.requires().clone().to_vec();
       let ops = match comp.component() {
         wick_config::config::ComponentImplementation::Wasm(c) => c.operation_signatures(),
         wick_config::config::ComponentImplementation::Composite(c) => c.operation_signatures(),

--- a/crates/wick/wick-config/src/config/common/bindings.rs
+++ b/crates/wick/wick-config/src/config/common/bindings.rs
@@ -1,5 +1,7 @@
 #![allow(missing_docs)] // delete when we move away from the `property` crate.
 
+use std::collections::HashMap;
+
 use wick_packet::RuntimeConfig;
 
 use super::{ComponentDefinition, HighLevelComponent, ImportDefinition, InterfaceDefinition};
@@ -33,6 +35,15 @@ impl ImportBinding {
   pub fn config(&self) -> Option<&RuntimeConfig> {
     match &self.kind {
       ImportDefinition::Component(c) => c.config().and_then(|v| v.value()),
+      ImportDefinition::Types(_) => None,
+    }
+  }
+
+  /// Get the configuration object for the collection.
+  #[must_use]
+  pub fn provide(&self) -> Option<&HashMap<String, String>> {
+    match &self.kind {
+      ImportDefinition::Component(c) => c.provide(),
       ImportDefinition::Types(_) => None,
     }
   }

--- a/crates/wick/wick-config/src/config/common/component_definition.rs
+++ b/crates/wick/wick-config/src/config/common/component_definition.rs
@@ -148,6 +148,20 @@ impl ComponentDefinition {
     }
   }
 
+  /// Returns any components this configuration provides to the implementation.
+  #[must_use]
+  pub fn provide(&self) -> Option<&HashMap<String, String>> {
+    match self {
+      #[allow(deprecated)]
+      ComponentDefinition::Wasm(c) => Some(c.provide()),
+      ComponentDefinition::GrpcUrl(_) => None,
+      ComponentDefinition::Manifest(c) => Some(c.provide()),
+      ComponentDefinition::Native(_) => None,
+      ComponentDefinition::Reference(_) => None,
+      ComponentDefinition::HighLevelComponent(_) => None,
+    }
+  }
+
   /// Returns the component config, if it exists
   #[must_use]
   pub fn config_mut(&mut self) -> Option<&mut LiquidJsonConfig> {

--- a/crates/wick/wick-config/src/config/component_config.rs
+++ b/crates/wick/wick-config/src/config/component_config.rs
@@ -1,7 +1,6 @@
 #![allow(missing_docs)] // delete when we move away from the `property` crate.
 mod composite;
 mod wasm;
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use asset_container::{AssetManager, Assets};
@@ -62,19 +61,19 @@ pub struct ComponentConfiguration {
 
   #[builder(default)]
   /// Any imports this component makes available to its implementation.
-  #[serde(skip_serializing_if = "HashMap::is_empty")]
-  pub(crate) import: HashMap<String, ImportBinding>,
+  #[serde(skip_serializing_if = "Vec::is_empty")]
+  pub(crate) import: Vec<ImportBinding>,
 
   #[asset(skip)]
   #[builder(default)]
   /// Any components or resources that must be provided to this component upon instantiation.
-  #[serde(skip_serializing_if = "HashMap::is_empty")]
-  pub(crate) requires: HashMap<String, BoundInterface>,
+  #[serde(skip_serializing_if = "Vec::is_empty")]
+  pub(crate) requires: Vec<BoundInterface>,
 
   #[builder(default)]
   /// Any resources this component defines.
-  #[serde(skip_serializing_if = "HashMap::is_empty")]
-  pub(crate) resources: HashMap<String, ResourceBinding>,
+  #[serde(skip_serializing_if = "Vec::is_empty")]
+  pub(crate) resources: Vec<ResourceBinding>,
 
   #[asset(skip)]
   #[builder(default)]
@@ -231,7 +230,7 @@ impl ComponentConfiguration {
   pub(crate) async fn setup_cache(&self, options: FetchOptions) -> Result<()> {
     setup_cache(
       &self.type_cache,
-      self.import.values(),
+      self.import.iter(),
       &self.cached_types,
       self.types.clone(),
       options,
@@ -282,10 +281,10 @@ impl ComponentConfiguration {
       ?root_config,
       "initializing component"
     );
-    for resource in self.resources.values_mut() {
+    for resource in self.resources.iter_mut() {
       resource.kind.render_config(root_config.as_ref(), None)?;
     }
-    for import in self.import.values_mut() {
+    for import in self.import.iter_mut() {
       import.kind.render_config(root_config.as_ref(), None)?;
     }
 
@@ -329,22 +328,18 @@ impl ComponentConfigurationBuilder {
   /// Add an imported component to the builder.
   pub fn add_import(&mut self, import: ImportBinding) {
     if let Some(imports) = &mut self.import {
-      imports.insert(import.id.clone(), import);
+      imports.push(import);
     } else {
-      let mut imports = HashMap::new();
-      imports.insert(import.id.clone(), import);
-      self.import = Some(imports);
+      self.import = Some(vec![import]);
     }
   }
 
   /// Add an imported resource to the builder.
   pub fn add_resource(&mut self, resource: ResourceBinding) {
     if let Some(r) = &mut self.resources {
-      r.insert(resource.id.clone(), resource);
+      r.push(resource);
     } else {
-      let mut r = HashMap::new();
-      r.insert(resource.id.clone(), resource);
-      self.resources = Some(r);
+      self.resources = Some(vec![resource]);
     }
   }
 

--- a/crates/wick/wick-config/src/utils.rs
+++ b/crates/wick/wick-config/src/utils.rs
@@ -125,8 +125,8 @@ pub(crate) fn resolve_configuration(src: &str, source: &Option<PathBuf>) -> Resu
 }
 
 pub(crate) fn make_resolver(
-  imports: HashMap<String, ImportBinding>,
-  resources: HashMap<String, ResourceBinding>,
+  imports: Vec<ImportBinding>,
+  resources: Vec<ResourceBinding>,
   runtime_config: Option<RuntimeConfig>,
   env: Option<HashMap<String, String>>,
 ) -> Box<Resolver> {
@@ -135,12 +135,12 @@ pub(crate) fn make_resolver(
 
 pub(crate) fn resolve(
   name: &str,
-  imports: &HashMap<String, ImportBinding>,
-  resources: &HashMap<String, ResourceBinding>,
+  imports: &[ImportBinding],
+  resources: &[ResourceBinding],
   runtime_config: Option<&RuntimeConfig>,
   env: Option<&HashMap<String, String>>,
 ) -> Result<OwnedConfigurationItem> {
-  if let Some(import) = imports.get(name) {
+  if let Some(import) = imports.iter().find(|i| i.id == name) {
     match &import.kind {
       ImportDefinition::Component(component) => {
         let mut component = component.clone();
@@ -152,7 +152,7 @@ pub(crate) fn resolve(
       ImportDefinition::Types(_) => todo!(),
     }
   }
-  if let Some(resource) = resources.get(name) {
+  if let Some(resource) = resources.iter().find(|i| i.id == name) {
     let mut resource = resource.kind.clone();
     return match resource.render_config(runtime_config, env) {
       Ok(_) => Ok(OwnedConfigurationItem::Resource(resource)),

--- a/crates/wick/wick-config/src/v0/conversions.rs
+++ b/crates/wick/wick-config/src/v0/conversions.rs
@@ -28,13 +28,8 @@ impl TryFrom<v0::HostManifest> for config::ComponentConfiguration {
         .network
         .collections
         .into_iter()
-        .map(|val| {
-          Ok((
-            val.namespace.clone(),
-            config::ImportBinding::new(val.namespace.clone(), val.try_into()?),
-          ))
-        })
-        .collect::<Result<HashMap<_, _>>>()?,
+        .map(|val| Ok(config::ImportBinding::new(val.namespace.clone(), val.try_into()?)))
+        .collect::<Result<Vec<_>>>()?,
       component: config::ComponentImplementation::Composite(composite),
       host: def.host.try_map_into()?,
       name: def.network.name,

--- a/crates/wick/wick-config/src/v1/conversions.rs
+++ b/crates/wick/wick-config/src/v1/conversions.rs
@@ -128,21 +128,9 @@ impl TryFrom<v1::ComponentConfiguration> for ComponentConfiguration {
       tests: def.tests.try_map_into()?,
       component: def.component.try_into()?,
       types: def.types.try_map_into()?,
-      requires: def
-        .requires
-        .into_iter()
-        .map(|v| Ok((v.name.clone(), v.try_into()?)))
-        .collect::<Result<_>>()?,
-      import: def
-        .import
-        .into_iter()
-        .map(|v| Ok((v.name.clone(), v.try_into()?)))
-        .collect::<Result<_>>()?,
-      resources: def
-        .resources
-        .into_iter()
-        .map(|v| Ok((v.name.clone(), v.try_into()?)))
-        .collect::<Result<_>>()?,
+      requires: def.requires.try_map_into()?,
+      import: def.import.try_map_into()?,
+      resources: def.resources.try_map_into()?,
       cached_types: Default::default(),
       type_cache: Default::default(),
       package: def.package.try_map_into()?,
@@ -159,18 +147,10 @@ impl TryFrom<ComponentConfiguration> for v1::ComponentConfiguration {
       metadata: def.metadata.try_map_into()?,
       host: def.host.try_map_into()?,
       name: def.name,
-      requires: def
-        .requires
-        .into_values()
-        .map(|v| v.try_into())
-        .collect::<Result<_>>()?,
-      import: def.import.into_values().map(|v| v.try_into()).collect::<Result<_>>()?,
+      requires: def.requires.try_map_into()?,
+      import: def.import.try_map_into()?,
       types: def.types.try_map_into()?,
-      resources: def
-        .resources
-        .into_values()
-        .map(|v| v.try_into())
-        .collect::<Result<_>>()?,
+      resources: def.resources.try_map_into()?,
       tests: def.tests.try_map_into()?,
       component: def.component.try_into()?,
       package: def.package.try_map_into()?,
@@ -381,16 +361,8 @@ impl TryFrom<v1::AppConfiguration> for AppConfiguration {
       metadata: def.metadata.try_map_into()?,
       name: def.name,
       options: None,
-      import: def
-        .import
-        .into_iter()
-        .map(|v| Ok((v.name.clone(), v.try_into()?)))
-        .collect::<Result<_>>()?,
-      resources: def
-        .resources
-        .into_iter()
-        .map(|v| Ok((v.name.clone(), v.try_into()?)))
-        .collect::<Result<_>>()?,
+      import: def.import.try_map_into()?,
+      resources: def.resources.try_map_into()?,
       triggers: def.triggers.into_iter().map(|v| v.try_into()).collect::<Result<_>>()?,
       cached_types: Default::default(),
       type_cache: Default::default(),
@@ -408,16 +380,8 @@ impl TryFrom<AppConfiguration> for v1::AppConfiguration {
     Ok(Self {
       metadata: value.metadata.try_map_into()?,
       name: value.name,
-      import: value
-        .import
-        .into_values()
-        .map(|v| v.try_into())
-        .collect::<Result<_>>()?,
-      resources: value
-        .resources
-        .into_values()
-        .map(|v| v.try_into())
-        .collect::<Result<_>>()?,
+      import: value.import.try_map_into()?,
+      resources: value.resources.try_map_into()?,
       triggers: value.triggers.try_map_into()?,
       package: value.package.try_map_into()?,
     })

--- a/crates/wick/wick-config/tests/v1_load_from_file.rs
+++ b/crates/wick/wick-config/tests/v1_load_from_file.rs
@@ -116,7 +116,7 @@ async fn test_component_extended() -> Result<(), ManifestError> {
 async fn regression_issue_42() -> Result<(), ManifestError> {
   let component = load_app("./tests/manifests/v1/template-expansion.yaml").await?;
   println!("{:?}", component);
-  let coll = component.imports().get("test").unwrap();
+  let coll = component.imports().get(0).unwrap();
   let value: String = coll.kind().config().unwrap().coerce_key("pwd").unwrap();
   let expected = std::env::var("CARGO_MANIFEST_DIR").unwrap();
 

--- a/crates/wick/wick-host/src/app_host.rs
+++ b/crates/wick/wick-host/src/app_host.rs
@@ -48,9 +48,9 @@ impl AppHost {
 
   fn init_resources(&mut self) -> Result<HashMap<String, Resource>> {
     let mut resources = HashMap::new();
-    for (id, def) in self.manifest.resources() {
+    for def in self.manifest.resources() {
       let resource = Resource::new(def.kind().clone())?;
-      resources.insert(id.clone(), resource);
+      resources.insert(def.id().to_owned(), resource);
     }
     Ok(resources)
   }

--- a/crates/wick/wick-runtime/src/error.rs
+++ b/crates/wick/wick-runtime/src/error.rs
@@ -1,28 +1,68 @@
 use std::convert::Infallible;
 
 use thiserror::Error;
-use wick_config::config::TriggerKind;
+use wick_config::config::{ComponentKind, TriggerKind};
 
 pub use crate::components::error::ComponentError;
 use crate::resources::ResourceKind;
 pub use crate::runtime_service::error::EngineError;
 
+#[derive(Debug, Clone, Copy)]
+pub enum Context {
+  Trigger,
+  TriggerKind(TriggerKind),
+  Import,
+  Resource,
+  ResourceKind(ResourceKind),
+  Component,
+  ComponentKind(ComponentKind),
+}
+
+impl std::fmt::Display for Context {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      Context::Trigger => write!(f, "trigger"),
+      Context::TriggerKind(kind) => write!(f, "trigger {}", kind),
+      Context::Import => write!(f, "import"),
+      Context::Resource => write!(f, "resource"),
+      Context::ResourceKind(kind) => write!(f, "resource {}", kind),
+      Context::Component => write!(f, "component"),
+      Context::ComponentKind(kind) => write!(f, "component {}", kind),
+    }
+  }
+}
+
+impl From<TriggerKind> for Context {
+  fn from(kind: TriggerKind) -> Self {
+    Context::TriggerKind(kind)
+  }
+}
+
+impl From<ResourceKind> for Context {
+  fn from(kind: ResourceKind) -> Self {
+    Context::ResourceKind(kind)
+  }
+}
+
+impl From<ComponentKind> for Context {
+  fn from(kind: ComponentKind) -> Self {
+    Context::ComponentKind(kind)
+  }
+}
+
 #[derive(Error, Debug)]
 pub enum RuntimeError {
-  #[error("Invalid trigger configuration, expected configuration for {0}")]
-  InvalidTriggerConfig(TriggerKind),
+  #[error("Invalid {0} configuration, expected configuration for {0}")]
+  InvalidConfig(Context, TriggerKind),
 
-  #[error("Trigger {0} requested resource '{1}' which could not be found")]
-  ResourceNotFound(TriggerKind, String),
+  #[error("{0} requested resource '{1}' which could not be found")]
+  ResourceNotFound(Context, String),
 
-  #[error("Trigger {0} referenced import '{1}' which could not be found")]
-  NotFound(String, String),
+  #[error("{0} requires resource kind {1}, not {2}")]
+  InvalidResourceType(Context, ResourceKind, ResourceKind),
 
-  #[error("Trigger {0} requires resource kind {1}, not {2}")]
-  InvalidResourceType(TriggerKind, ResourceKind, ResourceKind),
-
-  #[error("Trigger {0} did not shutdown gracefully: {1}")]
-  ShutdownFailed(TriggerKind, String),
+  #[error("{0} did not shutdown gracefully: {1}")]
+  ShutdownFailed(Context, String),
 
   #[error("The supplied id '{0}' does not point to a correct type or valid type: {1}")]
   ReferenceError(String, wick_config::Error),

--- a/crates/wick/wick-runtime/src/runtime.rs
+++ b/crates/wick/wick-runtime/src/runtime.rs
@@ -40,7 +40,7 @@ pub struct RuntimeInit {
   pub(crate) span: Span,
 
   #[builder(setter(custom = true))]
-  pub(crate) native_components: ComponentRegistry,
+  pub(crate) initial_components: ComponentRegistry,
 }
 
 impl Runtime {
@@ -100,7 +100,7 @@ impl std::fmt::Debug for RuntimeBuilder {
       .field("allowed_insecure", &self.allowed_insecure)
       .field("manifest", &self.manifest)
       .field("namespace", &self.namespace)
-      .field("native_components", &self.native_components)
+      .field("initial_components", &self.initial_components)
       .finish()
   }
 }
@@ -163,9 +163,9 @@ impl RuntimeBuilder {
   }
 
   pub fn add_native_component(&mut self, factory: Box<ComponentFactory>) -> &mut Self {
-    let mut val = self.native_components.take().unwrap_or_default();
+    let mut val = self.initial_components.take().unwrap_or_default();
     val.add(factory);
-    self.native_components.replace(val);
+    self.initial_components.replace(val);
     self
   }
 
@@ -180,7 +180,7 @@ impl RuntimeBuilder {
         manifest: definition,
         allow_latest: self.allow_latest.unwrap_or_default(),
         allowed_insecure: self.allowed_insecure.unwrap_or_default(),
-        native_components: self.native_components.unwrap_or_default(),
+        initial_components: self.initial_components.unwrap_or_default(),
         namespace: self.namespace.unwrap_or_default(),
         constraints: self.constraints.unwrap_or_default(),
         span,

--- a/crates/wick/wick-runtime/src/runtime_service/child_init.rs
+++ b/crates/wick/wick-runtime/src/runtime_service/child_init.rs
@@ -1,11 +1,12 @@
 use std::sync::Arc;
 
+use flow_graph_interpreter::HandlerMap;
 use seeded_random::Seed;
 use tracing::Span;
 use uuid::Uuid;
 use wick_config::config::ComponentConfiguration;
 use wick_config::Resolver;
-use wick_packet::RuntimeConfig;
+use wick_packet::{Entity, RuntimeConfig};
 
 use super::{ComponentRegistry, RuntimeService, ServiceInit};
 use crate::runtime::RuntimeInit;
@@ -19,6 +20,7 @@ pub(crate) struct ChildInit {
   pub(crate) allowed_insecure: Vec<String>,
   pub(crate) root_config: Option<RuntimeConfig>,
   pub(crate) resolver: Box<Resolver>,
+  pub(crate) provided: Option<HandlerMap>,
   #[allow(unused)]
   pub(crate) span: Span,
 }
@@ -42,17 +44,29 @@ pub(crate) fn init_child(
   opts: ChildInit,
 ) -> BoxFuture<'static, Result<Arc<RuntimeService>, EngineError>> {
   let child_span = info_span!(parent:opts.span,"runtime:child",id=%uid);
+  let mut components = ComponentRegistry::default();
 
-  let config = RuntimeInit {
-    manifest,
-    allow_latest: opts.allow_latest,
-    allowed_insecure: opts.allowed_insecure,
-    namespace,
-    constraints: Default::default(),
-    span: child_span,
-    native_components: ComponentRegistry::default(),
-  };
-  let init = ServiceInit::new_with_id(uid, opts.rng_seed, config);
+  Box::pin(async move {
+    for req in manifest.requires() {
+      let ns = req.id();
+      if let Some(handler) = opts.provided.as_ref().and_then(|p| p.get(ns).cloned()) {
+        components.add(Box::new(move |_| Ok(handler.clone())));
+      } else {
+        return Err(EngineError::RequirementUnsatisfied(Entity::component(ns)));
+      }
+    }
 
-  Box::pin(async move { RuntimeService::start(init).await })
+    let config = RuntimeInit {
+      manifest,
+      allow_latest: opts.allow_latest,
+      allowed_insecure: opts.allowed_insecure,
+      namespace,
+      constraints: Default::default(),
+      span: child_span,
+      initial_components: components,
+    };
+    let init = ServiceInit::new_with_id(uid, opts.rng_seed, config);
+
+    RuntimeService::start(init).await
+  })
 }

--- a/crates/wick/wick-runtime/src/runtime_service/error.rs
+++ b/crates/wick/wick-runtime/src/runtime_service/error.rs
@@ -18,6 +18,9 @@ pub enum EngineError {
   #[error("Could not generate graph from '{}': {1}", display_path(.0))]
   Graph(Option<PathBuf>, Box<flow_graph_interpreter::graph::GraphError>),
 
+  #[error("{0} configuration referenced import '{1}' which could not be found")]
+  NotFound(Context, String),
+
   #[error("Could not start runtime from '{}': {1}", display_path(.0))]
   RuntimeInit(Option<PathBuf>, String),
 
@@ -38,6 +41,9 @@ pub enum EngineError {
 
   #[error(transparent)]
   Asset(#[from] wick_config::AssetError),
+
+  #[error("entity {0} not found")]
+  RequirementUnsatisfied(Entity),
 
   #[error(transparent)]
   NativeComponent(#[from] flow_component::ComponentError),

--- a/crates/wick/wick-runtime/src/runtime_service/init.rs
+++ b/crates/wick/wick-runtime/src/runtime_service/init.rs
@@ -1,3 +1,5 @@
+use flow_graph_interpreter::HandlerMap;
+
 use super::{ChildInit, ComponentRegistry};
 use crate::dev::prelude::*;
 use crate::runtime::{RuntimeConstraint, RuntimeInit};
@@ -11,7 +13,7 @@ pub(crate) struct ServiceInit {
   pub(crate) allowed_insecure: Vec<String>,
   pub(crate) namespace: Option<String>,
   pub(crate) constraints: Vec<RuntimeConstraint>,
-  pub(crate) native_components: ComponentRegistry,
+  pub(crate) initial_components: ComponentRegistry,
   pub(crate) span: Span,
 }
 
@@ -26,7 +28,7 @@ impl ServiceInit {
       allowed_insecure: config.allowed_insecure,
       namespace: config.namespace,
       constraints: config.constraints,
-      native_components: config.native_components,
+      initial_components: config.initial_components,
       span: config.span,
     }
   }
@@ -41,12 +43,12 @@ impl ServiceInit {
       allowed_insecure: config.allowed_insecure,
       namespace: config.namespace,
       constraints: config.constraints,
-      native_components: config.native_components,
+      initial_components: config.initial_components,
       span: config.span,
     }
   }
 
-  pub(super) fn child_init(&self, root_config: Option<RuntimeConfig>) -> ChildInit {
+  pub(super) fn child_init(&self, root_config: Option<RuntimeConfig>, provided: Option<HandlerMap>) -> ChildInit {
     ChildInit {
       rng_seed: self.rng.seed(),
       runtime_id: self.id,
@@ -54,6 +56,7 @@ impl ServiceInit {
       allow_latest: self.allow_latest,
       allowed_insecure: self.allowed_insecure.clone(),
       resolver: self.manifest.resolver(),
+      provided,
       span: self.span.clone(),
     }
   }

--- a/crates/wick/wick-runtime/src/triggers.rs
+++ b/crates/wick/wick-runtime/src/triggers.rs
@@ -27,10 +27,10 @@ fn build_trigger_runtime(config: &AppConfiguration, span: Span) -> Result<Runtim
     rt = rt.allow_latest(*fetch_opts.allow_latest());
     rt = rt.allowed_insecure(fetch_opts.allow_insecure().clone());
   }
-  for import in config.imports().values() {
+  for import in config.imports() {
     rt.add_import(import.clone());
   }
-  for resource in config.resources().values() {
+  for resource in config.resources() {
     rt.add_resource(resource.clone());
   }
   rt = rt.span(span);

--- a/crates/wick/wick-runtime/src/triggers/cli.rs
+++ b/crates/wick/wick-runtime/src/triggers/cli.rs
@@ -115,7 +115,7 @@ impl Trigger for Cli {
     let config = if let TriggerDefinition::Cli(config) = config {
       config
     } else {
-      return Err(RuntimeError::InvalidTriggerConfig(TriggerKind::Cli));
+      return Err(RuntimeError::InvalidConfig(Context::Trigger, TriggerKind::Cli));
     };
 
     let mut args: Vec<String> = env::args().collect();

--- a/crates/wick/wick-runtime/src/triggers/http/rest_router.rs
+++ b/crates/wick/wick-runtime/src/triggers/http/rest_router.rs
@@ -293,7 +293,7 @@ mod test {
         .try_app_config()?;
 
       let trigger = Http::default();
-      let resource = Resource::new(app_config.resources().get("http").as_ref().unwrap().kind().clone())?;
+      let resource = Resource::new(app_config.resources().get(0).as_ref().unwrap().kind().clone())?;
       let resources = Arc::new([("http".to_owned(), resource)].iter().cloned().collect());
       let trigger_config = app_config.triggers()[0].clone();
       trigger

--- a/crates/wick/wick-runtime/src/triggers/time.rs
+++ b/crates/wick/wick-runtime/src/triggers/time.rs
@@ -162,7 +162,7 @@ impl Trigger for Time {
     let config = if let TriggerDefinition::Time(config) = config {
       config
     } else {
-      return Err(RuntimeError::InvalidTriggerConfig(TriggerKind::Time));
+      return Err(RuntimeError::InvalidConfig(Context::Trigger, TriggerKind::Time));
     };
 
     self.handle(app_config, config).await

--- a/crates/wick/wick-runtime/tests/triggers.rs
+++ b/crates/wick/wick-runtime/tests/triggers.rs
@@ -18,9 +18,9 @@ async fn load_app_yaml(path: &str) -> anyhow::Result<AppConfiguration> {
 
 fn init_resources(config: &AppConfiguration) -> Result<HashMap<String, Resource>> {
   let mut resources = HashMap::new();
-  for (id, def) in config.resources() {
-    let resource = Resource::new(def.kind().clone())?;
-    resources.insert(id.clone(), resource);
+  for res in config.resources() {
+    let resource = Resource::new(res.kind().clone())?;
+    resources.insert(res.id().to_owned(), resource);
   }
   Ok(resources)
 }

--- a/crates/wick/wick-runtime/tests/utils/mod.rs
+++ b/crates/wick/wick-runtime/tests/utils/mod.rs
@@ -1,11 +1,23 @@
+use std::path::{Path, PathBuf};
+
 use futures::stream::StreamExt;
 use tracing::debug;
 use wick_config::WickConfiguration;
 use wick_packet::{Entity, InherentData, Invocation, Packet, PacketStream, RuntimeConfig};
 use wick_runtime::{Runtime, RuntimeBuilder};
 
-pub async fn init_engine_from_yaml(path: &str, config: Option<RuntimeConfig>) -> anyhow::Result<(Runtime, uuid::Uuid)> {
-  let mut host_def = WickConfiguration::load_from_file(path).await?;
+#[allow(unused)]
+pub fn example(file: &str) -> PathBuf {
+  let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+  let workspace_dir = path.join("..").join("..").join("..").join("examples");
+  workspace_dir.join(file)
+}
+
+pub async fn init_engine_from_yaml(
+  path: impl AsRef<Path>,
+  config: Option<RuntimeConfig>,
+) -> anyhow::Result<(Runtime, uuid::Uuid)> {
+  let mut host_def = WickConfiguration::load_from_file(path.as_ref()).await?;
   host_def.set_root_config(config);
   let host_def = host_def.finish()?.try_component_config()?;
   debug!("Manifest loaded");
@@ -20,7 +32,7 @@ pub async fn init_engine_from_yaml(path: &str, config: Option<RuntimeConfig>) ->
 
 #[allow(unused)]
 pub async fn common_test(
-  path: &str,
+  path: impl AsRef<Path>,
   stream: PacketStream,
   target: &str,
   mut expected: Vec<Packet>,
@@ -30,7 +42,7 @@ pub async fn common_test(
 
 #[allow(unused)]
 pub async fn test_with_config(
-  path: &str,
+  path: impl AsRef<Path>,
   stream: PacketStream,
   target: &str,
   mut expected: Vec<Packet>,
@@ -42,7 +54,7 @@ pub async fn test_with_config(
 
 #[allow(unused)]
 pub async fn base_test(
-  path: &str,
+  path: impl AsRef<Path>,
   stream: PacketStream,
   target: Entity,
   mut expected: Vec<Packet>,

--- a/crates/wick/wick-runtime/tests/v1_components.rs
+++ b/crates/wick/wick-runtime/tests/v1_components.rs
@@ -113,3 +113,25 @@ async fn test_context_passthrough_base(
 
   Ok(())
 }
+
+#[test_logger::test(tokio::test)]
+async fn composite_requires() -> Result<()> {
+  common_test(
+    example("components/composite-provides.wick"),
+    packet_stream!(("input", "hello world")),
+    "echo_provided",
+    vec![Packet::encode("output", "hello world"), Packet::done("output")],
+  )
+  .await
+}
+
+#[test_logger::test(tokio::test)]
+async fn composite_imports() -> Result<()> {
+  common_test(
+    example("components/composite-imports.wick"),
+    packet_stream!(("input", "hello world")),
+    "echo_outer",
+    vec![Packet::encode("output", "hello world"), Packet::done("output")],
+  )
+  .await
+}

--- a/examples/components/composite-imports.wick
+++ b/examples/components/composite-imports.wick
@@ -1,0 +1,24 @@
+kind: wick/component@v1
+import:
+  - name: IMPORTED_COMPONENT
+    component:
+      kind: wick/component/manifest@v1
+      ref: ./echo.wick
+component:
+  kind: wick/component/composite@v1
+  operations:
+    - name: echo_outer
+      flow:
+        - <>.input -> IMPORTED_COMPONENT::echo[a].input
+        - a.output -> <>.output
+tests:
+  - name: basic
+    cases:
+      - name: default
+        operation: echo_outer
+        inputs:
+          - name: input
+            value: 'Hello, world!'
+        outputs:
+          - name: output
+            value: 'Hello, world!'

--- a/examples/components/composite-provides.wick
+++ b/examples/components/composite-provides.wick
@@ -1,0 +1,30 @@
+kind: wick/component@v1
+import:
+  - name: PROVIDED_COMPONENT
+    component:
+      kind: wick/component/manifest@v1
+      ref: ./echo.wick
+  - name: IMPORTED_COMPONENT
+    component:
+      kind: wick/component/manifest@v1
+      ref: ./composite-requires.wick
+      provide:
+        required_component: PROVIDED_COMPONENT
+component:
+  kind: wick/component/composite@v1
+  operations:
+    - name: echo_provided
+      flow:
+        - <>.input -> IMPORTED_COMPONENT::inner_operation[a].input
+        - a.output -> <>.output
+tests:
+  - name: basic
+    cases:
+      - name: default
+        operation: echo_provided
+        inputs:
+          - name: input
+            value: 'Hello, world!'
+        outputs:
+          - name: output
+            value: 'Hello, world!'

--- a/examples/components/composite-requires.wick
+++ b/examples/components/composite-requires.wick
@@ -1,0 +1,18 @@
+kind: wick/component@v1
+requires:
+  - name: required_component
+    interface:
+      operations:
+        - name: echo
+          inputs:
+            - name: input
+              type: string
+          outputs:
+            - name: output
+              type: string
+component:
+  kind: wick/component/composite@v1
+  operations:
+    - name: inner_operation
+      flow:
+        - <>.input -> required_component::echo -> <>.output

--- a/examples/http/wasm-http-call/harness.wick
+++ b/examples/http/wasm-http-call/harness.wick
@@ -6,18 +6,18 @@ metadata:
   licenses:
     - Apache-2.0
 import:
-  - name: wasm
-    component:
-      kind: wick/component/manifest@v1
-      ref: ./wasm-component/component.wick
-      provide:
-        client: client
   - name: client
     component:
       kind: wick/component/manifest@v1
       ref: ./client.wick
       with:
         url: '{{ ctx.root_config.url}}'
+  - name: wasm
+    component:
+      kind: wick/component/manifest@v1
+      ref: ./wasm-component/component.wick
+      provide:
+        client: client
 component:
   kind: wick/component/composite@v1
   with:


### PR DESCRIPTION
This PR adds support for requires/provides relationships in composite components. The configuration parsed correctly, but the functionality was never added. This led to unexpected errors and an unintuitive experience. This PR officially adds the ability for composite components to `require` components and access them in flows.

POTENTIAL BREAKING NOTE: This PR makes the order of `import`-ed components important. During the changes above, I saw some random test failures that stemmed from the indeterministic ordering of rust's `HashMap` keys. This PR changes those structures to lists which will make them reliable but order-dependent. Components must now be imported in an earlier position than they are provided to other components. 