### PR TITLE
Removed darwin target configurations

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,9 +1,3 @@
-[target.x86_64-apple-darwin]
-rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
-
-[target.aarch64-apple-darwin]
-rustflags = ["-C", "link-arg=-undefined", "-C", "link-arg=dynamic_lookup"]
-
 [target.aarch64-unknown-linux-gnu]
 linker = "aarch64-linux-gnu-gcc"
 


### PR DESCRIPTION
Removing the `.cargo/config` for darwin targets. They were necessary for cross-compilation a long time ago and if they or similar are still necessary we can add them to the cross compilation build tasks, vs having them enabled for dev users.