### PR TITLE
Fixed broken push on package with registry deps

### DIFF
--- a/crates/wick/wick-package/src/package.rs
+++ b/crates/wick/wick-package/src/package.rs
@@ -34,6 +34,9 @@ fn process_assets(
       }
       let pdir = parent_dir.clone();
       asset.update_baseurl(&pdir);
+      if !asset.exists_outside_cache() {
+        continue;
+      }
       let asset_path = asset.path()?; // the resolved, absolute path relative to the config location.
       if seen_assets.contains(&asset_path) {
         continue;


### PR DESCRIPTION
This PR fixes an issue where pushing a component with registry dependencies would fail. 