### PR TITLE
Added configurable buffer size & caches

### DIFF
--- a/crates/bins/wick/tests/run/integration/postgres.toml
+++ b/crates/bins/wick/tests/run/integration/postgres.toml
@@ -5,7 +5,7 @@ stdout = """
 
 cli:db: in WebAssembly CLI component
 cli:db: looking up user with id: 1.
-cli:db: calling provided component operation at URL: wick://cli/=>wick://MYDB/get_user
+cli:db: calling provided component operation at URL: wick://CLI/=>wick://MYDB/get_user
 cli:db: call succeeded, waiting for response...
 cli:db: row data: {"name":"Test User"}
 cli:db: response stream ended.

--- a/crates/wick/wick-asset-reference/src/asset_reference.rs
+++ b/crates/wick/wick-asset-reference/src/asset_reference.rs
@@ -96,6 +96,15 @@ impl PartialEq for AssetReference {
   }
 }
 
+impl Eq for AssetReference {}
+
+impl std::hash::Hash for AssetReference {
+  fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+    self.location.hash(state);
+    self.baseurl.read().hash(state);
+  }
+}
+
 impl AssetReference {
   /// Create a new location reference.
   pub fn new(location: impl AsRef<str>) -> Self {

--- a/crates/wick/wick-component-wasm/src/component.rs
+++ b/crates/wick/wick-component-wasm/src/component.rs
@@ -19,6 +19,8 @@ pub struct ComponentSetup {
   #[builder(setter(), default)]
   pub config: Option<RuntimeConfig>,
   #[builder(setter(), default)]
+  pub buffer_size: Option<u32>,
+  #[builder(setter(), default)]
   pub callback: Option<Arc<RuntimeCallback>>,
   #[builder(default, setter(into))]
   pub provided: HashMap<String, String>,
@@ -79,8 +81,13 @@ impl WasmComponent {
     if let Some(callback) = options.callback {
       builder = builder.link_callback(callback);
     }
+
     if let Some(engine) = options.engine {
       builder = builder.engine(engine);
+    }
+
+    if let Some(value) = options.buffer_size {
+      builder = builder.buffer_size(value);
     }
 
     let host = builder.build(&asset).await?;

--- a/crates/wick/wick-config/definitions/v1/manifest.apex
+++ b/crates/wick/wick-config/definitions/v1/manifest.apex
@@ -434,7 +434,7 @@ type WasmComponentConfiguration @tagged("wick/component/wasmrs@v1") {
   volumes: [ExposedVolume]
 
   "The default size to allocate to the component's send/receive buffer."
-  buffer_size: u32?,
+  max_packet_size: u32?,
 
   "Configuration necessary to provide when instantiating the component."
   with: [Field]
@@ -531,7 +531,7 @@ type ManifestComponent @tagged("wick/component/manifest@v1") {
   provide: {string:string}
 
   "If applicable, the default size to allocate to the component's send/receive buffer."
-  buffer_size: u32?
+  max_packet_size: u32?
 }
 
 "Composite operations are operations whose implementations come from connecting other operations into a flow or series of pipelines."

--- a/crates/wick/wick-config/definitions/v1/manifest.apex
+++ b/crates/wick/wick-config/definitions/v1/manifest.apex
@@ -433,6 +433,9 @@ type WasmComponentConfiguration @tagged("wick/component/wasmrs@v1") {
   "Volumes to expose to the component."
   volumes: [ExposedVolume]
 
+  "The default size to allocate to the component's send/receive buffer."
+  buffer_size: u32?,
+
   "Configuration necessary to provide when instantiating the component."
   with: [Field]
 
@@ -516,7 +519,7 @@ type GrpcUrlComponent @tagged("wick/component/grpc@v1") {
   with: {string: LiquidJsonValue}?,
 }
 
-"A native component that can be extracted and run as a microservice."
+"A configuration defined in a Wick component manifest."
 type ManifestComponent @tagged("wick/component/manifest@v1") {
   "The URL (and optional tag) or local file path to find the manifest."
   ref: LocationReference @rename("reference")  @required
@@ -526,6 +529,9 @@ type ManifestComponent @tagged("wick/component/manifest@v1") {
 
   "External components to provide to the referenced component."
   provide: {string:string}
+
+  "If applicable, the default size to allocate to the component's send/receive buffer."
+  buffer_size: u32?
 }
 
 "Composite operations are operations whose implementations come from connecting other operations into a flow or series of pipelines."

--- a/crates/wick/wick-config/docs/v1.md
+++ b/crates/wick/wick-config/docs/v1.md
@@ -733,6 +733,7 @@ Any one of the following types:
 |------------|------|-------------|-----------|------------|
 | `kind` | `string` | must be `"wick/component/wasmrs@v1"` | Yes | || `ref` | <code>[`LocationReference`](#locationreference)</code> |The path or OCI reference to the WebAssembly module|Yes||
 | `volumes` | <code>[`ExposedVolume`](#exposedvolume)[]</code> |Volumes to expose to the component.|||
+| `buffer_size` | <code>`u32`</code> |The default size to allocate to the component's send/receive buffer.|||
 | `with` | <code>[`Field`](#field)[]</code> |Configuration necessary to provide when instantiating the component.|||
 | `operations` | <code>[`OperationDefinition`](#operationdefinition)[]</code> |A list of operations implemented by the WebAssembly module.|||
 
@@ -898,7 +899,7 @@ Any one of the following types:
 ## ManifestComponent
 
   <p>
-    <div style="font-style:italic">A native component that can be extracted and run as a microservice.</div>
+    <div style="font-style:italic">A configuration defined in a Wick component manifest.</div>
   </p>
 
 
@@ -908,6 +909,7 @@ Any one of the following types:
 | `kind` | `string` | must be `"wick/component/manifest@v1"` | Yes | || `ref` | <code>[`LocationReference`](#locationreference)</code> |The URL (and optional tag) or local file path to find the manifest.|Yes||
 | `with` | <code>`{` `string` `: ` [`LiquidJsonValue`](#liquidjsonvalue) `}`</code> |Any configuration necessary for the component.|||
 | `provide` | <code>`{` `string` `: ` `string` `}`</code> |External components to provide to the referenced component.|||
+| `buffer_size` | <code>`u32`</code> |If applicable, the default size to allocate to the component's send/receive buffer.|||
 
 
 

--- a/crates/wick/wick-config/docs/v1.md
+++ b/crates/wick/wick-config/docs/v1.md
@@ -733,7 +733,7 @@ Any one of the following types:
 |------------|------|-------------|-----------|------------|
 | `kind` | `string` | must be `"wick/component/wasmrs@v1"` | Yes | || `ref` | <code>[`LocationReference`](#locationreference)</code> |The path or OCI reference to the WebAssembly module|Yes||
 | `volumes` | <code>[`ExposedVolume`](#exposedvolume)[]</code> |Volumes to expose to the component.|||
-| `buffer_size` | <code>`u32`</code> |The default size to allocate to the component's send/receive buffer.|||
+| `max_packet_size` | <code>`u32`</code> |The default size to allocate to the component's send/receive buffer.|||
 | `with` | <code>[`Field`](#field)[]</code> |Configuration necessary to provide when instantiating the component.|||
 | `operations` | <code>[`OperationDefinition`](#operationdefinition)[]</code> |A list of operations implemented by the WebAssembly module.|||
 
@@ -909,7 +909,7 @@ Any one of the following types:
 | `kind` | `string` | must be `"wick/component/manifest@v1"` | Yes | || `ref` | <code>[`LocationReference`](#locationreference)</code> |The URL (and optional tag) or local file path to find the manifest.|Yes||
 | `with` | <code>`{` `string` `: ` [`LiquidJsonValue`](#liquidjsonvalue) `}`</code> |Any configuration necessary for the component.|||
 | `provide` | <code>`{` `string` `: ` `string` `}`</code> |External components to provide to the referenced component.|||
-| `buffer_size` | <code>`u32`</code> |If applicable, the default size to allocate to the component's send/receive buffer.|||
+| `max_packet_size` | <code>`u32`</code> |If applicable, the default size to allocate to the component's send/receive buffer.|||
 
 
 

--- a/crates/wick/wick-config/json-schema/manifest.json
+++ b/crates/wick/wick-config/json-schema/manifest.json
@@ -1556,6 +1556,18 @@
               "$ref": "#/$defs/v1/ExposedVolume"
             }
           },
+          "buffer_size": {
+            "description": "The default size to allocate to the component&#x27;s send/receive buffer.",
+            "required": false,
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ]
+          },
           "with": {
             "description": "Configuration necessary to provide when instantiating the component.",
             "type": "array",
@@ -1827,6 +1839,18 @@
                 "type": "string"
               }
             }
+          },
+          "buffer_size": {
+            "description": "If applicable, the default size to allocate to the component&#x27;s send/receive buffer.",
+            "required": false,
+            "oneOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "string"
+              }
+            ]
           }
         },
         "required": [

--- a/crates/wick/wick-config/json-schema/manifest.json
+++ b/crates/wick/wick-config/json-schema/manifest.json
@@ -1556,7 +1556,7 @@
               "$ref": "#/$defs/v1/ExposedVolume"
             }
           },
-          "buffer_size": {
+          "max_packet_size": {
             "description": "The default size to allocate to the component&#x27;s send/receive buffer.",
             "required": false,
             "oneOf": [
@@ -1840,7 +1840,7 @@
               }
             }
           },
-          "buffer_size": {
+          "max_packet_size": {
             "description": "If applicable, the default size to allocate to the component&#x27;s send/receive buffer.",
             "required": false,
             "oneOf": [

--- a/crates/wick/wick-config/json-schema/v1/manifest.json
+++ b/crates/wick/wick-config/json-schema/v1/manifest.json
@@ -1143,6 +1143,12 @@
             "$ref": "#/$defs/v1/ExposedVolume"
           }
         },
+        "buffer_size": {
+          "description": "The default size to allocate to the component&#x27;s send/receive buffer.",
+          "required": false,
+
+          "oneOf": [{ "type": "number" }, { "type": "string" }]
+        },
         "with": {
           "description": "Configuration necessary to provide when instantiating the component.",
 
@@ -1393,6 +1399,12 @@
               "type": "string"
             }
           }
+        },
+        "buffer_size": {
+          "description": "If applicable, the default size to allocate to the component&#x27;s send/receive buffer.",
+          "required": false,
+
+          "oneOf": [{ "type": "number" }, { "type": "string" }]
         }
       },
       "required": ["ref"]

--- a/crates/wick/wick-config/json-schema/v1/manifest.json
+++ b/crates/wick/wick-config/json-schema/v1/manifest.json
@@ -1143,7 +1143,7 @@
             "$ref": "#/$defs/v1/ExposedVolume"
           }
         },
-        "buffer_size": {
+        "max_packet_size": {
           "description": "The default size to allocate to the component&#x27;s send/receive buffer.",
           "required": false,
 
@@ -1400,7 +1400,7 @@
             }
           }
         },
-        "buffer_size": {
+        "max_packet_size": {
           "description": "If applicable, the default size to allocate to the component&#x27;s send/receive buffer.",
           "required": false,
 

--- a/crates/wick/wick-config/src/config/component_config/wasm.rs
+++ b/crates/wick/wick-config/src/config/component_config/wasm.rs
@@ -39,7 +39,7 @@ pub struct WasmComponentImplementation {
   #[asset(skip)]
   #[builder(default)]
   #[serde(skip_serializing_if = "Option::is_none")]
-  pub(crate) buffer_size: Option<u32>,
+  pub(crate) max_packet_size: Option<u32>,
 }
 
 impl OperationSignatures for WasmComponentImplementation {

--- a/crates/wick/wick-config/src/config/component_config/wasm.rs
+++ b/crates/wick/wick-config/src/config/component_config/wasm.rs
@@ -34,6 +34,12 @@ pub struct WasmComponentImplementation {
   #[property(skip)]
   #[serde(skip_serializing_if = "Vec::is_empty")]
   pub(crate) operations: Vec<OperationDefinition>,
+
+  /// The default buffer size to use for the component.
+  #[asset(skip)]
+  #[builder(default)]
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub(crate) buffer_size: Option<u32>,
 }
 
 impl OperationSignatures for WasmComponentImplementation {

--- a/crates/wick/wick-config/src/config/components/manifest.rs
+++ b/crates/wick/wick-config/src/config/components/manifest.rs
@@ -24,4 +24,8 @@ pub struct ManifestComponent {
   #[builder(default)]
   #[serde(skip_serializing_if = "HashMap::is_empty")]
   pub(crate) provide: HashMap<String, String>,
+  /// If applicable, the size of the send/receive buffer to allocate to the component.
+  #[asset(skip)]
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub(crate) buffer_size: Option<u32>,
 }

--- a/crates/wick/wick-config/src/config/components/manifest.rs
+++ b/crates/wick/wick-config/src/config/components/manifest.rs
@@ -26,6 +26,7 @@ pub struct ManifestComponent {
   pub(crate) provide: HashMap<String, String>,
   /// If applicable, the size of the send/receive buffer to allocate to the component.
   #[asset(skip)]
+  #[builder(default)]
   #[serde(skip_serializing_if = "Option::is_none")]
-  pub(crate) buffer_size: Option<u32>,
+  pub(crate) max_packet_size: Option<u32>,
 }

--- a/crates/wick/wick-config/src/config/permissions.rs
+++ b/crates/wick/wick-config/src/config/permissions.rs
@@ -10,11 +10,3 @@ pub struct Permissions {
   #[builder(default)]
   pub(crate) dirs: HashMap<String, String>,
 }
-
-impl Permissions {
-  /// Create a new permissions object
-  #[must_use]
-  pub fn new(dirs: HashMap<String, String>) -> Self {
-    Self { dirs }
-  }
-}

--- a/crates/wick/wick-config/src/v0/conversions.rs
+++ b/crates/wick/wick-config/src/v0/conversions.rs
@@ -73,6 +73,7 @@ impl TryFrom<crate::v0::CollectionDefinition> for config::ComponentDefinition {
           reference: def.reference.clone().try_into()?,
           config: def.data.map(Into::into),
           provide: Default::default(),
+          buffer_size: None,
         })
       }
     };

--- a/crates/wick/wick-config/src/v0/conversions.rs
+++ b/crates/wick/wick-config/src/v0/conversions.rs
@@ -73,7 +73,7 @@ impl TryFrom<crate::v0::CollectionDefinition> for config::ComponentDefinition {
           reference: def.reference.clone().try_into()?,
           config: def.data.map(Into::into),
           provide: Default::default(),
-          buffer_size: None,
+          max_packet_size: None,
         })
       }
     };

--- a/crates/wick/wick-config/src/v1.rs
+++ b/crates/wick/wick-config/src/v1.rs
@@ -786,7 +786,7 @@ pub(crate) struct WasmComponentConfiguration {
 
   #[serde(default)]
   #[serde(skip_serializing_if = "Option::is_none")]
-  pub(crate) buffer_size: Option<u32>,
+  pub(crate) max_packet_size: Option<u32>,
   /// Configuration necessary to provide when instantiating the component.
 
   #[serde(default)]
@@ -983,7 +983,7 @@ pub(crate) struct ManifestComponent {
 
   #[serde(default)]
   #[serde(skip_serializing_if = "Option::is_none")]
-  pub(crate) buffer_size: Option<u32>,
+  pub(crate) max_packet_size: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/wick/wick-config/src/v1.rs
+++ b/crates/wick/wick-config/src/v1.rs
@@ -782,6 +782,11 @@ pub(crate) struct WasmComponentConfiguration {
   #[serde(default)]
   #[serde(skip_serializing_if = "Vec::is_empty")]
   pub(crate) volumes: Vec<ExposedVolume>,
+  /// The default size to allocate to the component&#x27;s send/receive buffer.
+
+  #[serde(default)]
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub(crate) buffer_size: Option<u32>,
   /// Configuration necessary to provide when instantiating the component.
 
   #[serde(default)]
@@ -957,7 +962,7 @@ pub(crate) struct GrpcUrlComponent {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(deny_unknown_fields)]
-/// A native component that can be extracted and run as a microservice.
+/// A configuration defined in a Wick component manifest.
 pub(crate) struct ManifestComponent {
   /// The URL (and optional tag) or local file path to find the manifest.
 
@@ -974,6 +979,11 @@ pub(crate) struct ManifestComponent {
   #[serde(skip_serializing_if = "HashMap::is_empty")]
   #[serde(deserialize_with = "crate::helpers::kv_deserializer")]
   pub(crate) provide: HashMap<String, String>,
+  /// If applicable, the default size to allocate to the component&#x27;s send/receive buffer.
+
+  #[serde(default)]
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub(crate) buffer_size: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]

--- a/crates/wick/wick-config/src/v1/conversions.rs
+++ b/crates/wick/wick-config/src/v1/conversions.rs
@@ -236,7 +236,7 @@ impl TryFrom<v1::WasmComponentConfiguration> for WasmComponentImplementation {
       config: value.with.try_map_into()?,
       operations: value.operations.try_map_into()?,
       volumes: value.volumes.try_map_into()?,
-      buffer_size: value.buffer_size,
+      max_packet_size: value.max_packet_size,
     })
   }
 }
@@ -293,7 +293,7 @@ impl TryFrom<WasmComponentImplementation> for v1::WasmComponentConfiguration {
       reference: value.reference.try_into()?,
       with: value.config.try_map_into()?,
       volumes: value.volumes.try_map_into()?,
-      buffer_size: value.buffer_size,
+      max_packet_size: value.max_packet_size,
     })
   }
 }
@@ -944,7 +944,7 @@ impl TryFrom<ManifestComponent> for v1::ManifestComponent {
       reference: def.reference.try_into()?,
       with: def.config.map_into(),
       provide: def.provide,
-      buffer_size: def.buffer_size,
+      max_packet_size: def.max_packet_size,
     })
   }
 }
@@ -1093,7 +1093,7 @@ impl TryFrom<crate::v1::ComponentDefinition> for ComponentDefinition {
         reference: v.reference.try_into()?,
         config: v.with.map_into(),
         provide: v.provide,
-        buffer_size: v.buffer_size,
+        max_packet_size: v.max_packet_size,
       }),
       v1::ComponentDefinition::ComponentReference(v) => ComponentDefinition::Reference(ComponentReference { id: v.id }),
       v1::ComponentDefinition::SqlComponent(v) => {

--- a/crates/wick/wick-config/src/v1/conversions.rs
+++ b/crates/wick/wick-config/src/v1/conversions.rs
@@ -236,6 +236,7 @@ impl TryFrom<v1::WasmComponentConfiguration> for WasmComponentImplementation {
       config: value.with.try_map_into()?,
       operations: value.operations.try_map_into()?,
       volumes: value.volumes.try_map_into()?,
+      buffer_size: value.buffer_size,
     })
   }
 }
@@ -292,6 +293,7 @@ impl TryFrom<WasmComponentImplementation> for v1::WasmComponentConfiguration {
       reference: value.reference.try_into()?,
       with: value.config.try_map_into()?,
       volumes: value.volumes.try_map_into()?,
+      buffer_size: value.buffer_size,
     })
   }
 }
@@ -942,6 +944,7 @@ impl TryFrom<ManifestComponent> for v1::ManifestComponent {
       reference: def.reference.try_into()?,
       with: def.config.map_into(),
       provide: def.provide,
+      buffer_size: def.buffer_size,
     })
   }
 }
@@ -1090,6 +1093,7 @@ impl TryFrom<crate::v1::ComponentDefinition> for ComponentDefinition {
         reference: v.reference.try_into()?,
         config: v.with.map_into(),
         provide: v.provide,
+        buffer_size: v.buffer_size,
       }),
       v1::ComponentDefinition::ComponentReference(v) => ComponentDefinition::Reference(ComponentReference { id: v.id }),
       v1::ComponentDefinition::SqlComponent(v) => {

--- a/crates/wick/wick-runtime/src/components.rs
+++ b/crates/wick/wick-runtime/src/components.rs
@@ -95,7 +95,7 @@ pub(crate) async fn init_wasm_impl_component(
     kind.reference(),
     namespace,
     opts,
-    buffer_size.or(kind.buffer_size()),
+    buffer_size.or(kind.max_packet_size()),
     permissions,
     provided,
   )
@@ -162,7 +162,7 @@ pub(crate) async fn init_manifest_component(
   let requires = manifest.requires();
   let provided = generate_provides_entities(requires, kind.provide())
     .map_err(|e| EngineError::ComponentInit(id.clone(), e.to_string()))?;
-  init_component_implementation(&manifest, id, opts, kind.buffer_size(), provided).await
+  init_component_implementation(&manifest, id, opts, kind.max_packet_size(), provided).await
 }
 
 pub(crate) async fn init_component_implementation(

--- a/crates/wick/wick-runtime/src/runtime_service.rs
+++ b/crates/wick/wick-runtime/src/runtime_service.rs
@@ -61,7 +61,7 @@ impl RuntimeService {
       span.in_scope(|| debug!(%ns,options=?component_init,"instantiating component"));
 
       let main_component =
-        init_component_implementation(&init.manifest, ns.clone(), component_init, Default::default()).await?;
+        init_component_implementation(&init.manifest, ns.clone(), component_init, None, Default::default()).await?;
       let reported_sig = main_component.component().signature();
       let manifest_sig = init.manifest.signature()?;
 

--- a/crates/wick/wick-runtime/src/runtime_service/utils.rs
+++ b/crates/wick/wick-runtime/src/runtime_service/utils.rs
@@ -67,7 +67,7 @@ pub(crate) async fn instantiate_imported_component(
   match kind {
     #[allow(deprecated)]
     config::ComponentDefinition::Wasm(def) => Ok(Some(
-      init_wasm_component(def.reference(), id, opts, None, Default::default()).await?,
+      init_wasm_component(def.reference(), id, opts, None, None, Default::default()).await?,
     )),
     config::ComponentDefinition::Manifest(def) => Ok(Some(init_manifest_component(def, id, opts).await?)),
     config::ComponentDefinition::Reference(_) => unreachable!(),


### PR DESCRIPTION
This PR:
- drops the default buffer size of wasm components down to 512k from 5mb and makes it configurable via the `max_packet_size` option.
- adds a global configuration cache to reduce the fetching and parsing of configuration.
- fixes how triggers initialize the runtime to reuse imports if they already exist or have already been added by the trigger. This dramatically improves perf and memory usage for Rest Router applications.