### PR TITLE
Made cron span less verbose

### DIFF
--- a/crates/wick/wick-runtime/src/triggers/time.rs
+++ b/crates/wick/wick-runtime/src/triggers/time.rs
@@ -156,7 +156,7 @@ impl Trigger for Time {
       }
     };
 
-    let span = info_span!("trigger:schedule", schedule = ?schedule);
+    let span = info_span!("trigger:schedule", schedule = cron);
     let mut runtime = build_trigger_runtime(&app_config, span.clone())?;
     let component_id = match resolve_ref(&app_config, config.operation().component())? {
       super::ResolvedComponent::Ref(id, _) => id.to_owned(),


### PR DESCRIPTION
The old `trigger:schedule` span included the whole schedule object. This PR changes it to the cron schedule alone.