### PR TITLE
Support volume restrictions on `file://` urls, update SQLite URL support for it

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -224,6 +224,10 @@ _wick-db-tests:
   {{wick}} test ./examples/db/tests/postgres-numeric-tests.wick
   {{wick}} test ./examples/db/tests/postgres-null-tests.wick
   {{wick}} test ./examples/db/tests/postgres-date-tests.wick
+  {{wick}} test ./examples/db/postgres-component.wick
+  {{wick}} test ./examples/db/azuresql-component.wick
+  {{wick}} test ./examples/db/sqlite-component.wick
+  {{wick}} test ./examples/db/sqlite-inmemory-component.wick
   {{wick}} test ./tests/cli-tests/tests/cmd/db/azuresql-tx-test.wick
 
 # Run `wick` tests for http components

--- a/crates/components/wick-sql/src/error.rs
+++ b/crates/components/wick-sql/src/error.rs
@@ -17,6 +17,11 @@ pub enum Error {
   #[error("Unknown database scheme '{0}'")]
   InvalidScheme(String),
 
+  #[error(
+    "To use in-memory SQLite databases, use the URL 'sqlite://memory'; to use a SQLite DB file, use a 'file://' URL"
+  )]
+  SqliteScheme,
+
   #[error("Failed to prepare arguments: {0}")]
   Prepare(String),
 

--- a/crates/components/wick-sql/src/sqlx/sqlite.rs
+++ b/crates/components/wick-sql/src/sqlx/sqlite.rs
@@ -1,19 +1,19 @@
 mod serialize;
 use sqlx::sqlite::SqlitePoolOptions;
 use sqlx::{Sqlite, SqlitePool};
-use url::Url;
 use wick_config::config::components::SqlComponentConfig;
 
 pub(crate) use self::serialize::*;
 use crate::common::sql_wrapper::ConvertedType;
 use crate::Error;
 
