### PR TITLE
Updated rust template to default to raw codegen for now

### DIFF
--- a/crates/wick/wick-component/src/macros.rs
+++ b/crates/wick/wick-component/src/macros.rs
@@ -171,6 +171,17 @@ macro_rules! payload_fan_out {
 #[doc(hidden)]
 #[macro_export]
 macro_rules! propagate_if_error_then {
+  (($($id:ident),*), $outputs:ident, $bail:expr) => {
+    ($(
+      match $id {
+        Ok(value) => value,
+        Err(err) => {
+          $outputs.broadcast_err(err.to_string());
+          $bail;
+        }
+      },
+    )*)
+  };
   ($result:expr, $outputs:ident, $bail:expr) => {
     match $result {
       Ok(value) => value,
@@ -205,6 +216,9 @@ macro_rules! propagate_if_error_then {
 ///
 #[macro_export]
 macro_rules! propagate_if_error {
+  (($($id:ident),*), $outputs:ident, continue) => {
+    $crate::propagate_if_error_then!(($($id),*), $outputs, continue)
+  };
   ($result:expr, $outputs:ident, continue) => {
     $crate::propagate_if_error_then!($result, $outputs, continue)
   };

--- a/templates/rust/build.rs
+++ b/templates/rust/build.rs
@@ -1,5 +1,7 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
   println!("cargo:rerun-if-changed=component.wick");
-  wick_component_codegen::configure().generate("component.wick")?;
+  wick_component_codegen::configure()
+    .raw(true)
+    .generate("component.wick")?;
   Ok(())
 }

--- a/templates/rust/component.wick
+++ b/templates/rust/component.wick
@@ -18,9 +18,9 @@ component:
     - name: add
       inputs:
         - name: left
-          type: u64
+          type: int
         - name: right
-          type: u64
+          type: int
       outputs:
         - name: output
-          type: u64
+          type: int


### PR DESCRIPTION
While we redo the codegen and get rid of the build scripts, this PR updates the template to default to "raw" codegen so it's harder to fall into the substream footguns the legacy codegen had.