### PR TITLE
Added support for `wick invoke` on app configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6339,6 +6339,7 @@ name = "wick-cli"
 version = "0.13.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "atty",
  "clap",
  "dhat",
@@ -6536,6 +6537,7 @@ name = "wick-host"
 version = "0.4.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "derive_builder",
  "flow-component",
  "futures 0.3.28",
@@ -6793,6 +6795,7 @@ dependencies = [
  "hyper",
  "hyper-reverse-proxy",
  "hyper-staticfile",
+ "itertools 0.11.0",
  "lazy_static",
  "once_cell",
  "openapiv3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -110,6 +110,7 @@ derive_builder = { version = "0.12", default-features = false }
 dhat = { version = "0.3.2", default-features = false }
 dialoguer = { version = "0.10", default-features = false }
 dyn-clone = { version = "1.0", default-features = false }
+either = { version = "1.9.0", default-features = false }
 env_logger = { version = "0.10", default-features = false }
 escargot = { version = "0.5", default-features = false }
 futures = { version = "0.3", default-features = false, features = ["std"] }

--- a/crates/bins/wick/Cargo.toml
+++ b/crates/bins/wick/Cargo.toml
@@ -55,6 +55,7 @@ structured-output = { workspace = true }
 regex = { workspace = true }
 dhat = { workspace = true, optional = true }
 once_cell = { workspace = true }
+async-trait = { workspace = true }
 
 [dev-dependencies]
 test_bin = { workspace = true }

--- a/crates/bins/wick/src/commands/list.rs
+++ b/crates/bins/wick/src/commands/list.rs
@@ -7,7 +7,7 @@ use serde_json::json;
 use structured_output::StructuredOutput;
 use wick_component_cli::options::DefaultCliOptions;
 use wick_config::WickConfiguration;
-use wick_host::ComponentHostBuilder;
+use wick_host::{ComponentHostBuilder, Host};
 use wick_interface_types::Field;
 
 use crate::utils::merge_config;
@@ -45,7 +45,7 @@ pub(crate) async fn handle(
   let mut host = ComponentHostBuilder::default().manifest(config).span(span).build()?;
 
   host.start_runtime(None).await?;
-  let mut signature = host.get_signature()?;
+  let mut signature = host.get_signature(None, None)?;
 
   // If we have a name from the manifest, override the host id the component host generates.
   if let Some(name) = manifest.name() {

--- a/crates/bins/wick/src/wick_host.rs
+++ b/crates/bins/wick/src/wick_host.rs
@@ -1,17 +1,17 @@
-use std::path::PathBuf;
+use std::collections::HashMap;
 
 use anyhow::Result;
 use seeded_random::Seed;
 use tracing::Span;
 use wick_component_cli::options::DefaultCliOptions;
 use wick_config::WickConfiguration;
-use wick_host::{ComponentHost, ComponentHostBuilder};
+use wick_host::{AppHost, AppHostBuilder, ComponentHostBuilder, WickHost};
 use wick_packet::RuntimeConfig;
 
 use crate::options::oci::OciOptions as WickOciOptions;
 use crate::utils::{get_auth_for_scope, merge_config};
 
-pub(crate) async fn build_component_host(
+pub(crate) async fn build_host(
   path: &str,
   oci: WickOciOptions,
   root_config: Option<RuntimeConfig>,
@@ -19,7 +19,7 @@ pub(crate) async fn build_component_host(
   seed: Option<u64>,
   server_settings: Option<DefaultCliOptions>,
   span: Span,
-) -> Result<ComponentHost> {
+) -> Result<WickHost> {
   let configured_creds = settings.credentials.iter().find(|c| path.starts_with(&c.scope));
 
   let (username, password) = get_auth_for_scope(configured_creds, oci.username.as_deref(), oci.password.as_deref());
@@ -28,29 +28,42 @@ pub(crate) async fn build_component_host(
   let mut fetch_opts: wick_oci_utils::OciOptions = oci.clone().into();
   fetch_opts.set_username(username).set_password(password);
 
-  let pb = PathBuf::from(path);
-
-  if !pb.exists() {
-    fetch_opts.set_cache_dir(env.global().cache().clone());
-  } else {
-    let mut path_dir = pb.clone();
-    path_dir.pop();
-    fetch_opts.set_cache_dir(path_dir.join(env.local().cache()));
-  };
+  fetch_opts.set_cache_dir(env.global().cache().clone());
 
   let mut manifest = WickConfiguration::fetch(path, fetch_opts).await?;
   manifest.set_root_config(root_config);
-  let manifest = manifest.finish()?.try_component_config()?;
+  let host = match manifest.manifest() {
+    WickConfiguration::Component(_) => {
+      let manifest = manifest.finish()?.try_component_config()?;
 
-  let manifest = merge_config(&manifest, &oci, server_settings);
+      let manifest = merge_config(&manifest, &oci, server_settings);
 
-  let mut host = ComponentHostBuilder::default()
-    .id(manifest.name().map_or_else(|| "component".to_owned(), |s| s.clone()))
-    .manifest(manifest)
-    .span(span)
-    .build()?;
+      let mut host = ComponentHostBuilder::default()
+        .id(manifest.name().map_or_else(|| "component".to_owned(), |s| s.clone()))
+        .manifest(manifest)
+        .span(span)
+        .build()?;
 
-  host.start_runtime(seed.map(Seed::unsafe_new)).await?;
+      host.start_runtime(seed.map(Seed::unsafe_new)).await?;
+      WickHost::Component(host)
+    }
+    WickConfiguration::App(_) => {
+      let env: HashMap<String, String> = std::env::vars().collect();
+      manifest.set_env(env);
+      let app_config = manifest.finish()?.try_app_config()?;
+      let mut host = AppHostBuilder::default();
+      let host = host
+        .runtime(AppHost::build_runtime(&app_config, seed, span.clone()).await?)
+        .manifest(app_config)
+        .span(span)
+        .build()?;
+
+      WickHost::App(host)
+    }
+    _ => {
+      bail!("Invalid manifest type: {}", manifest.manifest().kind());
+    }
+  };
 
   Ok(host)
 }

--- a/crates/bins/wick/tests/invoke.rs
+++ b/crates/bins/wick/tests/invoke.rs
@@ -3,6 +3,7 @@ static DIR: &str = "invoke";
 #[rstest::rstest]
 #[case("v1-wasmrs.toml")]
 #[case("stdin.toml")]
+#[case("app.toml")]
 fn wick_invoke(#[case] file: &'static str) {
   let kind = "unit";
   let file = format!("tests/{}/{}/{}", DIR, kind, file);

--- a/crates/bins/wick/tests/invoke/unit/app-cli.wick
+++ b/crates/bins/wick/tests/invoke/unit/app-cli.wick
@@ -1,0 +1,59 @@
+kind: wick/component@v1
+name: file-reader-cli-adapter
+import:
+  - name: wasi_fs
+    component:
+      kind: wick/component/manifest@v1
+      ref: ../../../../../../examples/components/wasi-fs/component.wick
+      with:
+        root: '{{ ctx.root_config.root }}'
+  - name: log
+    component:
+      kind: wick/component/manifest@v1
+      ref: registry.candle.dev/common/log:0.2.0
+component:
+  kind: wick/component/composite@v1
+  with:
+    - name: root
+      type: string
+  operations:
+    - name: main
+      inputs:
+        - name: args
+          type: 'string[]'
+        - name: interactive
+          type: cli::Interactive
+      outputs:
+        - name: code
+          type: u32
+      uses:
+        - name: GATE
+          operation: core::switch
+          with:
+            outputs:
+              - name: code
+                type: u32
+            cases:
+              - case: true
+                do: self::main::exit_ok
+            default: self::main::exit_err
+      flow:
+        - <>.args.1 -> wasi_fs::read_string -> log::string -> GATE.match
+        - GATE -> <>.code
+      operations:
+        - name: exit_ok
+          uses:
+            - name: SENDER
+              operation: core::sender
+              with:
+                output: 0
+          flow:
+            - SENDER.output -> <>.code
+        - name: exit_err
+          uses:
+            - name: SENDER
+              operation: core::sender
+              with:
+                output: 1
+          flow:
+            - SENDER.output -> <>.code

--- a/crates/bins/wick/tests/invoke/unit/app.toml
+++ b/crates/bins/wick/tests/invoke/unit/app.toml
@@ -1,0 +1,13 @@
+bin.name = "wick"
+args = [
+  "invoke",
+  "tests/invoke/unit/app.wick",
+  "CLI::wasi_fs::read_string",
+  "--with",
+  """{"root":"{{ctx.env.CARGO_MANIFEST_DIR}}"}""",
+  "--",
+  "--filename=\"Cargo.toml\"",
+]
+stdout = """
+{"payload":{"value":"[package]/nname = /"wick-cli/"/nversion = /"0.13.0/"/nedition = /"2021/"/ndefault-run = /"wick/"/nlicense = /"Elastic-2.0/"/nrepository = /"https://github.com/candlecorp/wick/"/ndescription = /"The binary executable for the Wick project./"/ninclude = [/"src/**/*/", /"LICENSE/", /"README.md/"]/n/n[features]/ndefault = []/ncross = [/"openssl/vendored/"]/nconsole = [/n  /"wick-logger/console/",/n  /"tokio/full/",/n  /"tokio/tracing/",/n] # Build with RUSTFLAGS=/"--cfg tokio_unstable/"/nmem-profiler = [/"dhat/"]/n/n# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html/n[dependencies]/nwick-xdg = { workspace = true, features = [/"serde/"] }/nwick-settings = { workspace = true }/nwick-packet = { workspace = true }/nwick-interface-types = { workspace = true }/nwick-rpc = { workspace = true, features = [/"client/"] }/nwick-component-cli = { workspace = true, features = [/"cli/", /"grpc/"] }/nwick-host = { workspace = true }/nwick-config = { workspace = true }/nwick-test = { workspace = true }/nwick-wascap = { workspace = true }/nwick-oci-utils = { workspace = true }/nwick-package = { workspace = true }/nwick-logger = { workspace = true }/nflow-expression-parser = { workspace = true }/nseeded-random = { workspace = true }/ntokio = { workspace = true, features = [/"macros/", /"rt/", /"rt-multi-thread/"] }/ntracing = { workspace = true }/nserde_json = { workspace = true }/nserde_yaml = { workspace = true }/nanyhow = { workspace = true }/ndialoguer = { workspace = true, features = [/"password/"] }/nhuman-panic = { workspace = true }/nfutures = { workspace = true }/nthiserror = { workspace = true }/nclap = { workspace = true, default-features = true, features = [/"derive/"] }/nnkeys = { workspace = true }/natty = { workspace = true }/njaq-core = { workspace = true, features = [/"serde_json/"] }/nmarkup-converter = { workspace = true }/nopenssl = { workspace = true, features = [/"vendored/"], optional = true }/noption-utils = { workspace = true }/nstructured-output = { workspace = true }/nregex = { workspace = true }/ndhat = { workspace = true, optional = true }/nonce_cell = { workspace = true }/nasync-trait = { workspace = true }/n/n[dev-dependencies]/ntest_bin = { workspace = true }/ntrycmd = { workspace = true }/ntest-logger = { workspace = true }/ntokio = { workspace = true, features = [/"process/"] }/nrstest = { workspace = true }/n/n[[bin]]/nname = /"wick/"/npath = /"src/main.rs/"/n"},"port":"output"}
+"""

--- a/crates/bins/wick/tests/invoke/unit/app.wick
+++ b/crates/bins/wick/tests/invoke/unit/app.wick
@@ -1,0 +1,12 @@
+name: wasi-test
+kind: wick/app@v1
+import:
+  - name: CLI
+    component:
+      kind: wick/component/manifest@v1
+      ref: ./app-cli.wick
+      with:
+        root: '{{ ctx.env.CARGO_MANIFEST_DIR }}'
+triggers:
+  - kind: wick/trigger/cli@v1
+    operation: CLI::main

--- a/crates/bins/wick/tests/run/unit/file-reader-lockdown-fail.toml
+++ b/crates/bins/wick/tests/run/unit/file-reader-lockdown-fail.toml
@@ -1,5 +1,4 @@
 #:schema https://raw.githubusercontent.com/assert-rs/trycmd/main/schema.json
-stdin = 'hey'
 bin.name = "wick"
 args = [
   "run",
@@ -19,8 +18,7 @@ stdout = """
 
 
 
-wick exited with error: lockdown configuration resulted in 1 failures: component __root__.CLI.wasi_fs is not allowed to access [CWD]
+wick exited with error: lockdown configuration resulted in 1 failures: component __local__::CLI::wasi_fs is not allowed to access [CWD]
 Run with --info, --debug, or --trace for more information.
 """
-stderr = """[..]"""
 status.code = 1

--- a/crates/bins/wick/tests/run/unit/file-reader-lockdown-pass-wildcard-components.toml
+++ b/crates/bins/wick/tests/run/unit/file-reader-lockdown-pass-wildcard-components.toml
@@ -1,5 +1,4 @@
 #:schema https://raw.githubusercontent.com/assert-rs/trycmd/main/schema.json
-stdin = 'hey'
 bin.name = "wick"
 args = [
   "run",

--- a/crates/bins/wick/tests/run/unit/file-reader-lockdown-pass-wildcard-dir.toml
+++ b/crates/bins/wick/tests/run/unit/file-reader-lockdown-pass-wildcard-dir.toml
@@ -1,5 +1,4 @@
 #:schema https://raw.githubusercontent.com/assert-rs/trycmd/main/schema.json
-stdin = 'hey'
 bin.name = "wick"
 args = [
   "run",

--- a/crates/bins/wick/tests/run/unit/file-reader-lockdown-pass.toml
+++ b/crates/bins/wick/tests/run/unit/file-reader-lockdown-pass.toml
@@ -1,5 +1,4 @@
 #:schema https://raw.githubusercontent.com/assert-rs/trycmd/main/schema.json
-stdin = 'hey'
 bin.name = "wick"
 args = [
   "run",

--- a/crates/bins/wick/tests/run/unit/lockdown-fail.wick
+++ b/crates/bins/wick/tests/run/unit/lockdown-fail.wick
@@ -2,5 +2,5 @@
 kind: wick/lockdown@v1
 resources:
   - kind: 'wick/resource/volume@v1'
-    components: ['*CLI.wasi_fs']
+    components: ['*CLI::wasi_fs']
     allow: '{{ ctx.env.CARGO_MANIFEST_DIR }}/tests'

--- a/crates/bins/wick/tests/run/unit/lockdown-pass-wildcard-dir.wick
+++ b/crates/bins/wick/tests/run/unit/lockdown-pass-wildcard-dir.wick
@@ -2,5 +2,5 @@
 kind: wick/lockdown@v1
 resources:
   - kind: 'wick/resource/volume@v1'
-    components: ['__root__.CLI.wasi_fs']
+    components: ['__local__::CLI::wasi_fs']
     allow: '*'

--- a/crates/bins/wick/tests/run/unit/lockdown-pass.wick
+++ b/crates/bins/wick/tests/run/unit/lockdown-pass.wick
@@ -2,5 +2,5 @@
 kind: wick/lockdown@v1
 resources:
   - kind: 'wick/resource/volume@v1'
-    components: ['__root__.CLI.wasi_fs']
+    components: ['__local__::CLI::wasi_fs']
     allow: '{{ ctx.env.CARGO_MANIFEST_DIR }}'

--- a/crates/wick/flow-graph-interpreter/src/interpreter.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter.rs
@@ -215,6 +215,10 @@ impl Interpreter {
     shutdown
   }
 
+  pub fn components(&self) -> &HandlerMap {
+    &self.components
+  }
+
   pub fn render_dotviz(&self, op: &str) -> Result<String, Error> {
     self.program.dotviz(op)
   }

--- a/crates/wick/wick-config/src/config.rs
+++ b/crates/wick/wick-config/src/config.rs
@@ -29,7 +29,7 @@ pub use types_config::*;
 use wick_asset_reference::{AssetReference, FetchOptions};
 use wick_interface_types::Field;
 use wick_packet::validation::expect_configuration_matches;
-use wick_packet::RuntimeConfig;
+use wick_packet::{Entity, RuntimeConfig};
 
 use crate::lockdown::Lockdown;
 use crate::utils::{_fetch_all, resolve_configuration};
@@ -143,7 +143,7 @@ impl WickConfiguration {
     }
     config.set_root_config(root_config);
     let config = config.finish()?;
-    let mut node = ConfigurationTreeNode::new(AppConfiguration::GENERIC_IDENTIFIER.into(), config);
+    let mut node = ConfigurationTreeNode::new(Entity::LOCAL.into(), config);
     node.fetch_children(options).await?;
 
     Ok(node)

--- a/crates/wick/wick-config/src/config/app_config/triggers.rs
+++ b/crates/wick/wick-config/src/config/app_config/triggers.rs
@@ -1,6 +1,8 @@
 use serde_json::Value;
 
 use crate::config::*;
+use crate::error::ManifestError;
+use crate::ExpandImports;
 mod cli;
 mod http;
 mod time;
@@ -30,6 +32,17 @@ impl TriggerDefinition {
       TriggerDefinition::Cli(_) => TriggerKind::Cli,
       TriggerDefinition::Http(_) => TriggerKind::Http,
       TriggerDefinition::Time(_) => TriggerKind::Time,
+    }
+  }
+}
+
+impl ExpandImports for TriggerDefinition {
+  type Error = ManifestError;
+  fn expand_imports(&mut self, bindings: &mut Vec<ImportBinding>, index: usize) -> Result<(), Self::Error> {
+    match self {
+      TriggerDefinition::Cli(c) => c.expand_imports(bindings, index),
+      TriggerDefinition::Http(c) => c.expand_imports(bindings, index),
+      TriggerDefinition::Time(c) => c.expand_imports(bindings, index),
     }
   }
 }

--- a/crates/wick/wick-config/src/config/app_config/triggers/cli.rs
+++ b/crates/wick/wick-config/src/config/app_config/triggers/cli.rs
@@ -1,15 +1,26 @@
 use wick_asset_reference::AssetReference;
 
-use crate::config::ComponentOperationExpression;
+use crate::config::{ComponentOperationExpression, ImportBinding};
+use crate::error::ManifestError;
+use crate::ExpandImports;
 
 #[derive(
   Debug, Clone, PartialEq, derive_asset_container::AssetManager, property::Property, serde::Serialize, Builder,
 )]
 #[builder(setter(into))]
 #[asset(asset(AssetReference))]
-#[property(get(public), set(private), mut(disable))]
+#[property(get(public), set(private), mut(public, suffix = "_mut"))]
 
 /// Normalized representation of a CLI trigger configuration.
 pub struct CliConfig {
   pub(crate) operation: ComponentOperationExpression,
+}
+
+impl ExpandImports for CliConfig {
+  type Error = ManifestError;
+  fn expand_imports(&mut self, bindings: &mut Vec<ImportBinding>, trigger_index: usize) -> Result<(), Self::Error> {
+    let id = format!("trigger_{}", trigger_index);
+    self.operation_mut().maybe_import(&id, bindings);
+    Ok(())
+  }
 }

--- a/crates/wick/wick-config/src/config/app_config/triggers/http/middleware.rs
+++ b/crates/wick/wick-config/src/config/app_config/triggers/http/middleware.rs
@@ -1,7 +1,9 @@
-use crate::config::{self, ComponentOperationExpression};
+use super::WickRouter;
+use crate::config::{self, ComponentOperationExpression, ImportBinding};
+use crate::error::ManifestError;
 
 #[derive(Debug, Clone, PartialEq, derive_asset_container::AssetManager, property::Property, serde::Serialize)]
-#[property(get(public), set(private), mut(disable))]
+#[property(get(public), set(private), mut(public, suffix = "_mut"))]
 #[asset(asset(config::AssetReference))]
 /// Request and response operations that run before and after the main operation.
 pub struct Middleware {
@@ -11,4 +13,30 @@ pub struct Middleware {
   /// The middleware to apply to responses.
   #[serde(skip_serializing_if = "Vec::is_empty")]
   pub(crate) response: Vec<ComponentOperationExpression>,
+}
+
+pub(super) fn expand_for_middleware_components(
+  trigger_index: usize,
+  router_index: usize,
+  router: &mut impl WickRouter,
+  bindings: &mut Vec<ImportBinding>,
+) -> Result<(), ManifestError> {
+  if let Some(middleware) = router.middleware_mut() {
+    for (i, operation) in middleware.request_mut().iter_mut().enumerate() {
+      let id = format!(
+        "trigger_{}_router_{}_request_middleware_{}",
+        trigger_index, router_index, i
+      );
+      operation.maybe_import(&id, bindings);
+    }
+    for (i, operation) in middleware.response_mut().iter_mut().enumerate() {
+      let id = format!(
+        "trigger_{}_router_{}_response_middleware_{}",
+        trigger_index, router_index, i
+      );
+      operation.maybe_import(&id, bindings);
+    }
+  }
+
+  Ok(())
 }

--- a/crates/wick/wick-config/src/config/app_config/triggers/http/proxy_router.rs
+++ b/crates/wick/wick-config/src/config/app_config/triggers/http/proxy_router.rs
@@ -1,5 +1,10 @@
 use wick_asset_reference::AssetReference;
 
+use super::index_to_router_id;
+use super::middleware::expand_for_middleware_components;
+use crate::config::{self, ImportBinding};
+use crate::error::ManifestError;
+
 #[derive(Debug, Clone, derive_asset_container::AssetManager, property::Property, serde::Serialize)]
 #[asset(asset(AssetReference))]
 #[property(get(public), set(private), mut(disable))]
@@ -26,7 +31,24 @@ impl super::WickRouter for ProxyRouterConfig {
     self.middleware.as_ref()
   }
 
+  fn middleware_mut(&mut self) -> Option<&mut super::Middleware> {
+    self.middleware.as_mut()
+  }
+
   fn path(&self) -> &str {
     &self.path
   }
+}
+
+pub(crate) fn process_runtime_config(
+  trigger_index: usize,
+  index: usize,
+  router_config: &mut ProxyRouterConfig,
+  bindings: &mut Vec<ImportBinding>,
+) -> Result<(), ManifestError> {
+  expand_for_middleware_components(trigger_index, index, router_config, bindings)?;
+  let router_component = config::ComponentDefinition::Native(config::components::NativeComponent {});
+  let router_binding = config::ImportBinding::component(index_to_router_id(trigger_index, index), router_component);
+  bindings.push(router_binding);
+  Ok(())
 }

--- a/crates/wick/wick-config/src/config/app_config/triggers/http/raw_router.rs
+++ b/crates/wick/wick-config/src/config/app_config/triggers/http/raw_router.rs
@@ -1,17 +1,20 @@
 use wick_asset_reference::AssetReference;
 
-use crate::config::{self, ComponentOperationExpression};
+use super::index_to_router_id;
+use super::middleware::expand_for_middleware_components;
+use crate::config::{self, ComponentOperationExpression, ImportBinding};
+use crate::error::ManifestError;
 
 #[derive(Debug, Clone, derive_asset_container::AssetManager, property::Property, serde::Serialize)]
 #[asset(asset(AssetReference))]
-#[property(get(public), set(private), mut(disable))]
+#[property(get(public), set(private), mut(public, suffix = "_mut"))]
 #[must_use]
 pub struct RawRouterConfig {
   #[asset(skip)]
   #[property(get(disable))]
   pub(crate) path: String,
   /// Middleware operations for this router.
-  #[property(get(disable))]
+  #[property(get(disable), mut(disable))]
   #[serde(skip_serializing_if = "Option::is_none")]
   pub(crate) middleware: Option<super::middleware::Middleware>,
   #[asset(skip)]
@@ -25,7 +28,30 @@ impl super::WickRouter for RawRouterConfig {
     self.middleware.as_ref()
   }
 
+  fn middleware_mut(&mut self) -> Option<&mut super::Middleware> {
+    self.middleware.as_mut()
+  }
+
   fn path(&self) -> &str {
     &self.path
   }
+}
+
+pub(crate) fn process_runtime_config(
+  trigger_index: usize,
+  index: usize,
+  router_config: &mut RawRouterConfig,
+  bindings: &mut Vec<ImportBinding>,
+) -> Result<(), ManifestError> {
+  expand_for_middleware_components(trigger_index, index, router_config, bindings)?;
+
+  router_config
+    .operation_mut()
+    .maybe_import(&index_to_router_id(trigger_index, index), bindings);
+
+  let router_component = config::ComponentDefinition::Native(config::components::NativeComponent {});
+  let router_binding = config::ImportBinding::component(index_to_router_id(trigger_index, index), router_component);
+  bindings.push(router_binding);
+
+  Ok(())
 }

--- a/crates/wick/wick-config/src/config/app_config/triggers/http/static_router.rs
+++ b/crates/wick/wick-config/src/config/app_config/triggers/http/static_router.rs
@@ -1,5 +1,10 @@
 use wick_asset_reference::AssetReference;
 
+use super::index_to_router_id;
+use super::middleware::expand_for_middleware_components;
+use crate::config::{self, ImportBinding};
+use crate::error::ManifestError;
+
 #[derive(Debug, Clone, derive_asset_container::AssetManager, property::Property, serde::Serialize)]
 #[asset(asset(AssetReference))]
 #[property(get(public), set(private), mut(disable))]
@@ -24,7 +29,25 @@ impl super::WickRouter for StaticRouterConfig {
     self.middleware.as_ref()
   }
 
+  fn middleware_mut(&mut self) -> Option<&mut super::Middleware> {
+    self.middleware.as_mut()
+  }
+
   fn path(&self) -> &str {
     &self.path
   }
+}
+
+pub(crate) fn process_runtime_config(
+  trigger_index: usize,
+  index: usize,
+  router_config: &mut StaticRouterConfig,
+  bindings: &mut Vec<ImportBinding>,
+) -> Result<(), ManifestError> {
+  expand_for_middleware_components(trigger_index, index, router_config, bindings)?;
+
+  let router_component = config::ComponentDefinition::Native(config::components::NativeComponent {});
+  let router_binding = config::ImportBinding::component(index_to_router_id(trigger_index, index), router_component);
+  bindings.push(router_binding);
+  Ok(())
 }

--- a/crates/wick/wick-config/src/config/app_config/triggers/time.rs
+++ b/crates/wick/wick-config/src/config/app_config/triggers/time.rs
@@ -1,13 +1,15 @@
 use wick_asset_reference::AssetReference;
 
 use super::OperationInputConfig;
-use crate::config::ComponentOperationExpression;
+use crate::config::{ComponentOperationExpression, ImportBinding};
+use crate::error::ManifestError;
+use crate::ExpandImports;
 
 #[derive(
   Debug, Clone, PartialEq, derive_asset_container::AssetManager, property::Property, serde::Serialize, Builder,
 )]
 #[builder(setter(into))]
-#[property(get(public), set(private), mut(disable))]
+#[property(get(public), set(private), mut(public, suffix = "_mut"))]
 #[asset(asset(AssetReference))]
 /// Normalized representation of a Time trigger configuration.
 pub struct TimeTriggerConfig {
@@ -32,4 +34,13 @@ pub struct ScheduleConfig {
   #[asset(skip)]
   #[builder(default)]
   pub(crate) repeat: u16,
+}
+
+impl ExpandImports for TimeTriggerConfig {
+  type Error = ManifestError;
+  fn expand_imports(&mut self, bindings: &mut Vec<ImportBinding>, trigger_index: usize) -> Result<(), Self::Error> {
+    let id = format!("trigger_{}", trigger_index);
+    self.operation_mut().maybe_import(&id, bindings);
+    Ok(())
+  }
 }

--- a/crates/wick/wick-config/src/config/component_config.rs
+++ b/crates/wick/wick-config/src/config/component_config.rs
@@ -10,10 +10,10 @@ use tracing::trace;
 pub use wasm::*;
 use wick_asset_reference::{AssetReference, FetchOptions};
 use wick_interface_types::{ComponentMetadata, ComponentSignature, Field, OperationSignature, TypeDefinition};
-use wick_packet::RuntimeConfig;
+use wick_packet::{Entity, RuntimeConfig};
 
 use super::common::package_definition::PackageConfig;
-use super::{AppConfiguration, ImportBinding, TestConfiguration};
+use super::{ImportBinding, TestConfiguration};
 use crate::config::template_config::Renderable;
 use crate::config::{BoundInterface, ResourceBinding};
 use crate::import_cache::{setup_cache, ImportCache};
@@ -283,6 +283,7 @@ impl ComponentConfiguration {
       ?root_config,
       "initializing component"
     );
+
     for resource in self.resources.iter_mut() {
       resource.kind.render_config(root_config.as_ref(), None)?;
     }
@@ -318,10 +319,10 @@ impl Lockdown for ComponentConfiguration {
       )]));
     };
 
-    if id == AppConfiguration::GENERIC_IDENTIFIER {
+    if id == Entity::LOCAL {
       return Err(LockdownError::new(vec![FailureKind::General(format!(
         "invalid component id: {}",
-        AppConfiguration::GENERIC_IDENTIFIER
+        Entity::LOCAL
       ))]));
     }
 

--- a/crates/wick/wick-config/src/config/configuration_tree.rs
+++ b/crates/wick/wick-config/src/config/configuration_tree.rs
@@ -92,7 +92,7 @@ pub fn flatten(node: ConfigurationTreeNode, prefix: &str) -> Vec<ConfigOrDefinit
   for child in children {
     match child {
       ConfigOrDefinition::Config(c) => {
-        let id = format!("{}.{}", prefix, c.name);
+        let id = format!("{}::{}", prefix, c.name);
         let new_node = ConfigurationTreeNode {
           name: id.clone(),
           element: c.element,

--- a/crates/wick/wick-config/src/lib.rs
+++ b/crates/wick/wick-config/src/lib.rs
@@ -95,6 +95,8 @@ pub mod audit;
 mod default;
 mod helpers;
 mod import_cache;
+mod traits;
+pub use traits::*;
 /// Data structures, traits, and errors associated with Lockdown configuration.
 pub mod lockdown;
 

--- a/crates/wick/wick-config/src/traits.rs
+++ b/crates/wick/wick-config/src/traits.rs
@@ -1,0 +1,9 @@
+use crate::config;
+
+/// The [TriggerConfiguration] trait is implemented by unknown configuration entities that may or may not need to alter the [AppConfiguration] they are running within.
+pub trait ExpandImports {
+  /// The type of error that may be returned when expanding imports.
+  type Error;
+  /// Expand imports with any inline definitions.
+  fn expand_imports(&mut self, bindings: &mut Vec<config::ImportBinding>, index: usize) -> Result<(), Self::Error>;
+}

--- a/crates/wick/wick-config/tests/v1_load_from_file.rs
+++ b/crates/wick/wick-config/tests/v1_load_from_file.rs
@@ -95,7 +95,7 @@ async fn test_component_extended() -> Result<(), ManifestError> {
 async fn regression_issue_42() -> Result<(), ManifestError> {
   let component = load_app("./tests/manifests/v1/template-expansion.yaml").await?;
   println!("{:?}", component);
-  let coll = component.imports().get(0).unwrap();
+  let coll = component.import().get(0).unwrap();
   let value: String = coll.kind().config().unwrap().coerce_key("pwd").unwrap();
   let expected = std::env::var("CARGO_MANIFEST_DIR").unwrap();
 

--- a/crates/wick/wick-host/Cargo.toml
+++ b/crates/wick/wick-host/Cargo.toml
@@ -31,6 +31,8 @@ uuid = { workspace = true }
 futures = { workspace = true }
 derive_builder = { workspace = true }
 option-utils = { workspace = true }
+async-trait = { workspace = true }
+
 
 [dev-dependencies]
 wick-logger = { workspace = true }

--- a/crates/wick/wick-host/src/collection.rs
+++ b/crates/wick/wick-host/src/collection.rs
@@ -5,7 +5,7 @@ use flow_component::{Component, ComponentError, RuntimeCallback};
 use wick_interface_types::*;
 use wick_packet::{Invocation, PacketStream, RuntimeConfig};
 
-use crate::ComponentHost;
+use crate::{ComponentHost, Host};
 
 #[derive(Debug, Default)]
 pub struct Context {
@@ -23,7 +23,7 @@ pub struct HostComponent {
 
 impl HostComponent {
   pub fn new(host: ComponentHost) -> Self {
-    let signature: ComponentSignature = host.get_signature().unwrap();
+    let signature: ComponentSignature = host.get_signature(None, None).unwrap();
 
     Self {
       id: host.get_host_id().to_owned(),

--- a/crates/wick/wick-host/src/lib.rs
+++ b/crates/wick/wick-host/src/lib.rs
@@ -92,13 +92,15 @@ extern crate tracing;
 pub(crate) mod macros;
 
 mod app_host;
-pub use app_host::{AppHost, AppHostBuilder, TriggerState};
 pub mod collection;
 mod component_host;
 mod error;
-
+mod traits;
+pub use app_host::{AppHost, AppHostBuilder, TriggerState};
 pub use collection::HostComponent;
 pub use component_host::{ComponentHost, ComponentHostBuilder};
+pub use traits::{Host, RuntimeError, WickHost};
+
+pub type Error = error::HostError;
 
 pub(crate) type Result<T> = std::result::Result<T, error::HostError>;
-pub type Error = error::HostError;

--- a/crates/wick/wick-host/src/traits.rs
+++ b/crates/wick/wick-host/src/traits.rs
@@ -1,0 +1,69 @@
+use wick_config::WickConfiguration;
+use wick_interface_types::ComponentSignature;
+use wick_packet::{Entity, Invocation, PacketStream, RuntimeConfig};
+pub use wick_runtime::error::RuntimeError;
+
+use crate::error::HostError;
+use crate::{AppHost, ComponentHost};
+
+#[async_trait::async_trait]
+pub trait Host {
+  fn namespace(&self) -> &str;
+  fn get_signature(&self, path: Option<&[&str]>, entity: Option<&Entity>) -> Result<ComponentSignature, HostError>;
+  async fn invoke(&self, invocation: Invocation, data: Option<RuntimeConfig>) -> Result<PacketStream, HostError>;
+  async fn invoke_deep(
+    &self,
+    path: Option<&[&str]>,
+    invocation: Invocation,
+    data: Option<RuntimeConfig>,
+  ) -> Result<PacketStream, HostError>;
+  fn get_active_config(&self) -> WickConfiguration;
+}
+
+#[derive(Debug)]
+pub enum WickHost {
+  App(AppHost),
+  Component(ComponentHost),
+}
+
+#[async_trait::async_trait]
+impl Host for WickHost {
+  fn namespace(&self) -> &str {
+    match self {
+      Self::App(h) => h.namespace(),
+      Self::Component(h) => h.namespace(),
+    }
+  }
+
+  fn get_signature(&self, path: Option<&[&str]>, entity: Option<&Entity>) -> Result<ComponentSignature, HostError> {
+    match self {
+      Self::App(h) => h.get_signature(path, entity),
+      Self::Component(h) => h.get_signature(path, entity),
+    }
+  }
+
+  async fn invoke(&self, invocation: Invocation, data: Option<RuntimeConfig>) -> Result<PacketStream, HostError> {
+    match self {
+      Self::App(h) => h.invoke(invocation, data).await,
+      Self::Component(h) => h.invoke(invocation, data).await,
+    }
+  }
+  async fn invoke_deep(
+    &self,
+    path: Option<&[&str]>,
+    invocation: Invocation,
+    data: Option<RuntimeConfig>,
+  ) -> Result<PacketStream, HostError> {
+    match self {
+      Self::App(h) => h.invoke_deep(path, invocation, data).await,
+      Self::Component(h) => h.invoke_deep(path, invocation, data).await,
+    }
+  }
+
+  fn get_active_config(&self) -> WickConfiguration {
+    match self {
+      Self::App(h) => h.get_active_config(),
+      Self::Component(h) => h.get_active_config(),
+    }
+  }
+}

--- a/crates/wick/wick-host/tests/app.rs
+++ b/crates/wick/wick-host/tests/app.rs
@@ -1,0 +1,35 @@
+mod utils;
+use std::path::PathBuf;
+
+use anyhow::Result;
+use tokio_stream::StreamExt;
+use tracing::Span;
+use wick_host::{AppHost, AppHostBuilder, Host};
+use wick_packet::{packets, Entity, InherentData, Invocation, Packet};
+
+#[test_logger::test(tokio::test)]
+async fn test_deep_invoke() -> Result<()> {
+  let app_config = utils::load_app_config("run/unit/file-reader.wick", None).await?;
+  let rt = AppHost::build_runtime(&app_config, Some(1), Span::current()).await?;
+  let app_host = AppHostBuilder::default().manifest(app_config).runtime(rt).build()?;
+  let target = Entity::operation("wasi_fs", "read_string");
+  let file = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("Cargo.toml");
+  let invocation = Invocation::new(
+    Entity::test("test_deep_invoke"),
+    target,
+    packets!(("filename", file.to_string_lossy())),
+    InherentData::unsafe_default(),
+    &Span::current(),
+  );
+  let stream = app_host.invoke_deep(Some(&["CLI"]), invocation, None).await?;
+
+  let mut packets: Vec<_> = stream.collect().await;
+
+  assert_eq!(packets.len(), 2);
+  packets.pop();
+  let output = packets.pop().unwrap().unwrap();
+
+  assert_eq!(output, Packet::encode("output", std::fs::read_to_string(file)?));
+
+  Ok(())
+}

--- a/crates/wick/wick-host/tests/utils/mod.rs
+++ b/crates/wick/wick-host/tests/utils/mod.rs
@@ -1,0 +1,31 @@
+use std::collections::HashMap;
+
+use anyhow::Result;
+use wick_config::config::{AppConfiguration, UninitializedConfiguration};
+use wick_config::WickConfiguration;
+use wick_packet::RuntimeConfig;
+
+pub async fn load_config(path: &str) -> Result<UninitializedConfiguration> {
+  let cargo_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+  let path = cargo_dir.join("../../bins/wick/tests").join(path);
+  let config = WickConfiguration::fetch(&path, Default::default()).await?;
+  Ok(config)
+}
+
+#[allow(unused)]
+pub async fn load_wick_config(
+  path: &str,
+  root_config: Option<RuntimeConfig>,
+  env: Option<HashMap<String, String>>,
+) -> Result<WickConfiguration> {
+  let mut config = load_config(path).await?;
+  config.set_env(env).set_root_config(root_config);
+  Ok(config.finish()?)
+}
+
+pub async fn load_app_config(path: &str, root_config: Option<RuntimeConfig>) -> Result<AppConfiguration> {
+  let mut config = load_config(path).await?;
+  let env = std::env::vars().collect();
+  config.set_env(Some(env)).set_root_config(root_config);
+  Ok(config.finish()?.try_app_config()?)
+}

--- a/crates/wick/wick-packet/src/error.rs
+++ b/crates/wick/wick-packet/src/error.rs
@@ -98,6 +98,9 @@ pub enum ParseError {
   /// Encountered an invalid scheme when parsing an entity URL.
   #[error("Invalid scheme {0}")]
   Scheme(String),
+  /// No path supplied in the entity URL.
+  #[error("Missing path")]
+  MissingPath,
   /// No authority/host supplied in the entity URL.
   #[error("Missing authority/host")]
   Authority,

--- a/crates/wick/wick-runtime/Cargo.toml
+++ b/crates/wick/wick-runtime/Cargo.toml
@@ -73,6 +73,7 @@ tokio-stream = { workspace = true }
 tracing = { workspace = true }
 uuid = { workspace = true }
 derive_builder = { workspace = true }
+itertools = { workspace = true }
 
 [dev-dependencies]
 wick-invocation-server = { workspace = true }

--- a/crates/wick/wick-runtime/src/components/component_service.rs
+++ b/crates/wick/wick-runtime/src/components/component_service.rs
@@ -54,7 +54,7 @@ impl InvocationHandler for NativeComponentService {
     let task = async move {
       Ok(crate::dispatch::InvocationResponse::Stream {
         tx_id,
-        rx: fut.instrument(span).await.map_err(EngineError::NativeComponent)?,
+        rx: fut.instrument(span).await.map_err(ScopeError::NativeComponent)?,
       })
     };
     Ok(Box::pin(task))

--- a/crates/wick/wick-runtime/src/components/error.rs
+++ b/crates/wick/wick-runtime/src/components/error.rs
@@ -10,9 +10,9 @@ pub enum ComponentError {
   UnsatisfiedRequirement(String),
 
   #[error("{0}")]
-  EngineError(String),
+  ScopeError(String),
 
-  #[error("Error initializing inner engine scope '{0}' : {1}")]
+  #[error("Error initializing inner runtime scope '{0}' : {1}")]
   SubScope(AssetReference, String),
 
   #[error("{0}")]

--- a/crates/wick/wick-runtime/src/components/validation.rs
+++ b/crates/wick/wick-runtime/src/components/validation.rs
@@ -2,14 +2,14 @@ use std::path::Path;
 
 use wick_interface_types::ComponentSignature;
 
-use crate::EngineError;
+use crate::ScopeError;
 
 pub(crate) fn expect_signature_match(
   _actual_src: Option<&Path>,
   actual: &ComponentSignature,
   _expected_src: Option<&Path>,
   expected: &ComponentSignature,
-) -> Result<(), EngineError> {
+) -> Result<(), ScopeError> {
   if actual != expected {
     // Disabling for now.
     // debug!(

--- a/crates/wick/wick-runtime/src/dev.rs
+++ b/crates/wick/wick-runtime/src/dev.rs
@@ -14,7 +14,7 @@ pub(crate) mod prelude {
   pub(crate) use crate::components::InvocationHandler;
   pub(crate) use crate::dispatch::InvocationResponse;
   pub(crate) use crate::error::*;
-  pub(crate) use crate::runtime_service::RuntimeService;
+  pub(crate) use crate::runtime::scope::Scope;
   pub(crate) use crate::utils::*;
   pub(crate) use crate::BoxFuture;
 }

--- a/crates/wick/wick-runtime/src/error.rs
+++ b/crates/wick/wick-runtime/src/error.rs
@@ -2,10 +2,11 @@ use std::convert::Infallible;
 
 use thiserror::Error;
 use wick_config::config::{ComponentKind, TriggerKind};
+use wick_packet::Entity;
 
 pub use crate::components::error::ComponentError;
 use crate::resources::ResourceKind;
-pub use crate::runtime_service::error::EngineError;
+pub use crate::runtime::scope::error::ScopeError;
 
 #[derive(Debug, Clone, Copy)]
 pub enum Context {
@@ -53,7 +54,13 @@ impl From<ComponentKind> for Context {
 #[derive(Error, Debug)]
 pub enum RuntimeError {
   #[error("Invalid {0} configuration, expected configuration for {0}")]
-  InvalidConfig(Context, TriggerKind),
+  TriggerKind(Context, TriggerKind),
+
+  #[error("Invalid {0} configuration: {1}")]
+  InvalidConfig(Context, String),
+
+  #[error("invalid target '{0}'")]
+  InvalidTarget(Entity),
 
   #[error("{0} requested resource '{1}' which could not be found")]
   ResourceNotFound(Context, String),
@@ -69,6 +76,9 @@ pub enum RuntimeError {
 
   #[error("{0}")]
   InitializationFailed(String),
+
+  #[error("Could not find scope '{}' via path {}", .1.as_ref().map_or_else(||Entity::LOCAL,|e|e.component_id()), .0.as_ref().map_or_else(||"".to_owned(),|v|format!("via path {} ",v.join("::"))))]
+  ScopeNotFound(Option<Vec<String>>, Option<Entity>),
 
   #[error("Invocation error: {0}")]
   InvocationError(String),

--- a/crates/wick/wick-runtime/src/lib.rs
+++ b/crates/wick/wick-runtime/src/lib.rs
@@ -99,15 +99,14 @@ mod dispatch;
 pub mod error;
 pub mod resources;
 mod runtime;
-mod runtime_service;
 mod triggers;
 pub(crate) mod utils;
 
-pub use components::engine_component::EngineComponent;
 pub use components::error::ComponentError;
+pub use components::scope_component::ScopeComponent;
+pub use runtime::scope::error::ScopeError;
 pub use runtime::{Runtime, RuntimeBuilder};
-pub use runtime_service::error::EngineError;
-pub use triggers::{get_trigger_loader, Trigger};
+pub use triggers::{build_trigger_runtime, get_trigger_loader, Trigger, TriggerRuntimeConfig};
 
 pub type Error = error::RuntimeError;
 

--- a/crates/wick/wick-runtime/src/runtime/scope.rs
+++ b/crates/wick/wick-runtime/src/runtime/scope.rs
@@ -7,73 +7,111 @@ mod utils;
 pub(crate) use child_init::{init_child, ChildInit};
 pub(crate) use component_registry::{ComponentFactory, ComponentRegistry};
 use flow_graph_interpreter::{HandlerMap, NamespaceHandler};
-pub(crate) use init::ServiceInit;
+pub(crate) use init::ScopeInit;
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 use uuid::Uuid;
+use wick_packet::Entity;
 
 use crate::dev::prelude::*;
 
-type ServiceMap = HashMap<Uuid, Arc<RuntimeService>>;
-type Result<T> = std::result::Result<T, EngineError>;
+type ServiceMap = HashMap<Uuid, Scope>;
+type Result<T> = std::result::Result<T, ScopeError>;
 
-static HOST_REGISTRY: Lazy<Mutex<ServiceMap>> = Lazy::new(|| Mutex::new(HashMap::new()));
+static SCOPE_REGISTRY: Lazy<Mutex<ServiceMap>> = Lazy::new(|| Mutex::new(HashMap::new()));
 
 #[must_use]
+#[derive(Debug, Clone)]
+pub(crate) struct Scope {
+  inner: Arc<InnerScope>,
+}
+
 #[derive(Debug)]
-pub(crate) struct RuntimeService {
+pub(crate) struct InnerScope {
   #[allow(unused)]
   started_time: std::time::Instant,
+  pub(crate) parent: Option<Uuid>,
   pub(crate) id: Uuid,
   pub(super) namespace: String,
   pub(super) active_config: ComponentConfiguration,
-  interpreter: Arc<flow_graph_interpreter::Interpreter>,
+  interpreter: flow_graph_interpreter::Interpreter,
 }
 
-impl RuntimeService {
-  pub(crate) async fn start(mut init: ServiceInit) -> Result<Arc<Self>> {
+impl Scope {
+  pub(crate) async fn start(mut init: ScopeInit) -> Result<Self> {
     let started_time = std::time::Instant::now();
     let (extends, components) = init.instantiate_main().await?;
     let components = init.instantiate_imports(extends, components).await?;
     let interpreter = init.init_interpreter(components).await?;
 
-    let engine = Arc::new(RuntimeService {
-      started_time,
-      id: init.id,
-      namespace: init.namespace(),
-      active_config: init.manifest,
-      interpreter: Arc::new(interpreter),
-    });
+    let scope = Scope {
+      inner: Arc::new(InnerScope {
+        parent: init.parent,
+        started_time,
+        id: init.id,
+        namespace: init.namespace(),
+        active_config: init.manifest,
+        interpreter,
+      }),
+    };
 
-    let mut registry = HOST_REGISTRY.lock();
-    registry.insert(init.id, engine.clone());
+    let mut registry = SCOPE_REGISTRY.lock();
+    registry.insert(init.id, scope.clone());
 
-    Ok(engine)
+    Ok(scope)
   }
 
-  pub(crate) fn for_id(id: &Uuid) -> Option<Arc<Self>> {
-    let registry = HOST_REGISTRY.lock();
+  pub(crate) fn for_id(id: &Uuid) -> Option<Self> {
+    let registry = SCOPE_REGISTRY.lock();
     registry.get(id).cloned()
   }
 
+  pub(crate) fn id(&self) -> Uuid {
+    self.inner.id
+  }
+
+  pub(crate) fn namespace(&self) -> &str {
+    &self.inner.namespace
+  }
+
   pub(crate) async fn shutdown(&self) -> std::result::Result<(), RuntimeError> {
-    let _ = self.interpreter.shutdown().await;
+    let _ = self.inner.interpreter.shutdown().await;
     Ok(())
   }
 
   pub(crate) fn render_dotviz(&self, op: &str) -> std::result::Result<String, RuntimeError> {
-    self.interpreter.render_dotviz(op).map_err(RuntimeError::DotViz)
+    self.inner.interpreter.render_dotviz(op).map_err(RuntimeError::DotViz)
   }
 
   pub(crate) fn active_config(&self) -> &ComponentConfiguration {
-    &self.active_config
+    &self.inner.active_config
+  }
+
+  pub(super) fn find(parent: Option<Uuid>, ns: &str) -> Option<Scope> {
+    let registry = SCOPE_REGISTRY.lock();
+    registry
+      .values()
+      .find(|scope| scope.inner.namespace == ns && scope.inner.parent == parent)
+      .cloned()
+  }
+
+  pub(super) fn get_handler_signature(&self, ns: &str) -> Option<&ComponentSignature> {
+    if ns == Entity::LOCAL {
+      return Some(self.inner.interpreter.signature());
+    }
+    self
+      .inner
+      .interpreter
+      .components()
+      .get(ns)
+      .map(|c| c.component().signature())
   }
 }
 
-impl InvocationHandler for RuntimeService {
+impl InvocationHandler for Scope {
   fn get_signature(&self) -> std::result::Result<ComponentSignature, ComponentError> {
-    let mut signature = self.interpreter.signature().clone();
-    signature.name = Some(self.id.as_hyphenated().to_string());
+    let mut signature = self.inner.interpreter.signature().clone();
+    signature.name = Some(self.inner.id.as_hyphenated().to_string());
 
     Ok(signature)
   }
@@ -85,7 +123,7 @@ impl InvocationHandler for RuntimeService {
   ) -> std::result::Result<BoxFuture<std::result::Result<InvocationResponse, ComponentError>>, ComponentError> {
     let tx_id = invocation.tx_id;
 
-    let fut = self.interpreter.invoke(invocation, config);
+    let fut = self.inner.interpreter.invoke(invocation, config);
     let task = async move {
       match fut.await {
         Ok(response) => Ok(InvocationResponse::Stream { tx_id, rx: response }),
@@ -113,7 +151,7 @@ fn generate_provides_handlers(
         let ns_handler = NamespaceHandler::new_from_shared(to, handler.component().clone());
         let _ = provide.add(ns_handler); // Can't fail, we just created the map and are iterating over unique keys.
       } else {
-        return Err(EngineError::NotFound(Context::Component, from.clone()));
+        return Err(ScopeError::NotFound(Context::Component, from.clone()));
       }
     }
   }

--- a/crates/wick/wick-runtime/src/runtime/scope/component_registry.rs
+++ b/crates/wick/wick-runtime/src/runtime/scope/component_registry.rs
@@ -2,9 +2,9 @@ use flow_graph_interpreter::NamespaceHandler;
 use seeded_random::Seed;
 
 use crate::components::initialize_native_component;
-use crate::{EngineError, V0_NAMESPACE};
+use crate::{ScopeError, V0_NAMESPACE};
 
-pub(crate) type ComponentFactory = dyn Fn(Seed) -> Result<NamespaceHandler, EngineError> + Send + Sync;
+pub(crate) type ComponentFactory = dyn Fn(Seed) -> Result<NamespaceHandler, ScopeError> + Send + Sync;
 
 #[derive()]
 pub(crate) struct ComponentRegistry(Vec<Box<ComponentFactory>>);

--- a/crates/wick/wick-runtime/src/runtime/scope/error.rs
+++ b/crates/wick/wick-runtime/src/runtime/scope/error.rs
@@ -11,7 +11,7 @@ fn display_path(pb: &Option<PathBuf>) -> String {
 }
 
 #[derive(Error, Debug)]
-pub enum EngineError {
+pub enum ScopeError {
   #[error("Could not start interpreter from '{}': {1}", display_path(.0))]
   InterpreterInit(Option<PathBuf>, Box<flow_graph_interpreter::error::InterpreterError>),
 
@@ -87,26 +87,26 @@ impl std::fmt::Display for InternalError {
   }
 }
 
-impl From<EngineError> for ComponentError {
-  fn from(e: EngineError) -> Self {
-    ComponentError::EngineError(e.to_string())
+impl From<ScopeError> for ComponentError {
+  fn from(e: ScopeError) -> Self {
+    ComponentError::ScopeError(e.to_string())
   }
 }
 
-impl From<wick_component_wasm::Error> for EngineError {
+impl From<wick_component_wasm::Error> for ScopeError {
   fn from(e: wick_component_wasm::Error) -> Self {
-    EngineError::Wasm(Box::new(e))
+    ScopeError::Wasm(Box::new(e))
   }
 }
 
-impl From<flow_graph::error::Error> for EngineError {
+impl From<flow_graph::error::Error> for ScopeError {
   fn from(e: flow_graph::error::Error) -> Self {
-    EngineError::FlowGraph(Box::new(e))
+    ScopeError::FlowGraph(Box::new(e))
   }
 }
 
-impl From<wick_config::Error> for EngineError {
+impl From<wick_config::Error> for ScopeError {
   fn from(e: wick_config::Error) -> Self {
-    EngineError::Manifest(Box::new(e))
+    ScopeError::Manifest(Box::new(e))
   }
 }

--- a/crates/wick/wick-runtime/src/test.rs
+++ b/crates/wick/wick-runtime/src/test.rs
@@ -11,7 +11,7 @@ use wick_config::WickConfiguration;
 use crate::test::prelude::*;
 use crate::{Runtime, RuntimeBuilder};
 
-pub(crate) async fn init_engine_from_yaml(path: &str) -> Result<(Runtime, uuid::Uuid)> {
+pub(crate) async fn init_scope_from_yaml(path: &str) -> Result<(Runtime, uuid::Uuid)> {
   let crate_dir = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"));
 
   let def = WickConfiguration::fetch(&crate_dir.join("tests").join(path), Default::default())
@@ -19,11 +19,11 @@ pub(crate) async fn init_engine_from_yaml(path: &str) -> Result<(Runtime, uuid::
     .finish()?
     .try_component_config()?;
 
-  let engine = RuntimeBuilder::from_definition(def).build(None).await?;
+  let scope = RuntimeBuilder::from_definition(def).build(None).await?;
 
-  let engine_id = engine.uid;
-  trace!(engine_id = %engine_id, "engine uid");
-  Ok((engine, engine_id))
+  let scope_id = scope.uid;
+  trace!(scope_id = %scope_id, "scope id");
+  Ok((scope, scope_id))
 }
 
 pub(crate) async fn load_test_manifest(name: &str) -> Result<WickConfiguration> {

--- a/crates/wick/wick-runtime/src/triggers.rs
+++ b/crates/wick/wick-runtime/src/triggers.rs
@@ -8,19 +8,20 @@ use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 use structured_output::StructuredOutput;
 use tracing::Span;
-use wick_config::config::{ComponentDefinition, TriggerDefinition, TriggerKind};
+use wick_config::config::{ComponentDefinition, ComponentOperationExpression, TriggerDefinition, TriggerKind};
 
 use crate::dev::prelude::*;
 use crate::resources::Resource;
+use crate::runtime::RuntimeConstraint;
 use crate::RuntimeBuilder;
 
-fn build_trigger_runtime(config: &AppConfiguration, span: Span) -> Result<RuntimeBuilder, Infallible> {
+pub fn build_trigger_runtime(config: &AppConfiguration, span: Span) -> Result<RuntimeBuilder, Infallible> {
   let mut rt = RuntimeBuilder::default();
   if let Some(fetch_opts) = config.options() {
     rt = rt.allow_latest(*fetch_opts.allow_latest());
     rt = rt.allowed_insecure(fetch_opts.allow_insecure().clone());
   }
-  for import in config.imports() {
+  for import in config.import() {
     rt.add_import(import.clone());
   }
   for resource in config.resources() {
@@ -32,16 +33,53 @@ fn build_trigger_runtime(config: &AppConfiguration, span: Span) -> Result<Runtim
 
 #[async_trait]
 pub trait Trigger {
+  /// Start executing the trigger.
   async fn run(
     &self,
     name: String,
+    runtime: crate::Runtime,
     app_config: AppConfiguration,
     config: TriggerDefinition,
     resources: Arc<HashMap<String, Resource>>,
     span: Span,
   ) -> Result<StructuredOutput, RuntimeError>;
+
+  /// Shutdown a running trigger.
   async fn shutdown_gracefully(self) -> Result<(), RuntimeError>;
+
+  /// Wait for the trigger to finish.
   async fn wait_for_done(&self);
+}
+
+/// Runtime configuration necessary for a trigger to execute.
+#[derive(Debug, Clone)]
+pub struct TriggerRuntimeConfig {
+  pub(crate) constraints: Vec<RuntimeConstraint>,
+}
+
+impl TriggerRuntimeConfig {
+  /// Extend a runtime builder with the configuration contained within.
+  pub fn extend_runtime(self, rt: &mut RuntimeBuilder) {
+    for constraint in self.constraints {
+      rt.add_constraint(constraint);
+    }
+  }
+}
+
+pub(crate) trait ComponentId {
+  fn component_id(&self) -> Result<&str, RuntimeError>;
+}
+
+impl ComponentId for ComponentOperationExpression {
+  fn component_id(&self) -> Result<&str, RuntimeError> {
+    match self.component() {
+      ComponentDefinition::Reference(r) => Ok(r.id()),
+      _ => Err(RuntimeError::InvalidConfig(
+        Context::Trigger,
+        "expected a component reference but found an unimported definition, this is a bug".to_owned(),
+      )),
+    }
+  }
 }
 
 pub(crate) type TriggerLoader = Arc<dyn Fn() -> Result<Arc<dyn Trigger + Send + Sync>, RuntimeError> + Send + Sync>;
@@ -57,30 +95,4 @@ static TRIGGER_LOADER_REGISTRY: Lazy<Mutex<HashMap<TriggerKind, TriggerLoader>>>
 #[must_use]
 pub fn get_trigger_loader(name: &TriggerKind) -> Option<TriggerLoader> {
   TRIGGER_LOADER_REGISTRY.lock().get(name).cloned()
-}
-
-pub(crate) enum ResolvedComponent<'a> {
-  Ref(&'a str, ComponentDefinition),
-  Inline(&'a ComponentDefinition),
-}
-
-pub(crate) fn resolve_ref<'a>(
-  app_config: &AppConfiguration,
-  component: &'a ComponentDefinition,
-) -> Result<ResolvedComponent<'a>, RuntimeError> {
-  let def = if let ComponentDefinition::Reference(cref) = component {
-    ResolvedComponent::Ref(
-      cref.id(),
-      app_config
-        .resolve_binding(cref.id())
-        .map_err(|e| {
-          RuntimeError::InitializationFailed(format!("Error initializing component {}: error was {}", cref.id(), e))
-        })?
-        .try_component()
-        .map_err(|e| RuntimeError::ReferenceError(cref.id().to_owned(), e))?,
-    )
-  } else {
-    ResolvedComponent::Inline(component)
-  };
-  Ok(def)
 }

--- a/crates/wick/wick-runtime/src/triggers/http/component_utils.rs
+++ b/crates/wick/wick-runtime/src/triggers/http/component_utils.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::sync::Arc;
 
 use hyper::header::CONTENT_LENGTH;
 use hyper::http::response::Builder;
@@ -31,7 +30,7 @@ pub(super) async fn handle_request_middleware(
   tx_id: Uuid,
   target: Entity,
   operation_config: Option<RuntimeConfig>,
-  engine: Arc<Runtime>,
+  runtime: Runtime,
   req: &wick_http::HttpRequest,
   span: &Span,
 ) -> Result<Option<wick_http::RequestMiddlewareResponse>, HttpError> {
@@ -45,7 +44,7 @@ pub(super) async fn handle_request_middleware(
     span,
   );
 
-  let stream = engine
+  let stream = runtime
     .invoke(invocation, operation_config)
     .await
     .map_err(|e| HttpError::OperationError(e.to_string()))?;
@@ -85,7 +84,7 @@ pub(super) async fn handle_response_middleware(
   tx_id: Uuid,
   target: Entity,
   operation_config: Option<RuntimeConfig>,
-  engine: Arc<Runtime>,
+  runtime: Runtime,
   req: &wick_http::HttpRequest,
   res: &wick_http::HttpResponse,
   span: &Span,
@@ -100,7 +99,7 @@ pub(super) async fn handle_response_middleware(
     span,
   );
 
-  let stream = engine
+  let stream = runtime
     .invoke(invocation, operation_config)
     .await
     .map_err(|e| HttpError::OperationError(e.to_string()))?;

--- a/tests/codegen-tests/src/import_types/mod.rs
+++ b/tests/codegen-tests/src/import_types/mod.rs
@@ -47,7 +47,9 @@ mod imported_components_wasm {
     ) -> std::result::Result<wick_packet::PacketStream, wick_packet::Error> {
       let input = input.map(wick_component::wick_packet::into_packet("input"));
       let stream = wick_component::empty();
-      let stream = stream.merge(input);
+      let stream = stream
+        .merge(input)
+        .chain(wick_component::iter_raw(vec![Ok(Packet::done("input"))]));
       let stream = wick_packet::PacketStream::new(Box::pin(stream));
       Ok(
         self


### PR DESCRIPTION
Historically, `wick invoke` would only work on component configuration, and making individual calls to operations in complex wick apps has gotten more difficult with provides/requires, root configuration, and resources. 

This PR adds `wick invoke` support for application configurations. When you do `wick invoke your-app.wick <path::component::operation>`, `wick` will instantiate a runtime and all children scopes, but will not start any trigger logic. It will find the appropriate scope by name and execute the operation in isolation. The `deep reference` syntax is IDs separated with two colons. E.g.,

```bash
$ wick invoke app.wick parent1::parent2::component::operation [same invoke config]
```

In addition, this PR:
- enables deep invocation support for `wick invoke` on components for consistency.
- refactors inconsistent, legacy naming in wick-runtime.
- changes the audit/lockdown component syntax from dot-delimited (`this.that`) to double-semi-colon-delimited (`this::that`) for consistency.
- changes the `__root__` audit/lockdown node to `__local__` to align with local Entities.