-pub(crate) async fn connect(_config: &SqlComponentConfig, addr: &Url) -> Result<SqlitePool, Error> {
+pub(crate) async fn connect(_config: &SqlComponentConfig, addr: Option<&str>) -> Result<SqlitePool, Error> {
+  let addr = addr.unwrap_or(":memory:");
   debug!(%addr, "connecting to sqlite");
 
   let pool = SqlitePoolOptions::new()
     .max_connections(5)
-    .connect(addr.as_ref())
+    .connect(addr)
     .await
     .map_err(|e| Error::SqliteConnect(e.to_string()))?;
   Ok(pool)

--- a/crates/components/wick-sql/src/sqlx/sqlite/serialize.rs
+++ b/crates/components/wick-sql/src/sqlx/sqlite/serialize.rs
@@ -138,7 +138,7 @@ mod integration_test {
 
   async fn connect() -> SqliteConnection {
     let db = std::env::var("SQLITE_DB").unwrap();
-    let conn_string = format!("sqlite://{}", db);
+    let conn_string = format!("file://{}", db);
 
     SqliteConnection::connect(&conn_string).await.unwrap()
   }

--- a/crates/wick/wick-config/src/lockdown/error.rs
+++ b/crates/wick/wick-config/src/lockdown/error.rs
@@ -58,6 +58,10 @@ pub enum FailureKind {
   Address(String, String),
   /// A component is not allowed to access given url.
   Url(String, String),
+  /// A file:// URL could not be turned into a filepath.
+  FileUrlInvalid(url::Url),
+  /// A file:// URL does not point to a concrete file.
+  FileUrlNotFound(url::Url),
 }
 
 impl std::fmt::Display for FailureKind {
@@ -80,6 +84,8 @@ impl std::fmt::Display for FailureKind {
         FailureKind::Port(id, port) =>  write!(f, "component {} is not allowed to access {}", id, port),
         FailureKind::Address(id,address) =>  write!(f, "component {} is not allowed to access {}", id, address),
         FailureKind::Url(id, url) =>  write!(f, "component {} is not allowed to access {}", id, url),
+        FailureKind::FileUrlInvalid(url) =>  write!(f, "could not create a file path out of {}", url),
+        FailureKind::FileUrlNotFound(url) =>  write!(f, "file URL '{}' does not point to a valid file", url),
     }
   }
 }

--- a/crates/wick/wick-config/src/lockdown/url.rs
+++ b/crates/wick/wick-config/src/lockdown/url.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 use std::collections::HashSet;
 
 use wildmatch::WildMatch;
@@ -15,6 +14,7 @@ pub(crate) fn validate<'a>(
   restrictions: impl Iterator<Item = &'a UrlRestriction>,
 ) -> Result<(), LockdownError> {
   let mut failures = HashSet::new();
+
   for restriction in restrictions {
     match is_allowed(component_id, resource_id, resource, restriction) {
       Ok(_) => return Ok(()),

--- a/examples/db/azuresql-component.wick
+++ b/examples/db/azuresql-component.wick
@@ -30,10 +30,7 @@ component:
           type: string
         - name: email
           type: string
-      query: INSERT INTO users(name, email) OUTPUT INSERTED.* VALUES ($1, $2)
-      arguments:
-        - name
-        - email
+      query: INSERT INTO users(name, email) OUTPUT INSERTED.* VALUES (${name}, ${email})
     - name: set_user_with_id
       inputs:
         - name: id
@@ -42,10 +39,7 @@ component:
           type: string
         - name: email
           type: string
-      query: INSERT INTO users(id, name, email) OUTPUT INSERTED.* VALUES ($1, $2, $3)
-      arguments:
-        - name
-        - email
+      query: INSERT INTO users(id, name, email) OUTPUT INSERTED.* VALUES (${id}, ${name}, ${email})
     - name: set_user_with_columns
       inputs:
         - name: input
@@ -53,3 +47,22 @@ component:
       query: INSERT INTO users(name, email) OUTPUT INSERTED.* VALUES ($1, $2)
       arguments:
         - input... # This special `spread` syntax expands the input array into individual positional arguments
+tests:
+  - with:
+      password: '{{ctx.env.TEST_PASSWORD}}'
+      host: '{{ctx.env.TEST_HOST}}'
+      port: '{{ctx.env.MSSQL_PORT}}'
+    cases:
+      - operation: set_user
+        inputs:
+          - name: name
+            value: TEST_NAME
+          - name: email
+            value: TEST_EMAIL@example.com
+        outputs:
+          - name: output
+            assertions:
+              - operator: Contains
+                value:
+                  email: TEST_EMAIL@example.com
+                  name: TEST_NAME

--- a/examples/db/sqlite-component.wick
+++ b/examples/db/sqlite-component.wick
@@ -4,17 +4,13 @@ resources:
   - name: DBADDR
     resource:
       kind: wick/resource/url@v1
-      url: postgres://postgres:{{ ctx.root_config.password }}@{{ ctx.root_config.host }}:{{ ctx.root_config.port }}/wick_test
+      url: file://{{ ctx.root_config.db_file }}
 component:
   kind: wick/component/sql@v1
   resource: DBADDR
   tls: false
   with:
-    - name: password
-      type: string
-    - name: host
-      type: string
-    - name: port
+    - name: db_file
       type: string
   operations:
     - name: get_user
@@ -38,9 +34,7 @@ component:
         - input... # This is special "spread" syntax that expands the input array into individual positional arguments
 tests:
   - with:
-      password: '{{ctx.env.TEST_PASSWORD}}'
-      host: '{{ctx.env.TEST_HOST}}'
-      port: '{{ctx.env.POSTGRES_PORT}}'
+      db_file: '{{ctx.env.SQLITE_DB}}'
     cases:
       - operation: set_user
         inputs:

--- a/examples/db/sqlite-inmemory-component.wick
+++ b/examples/db/sqlite-inmemory-component.wick
@@ -1,0 +1,63 @@
+name: my_component
+kind: wick/component@v1
+resources:
+  - name: DBADDR
+    resource:
+      kind: wick/resource/url@v1
+      url: sqlite://memory
+component:
+  kind: wick/component/sql@v1
+  resource: DBADDR
+  tls: false
+  with:
+    - name: db_file
+      type: string
+  operations:
+    - name: init
+      inputs: []
+      exec: |
+        CREATE TABLE users (
+          id INTEGER PRIMARY KEY,
+          name TEXT NOT NULL,
+          email TEXT NOT NULL
+        );
+    - name: set_user
+      inputs:
+        - name: name
+          type: string
+        - name: email
+          type: string
+      query: INSERT INTO users(name, email) VALUES (${name}, ${email}) RETURNING *
+tests:
+  - with:
+      db_file: '{{ctx.env.SQLITE_DB}}'
+    cases:
+      - operation: init
+        inputs: []
+        outputs:
+          - name: output
+            value: 0
+      - operation: set_user
+        inputs:
+          - name: name
+            value: TEST_NAME
+          - name: email
+            value: TEST_EMAIL@example.com
+        outputs:
+          - name: output
+            value:
+              email: TEST_EMAIL@example.com
+              name: TEST_NAME
+              id: 1
+      - operation: set_user
+        inputs:
+          - name: name
+            value: TEST_NAME2
+          - name: email
+            value: TEST_EMAIL2@example.com
+        outputs:
+          - name: output
+            value:
+              email: TEST_EMAIL2@example.com
+              name: TEST_NAME2
+              id: 2

--- a/tests/cli-tests/tests/cmd/db/sqlite-component.toml
+++ b/tests/cli-tests/tests/cmd/db/sqlite-component.toml
@@ -1,0 +1,16 @@
+#:schema https://raw.githubusercontent.com/assert-rs/trycmd/main/schema.json
+bin.name = "wick"
+args = [
+  "invoke",
+  "examples/db/postgres-component.wick",
+  '--with',
+  "{\"password\":\"{{ctx.env.TEST_PASSWORD}}\",\"port\":\"{{ctx.env.POSTGRES_PORT}}\",\"host\":\"{{ctx.env.TEST_HOST}}\"}",
+  "set_user",
+  "--",
+  "--name",
+  "TEST_NAME",
+  "--email",
+  "TEST_EMAIL@example.com"
+]
+stdout = """{"payload":{"value":{"email":"TEST_EMAIL@example.com","id":[..],"name":"TEST_NAME"}},"port":"output"}
+"""


### PR DESCRIPTION
This PR adds support for applying `Volume` restrictions to `Url` resources if the URL is a `file://` URL.

The only notable side effect is that SQLite DB URLs must now use the `file://` scheme vs the custom `sqlite://` scheme. This is to avoid setting the precedent of some URL schemes pointing to files internally.

This PR also adds support for SQLite in-memory databases which can be enabled with the URL `sqlite://memory` (since it's special-by-default and doesn't point to any real resource). The errors thrown in either case point the user to the right syntax when possible.