### PR TITLE
feat: improved output of `wick list`

### DIFF
--- a/crates/wick/flow-graph-interpreter/src/graph.rs
+++ b/crates/wick/flow-graph-interpreter/src/graph.rs
@@ -123,7 +123,7 @@ fn process_connection_expression(
     .map(|component| component.add_input(to.port().name().unwrap()));
 
   if to_port.is_none() {
-    error!("Missing downstream: instance {:?}", to);
+    error!("missing downstream: instance {:?}", to);
     return Err(GraphError::missing_downstream(to.instance().id().unwrap()));
   }
   let to_port = to_port.unwrap();

--- a/crates/wick/flow-graph-interpreter/src/interpreter/channel.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/channel.rs
@@ -148,7 +148,7 @@ impl InterpreterDispatchChannel {
 
     tokio::task::spawn(async move {
       if tx.send(event).await.is_err() {
-        warn!("Interpreter channel closed unexpectedly. This is likely due to an intentional shutdown while there are still events processing.");
+        warn!("interpreter channel closed unexpectedly. This is likely due to an intentional shutdown while there are still events processing.");
       }
     });
   }

--- a/crates/wick/flow-graph-interpreter/src/interpreter/components/core/switch.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/components/core/switch.rs
@@ -183,7 +183,7 @@ fn gen_signature(
     output_names.sort();
     output_names == default_op_names
   }) {
-    error!("The default operation and all case conditions must have the same output signature.");
+    error!("the default operation and all case conditions must have the same output signature.");
     panic!();
   }
 

--- a/crates/wick/flow-graph-interpreter/src/interpreter/program/validator.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/program/validator.rs
@@ -27,7 +27,7 @@ impl Validator {
           let component = components.get(reference.component_id());
 
           if component.is_none() {
-            error!("Missing component: {}", reference.component_id());
+            error!("missing component: {}", reference.component_id());
             validation_errors.push(ValidationError::MissingComponent(reference.component_id().to_owned()));
             continue;
           }

--- a/crates/wick/wick-component-cli/src/cli.rs
+++ b/crates/wick/wick-component-cli/src/cli.rs
@@ -69,14 +69,14 @@ pub fn print_info(info: &ServerState) {
   }
 
   if !something_started {
-    warn!("No server information available, did you intend to start a host without GRPC or a mesh connection?");
-    warn!("If not, try passing the flag --rpc or --mesh to explicitly enable those features.");
+    warn!("no server information available, did you intend to start a host without GRPC or a mesh connection?");
+    warn!("if not, try passing the flag --rpc or --mesh to explicitly enable those features.");
   }
 }
 
 /// Starts an RPC server for the passed [SharedComponent].
 pub async fn start_server(collection: SharedComponent, opts: Option<Options>) -> Result<ServerState> {
-  debug!("Starting server with options: {:?}", opts);
+  debug!("starting server with options: {:?}", opts);
 
   let opts = opts.unwrap_or_default();
 
@@ -118,7 +118,7 @@ pub async fn init_cli(collection: SharedComponent, opts: Option<Options>) -> Res
   let state = start_server(collection, opts).await?;
   print_info(&state);
 
-  info!("Waiting for ctrl-C");
+  info!("waiting for ctrl-C");
   signal::ctrl_c().await?;
   println!(); // start on a new line.
   state.stop_rpc_server().await;

--- a/crates/wick/wick-component-cli/src/cli/grpc.rs
+++ b/crates/wick/wick-component-cli/src/cli/grpc.rs
@@ -15,7 +15,7 @@ pub(super) async fn start_rpc_server(
   options: &ServerOptions,
   svc: InvocationServiceServer<InvocationServer>,
 ) -> Result<(SocketAddr, Sender<ServerMessage>)> {
-  debug!("Initializing RPC server");
+  debug!("initializing RPC server");
   let port = options.port.unwrap_or(0);
   let address = options.address.unwrap_or(Ipv4Addr::from_str("127.0.0.1")?);
 
@@ -76,13 +76,13 @@ pub(super) async fn start_rpc_server(
   let (tx, mut rx) = tokio::sync::mpsc::channel::<ServerMessage>(1);
   let server = builder.serve_with_incoming_shutdown(stream, async move {
     rx.recv().await;
-    info!("Received RPC shutdown message.");
+    info!("received RPC shutdown message.");
   });
 
   tokio::spawn(async move {
-    info!("Starting RPC server");
+    info!("starting RPC server");
     if let Err(e) = server.await {
-      error!("Error running RPC server: {}", e);
+      error!("error running RPC server: {}", e);
     };
     info!("RPC server shut down");
   });

--- a/crates/wick/wick-component-wasm/src/component.rs
+++ b/crates/wick/wick-component-wasm/src/component.rs
@@ -164,9 +164,9 @@ mod tests {
     let outputs = component
       .handle(invocation, Some(config.try_into()?), panic_callback())
       .await?;
-    debug!("Got stream");
+    debug!("got stream");
     let mut packets: Vec<_> = outputs.collect().await;
-    debug!("Output packets: {:?}", packets);
+    debug!("output packets: {:?}", packets);
 
     let output = packets.pop().unwrap().unwrap();
 
@@ -185,9 +185,9 @@ mod tests {
     let outputs = component
       .handle(invocation, Some(config.try_into()?), panic_callback())
       .await?;
-    debug!("Got stream");
+    debug!("got stream");
     let mut packets: Vec<_> = outputs.collect().await;
-    debug!("Output packets: {:?}", packets);
+    debug!("output packets: {:?}", packets);
 
     let _ = packets.pop();
     let output = packets.pop().unwrap().unwrap();
@@ -210,7 +210,7 @@ mod tests {
       .handle(invocation, Some(config.try_into()?), panic_callback())
       .await?;
     let mut packets: Vec<_> = outputs.collect().await;
-    debug!("Output packets: {:?}", packets);
+    debug!("output packets: {:?}", packets);
 
     let _ = packets.pop();
     let output = packets.pop().unwrap().unwrap();

--- a/crates/wick/wick-component/src/adapters/binary/paired_right_stream.rs
+++ b/crates/wick/wick-component/src/adapters/binary/paired_right_stream.rs
@@ -105,7 +105,7 @@ where
           outputs.broadcast_open();
           continue;
         }
-        tracing::debug!("Received open bracket while already started");
+        tracing::debug!("received open bracket while already started");
         let _ = tx.send_result(Err(Box::new(wick_packet::Error::Component(
           "Received open bracket while already started".to_owned(),
         ))));

--- a/crates/wick/wick-config/src/config/common/glob.rs
+++ b/crates/wick/wick-config/src/config/common/glob.rs
@@ -48,7 +48,7 @@ impl AssetManager for Glob {
     let entries = match glob::glob(pattern.to_str().unwrap()) {
       Ok(entries) => entries,
       Err(e) => {
-        error!("Failed to glob: {}", e);
+        error!("failed to glob: {}", e);
         panic!();
       }
     };

--- a/crates/wick/wick-invocation-server/src/invocation_server.rs
+++ b/crates/wick/wick-invocation-server/src/invocation_server.rs
@@ -139,7 +139,7 @@ impl InvocationService for InvocationServer {
       .await;
     if let Err(e) = result {
       let message = e.to_string();
-      error!("Invocation failed: {}", message);
+      error!("invocation failed: {}", message);
       tx.send(Err(Status::internal(message))).await.unwrap();
       self.record_execution(op_id, JobResult::Error, start.elapsed());
     } else {

--- a/crates/wick/wick-rpc/src/client.rs
+++ b/crates/wick/wick-rpc/src/client.rs
@@ -34,7 +34,7 @@ pub async fn make_rpc_client<T: TryInto<Uri> + Send>(
     let mut tls = ClientTlsConfig::new().identity(identity);
 
     if let Some(ca) = ca {
-      debug!("Using CA from {}", ca.to_string_lossy());
+      debug!("using CA from {}", ca.to_string_lossy());
       let ca_pem = tokio::fs::read(ca).await?;
       let ca = Certificate::from_pem(ca_pem);
       tls = tls.ca_certificate(ca);
@@ -45,7 +45,7 @@ pub async fn make_rpc_client<T: TryInto<Uri> + Send>(
 
     builder = builder.tls_config(tls).map_err(RpcClientError::TlsError)?;
   } else if let Some(ca) = ca {
-    debug!("Using CA from {}", ca.to_string_lossy());
+    debug!("using CA from {}", ca.to_string_lossy());
 
     let ca_pem = tokio::fs::read(ca).await?;
     let ca = Certificate::from_pem(ca_pem);
@@ -96,22 +96,22 @@ impl RpcClient {
 
   /// Make a request to the stats RPC method
   pub async fn stats(&mut self, request: StatsRequest) -> Result<StatsResponse, RpcClientError> {
-    debug!("Making stats request");
+    debug!("making stats request");
     let result = self
       .inner
       .stats(request)
       .await
       .map_err(RpcClientError::StatsCallFailed)?;
-    debug!("Stats result: {:?}", result);
+    debug!("stats result: {:?}", result);
     Ok(result.into_inner())
   }
 
   /// Make a request to the list RPC method
   pub async fn list(&mut self) -> Result<Vec<wick_interface_types::ComponentSignature>, RpcClientError> {
     let request = ListRequest {};
-    debug!("Making list request");
+    debug!("making list request");
     let result = self.inner.list(request).await.map_err(RpcClientError::ListCallFailed)?;
-    debug!("List result: {:?}", result);
+    debug!("list result: {:?}", result);
     let response = result.into_inner();
 
     response
@@ -127,13 +127,13 @@ impl RpcClient {
     &mut self,
     request: impl Stream<Item = InvocationRequest> + Send + Sync + 'static,
   ) -> Result<PacketStream, RpcClientError> {
-    debug!("Making invocation ");
+    debug!("making invocation ");
     let result = self
       .inner
       .invoke(request)
       .await
       .map_err(RpcClientError::InvocationFailed)?;
-    debug!("Invocation result: {:?}", result);
+    debug!("invocation result: {:?}", result);
 
     // Need to do this because tonic::decode::Decoder is not Sync and can't be turned into a PacketStream.
     let stream = convert_tonic_streaming(result.into_inner());

--- a/crates/wick/wick-runtime/src/triggers/http/routers/rest/route.rs
+++ b/crates/wick/wick-runtime/src/triggers/http/routers/rest/route.rs
@@ -108,7 +108,7 @@ impl Route {
         PathPart::Param(field) => {
           if let Some(part) = path_parts.next() {
             let Ok(value) = field.ty.coerce_str(part) else {
-              warn!("Failed to coerce {:?} to {:?}", part, field.ty);
+              warn!("failed to coerce {:?} to {:?}", part, field.ty);
               return Err(HttpError::InvalidParameter(field.name.clone()));
             };
             path_params.push(field.clone().with_value(value));
@@ -142,7 +142,7 @@ impl Route {
 
           if let Type::List { ty } = &param.ty {
             let Ok(value) = ty.coerce_str(value) else {
-              warn!("Failed to coerce {} to {} for query param {}", value, param.ty, name);
+              warn!("failed to coerce {} to {} for query param {}", value, param.ty, name);
               return Err(HttpError::InvalidParameter(param.name.clone()));
             };
 
@@ -162,7 +162,7 @@ impl Route {
           }
 
           let Ok(value) = param.ty.coerce_str(value) else {
-            warn!("Failed to coerce query param {} to {}", name, param.ty);
+            warn!("failed to coerce query param {} to {}", name, param.ty);
             return Err(HttpError::InvalidParameter(param.name.clone()));
           };
 

--- a/crates/wick/wick-runtime/src/triggers/time.rs
+++ b/crates/wick/wick-runtime/src/triggers/time.rs
@@ -96,7 +96,7 @@ async fn create_schedule(
       tokio::spawn(async move {
         let fut = invoke_operation(rt, target, payload, &job_span);
         if let Err(e) = fut.await {
-          job_span.in_scope(|| error!("Error invoking operation: {}", e));
+          job_span.in_scope(|| error!("error invoking operation: {}", e));
           let _ = fail_tx.send(()).await;
         }
       });

--- a/crates/wick/wick-runtime/tests/utils/mod.rs
+++ b/crates/wick/wick-runtime/tests/utils/mod.rs
@@ -20,7 +20,7 @@ pub async fn init_engine_from_yaml(
   let mut host_def = WickConfiguration::fetch(path.as_ref(), Default::default()).await?;
   host_def.set_root_config(config);
   let host_def = host_def.finish()?.try_component_config()?;
-  debug!("Manifest loaded");
+  debug!("manifest loaded");
 
   let builder = RuntimeBuilder::from_definition(host_def).namespace("__TEST__");
 

--- a/src/commands/config/dot.rs
+++ b/src/commands/config/dot.rs
@@ -33,7 +33,7 @@ pub(crate) async fn handle(
   settings: wick_settings::Settings,
   span: tracing::Span,
 ) -> Result<StructuredOutput> {
-  span.in_scope(|| debug!("Generate dotviz graph"));
+  span.in_scope(|| debug!("generate dotviz graph"));
   let configured_creds = settings
     .credentials
     .iter()

--- a/src/commands/key/gen.rs
+++ b/src/commands/key/gen.rs
@@ -25,7 +25,7 @@ pub(crate) async fn handle(
   span: tracing::Span,
 ) -> Result<StructuredOutput> {
   let _enter = span.enter();
-  debug!("Generating {} key", crate::keys::keypair_type_to_string(&opts.keytype));
+  debug!("generating {} key", crate::keys::keypair_type_to_string(&opts.keytype));
 
   let kp = KeyPair::new(opts.keytype);
 

--- a/src/commands/key/list.rs
+++ b/src/commands/key/list.rs
@@ -23,9 +23,9 @@ pub(crate) async fn handle(
   span: tracing::Span,
 ) -> Result<StructuredOutput> {
   let _enter = span.enter();
-  debug!("Listing keys");
+  debug!("listing keys");
   let (dir, keys) = get_key_files(opts.directory)?;
-  info!("Listing keys in {}", dir.to_string_lossy());
+  info!("listing keys in {}", dir.to_string_lossy());
 
   let json = json!({"keys":keys});
 

--- a/src/commands/list.rs
+++ b/src/commands/list.rs
@@ -73,7 +73,7 @@ fn write_line(mut buff: impl Write, op: &OperationSignature) -> std::fmt::Result
 
 fn config(config: &[Field]) -> String {
   if config.is_empty() {
-    return String::new();
+    String::new()
   } else {
     format!(
       "with: {{ {} }}",

--- a/src/commands/new/app.rs
+++ b/src/commands/new/app.rs
@@ -45,7 +45,7 @@ pub(crate) async fn handle(
   span: tracing::Span,
 ) -> Result<StructuredOutput> {
   let files: Result<Vec<File>> = span.in_scope(|| {
-    info!("Initializing wick application: {}", opts.name);
+    info!("initializing wick application: {}", opts.name);
     let mut config = AppConfiguration::default();
     config.set_name(opts.name);
     config.set_metadata(crate::commands::new::generic_metadata("New wick application"));

--- a/src/commands/new/component/composite.rs
+++ b/src/commands/new/component/composite.rs
@@ -36,7 +36,7 @@ pub(crate) async fn handle(
     let mut component = CompositeComponentImplementation::default();
     component.operations_mut().push(
       FlowOperationBuilder::default()
-        .name("operation_name")
+        .name("echo")
         .expressions(vec!["<>.input -> <>.output".parse().unwrap()])
         .inputs(vec![Field::new("input", Type::Object)])
         .outputs(vec![Field::new("output", Type::Object)])

--- a/src/commands/new/component/composite.rs
+++ b/src/commands/new/component/composite.rs
@@ -27,7 +27,7 @@ pub(crate) async fn handle(
   let _span = span.enter();
   let name = crate::commands::new::sanitize_name(&opts.name);
   let files: Result<Vec<File>> = span.in_scope(|| {
-    info!("Initializing wick http component: {}", name);
+    info!("initializing wick composite component: {}", name);
 
     let mut config = ComponentConfiguration::default();
     config.set_name(name.clone());

--- a/src/commands/new/component/composite.rs
+++ b/src/commands/new/component/composite.rs
@@ -3,6 +3,7 @@ use clap::Args;
 use structured_output::StructuredOutput;
 use wick_config::config::components::ComponentConfig;
 use wick_config::config::{self, ComponentConfiguration, CompositeComponentImplementation, FlowOperationBuilder};
+use wick_interface_types::{Field, Type};
 
 use crate::io::File;
 
@@ -37,6 +38,8 @@ pub(crate) async fn handle(
       FlowOperationBuilder::default()
         .name("operation_name")
         .expressions(vec!["<>.input -> <>.output".parse().unwrap()])
+        .inputs(vec![Field::new("input", Type::Object)])
+        .outputs(vec![Field::new("output", Type::Object)])
         .build()
         .unwrap(),
     );

--- a/src/commands/new/component/http.rs
+++ b/src/commands/new/component/http.rs
@@ -45,7 +45,7 @@ pub(crate) async fn handle(
       .codec(Codec::Json)
       .resource(resource_name)
       .operations([HttpClientOperationDefinitionBuilder::default()
-        .name("operation_name".to_owned())
+        .name("example_request".to_owned())
         .method(config::HttpMethod::Get)
         .path("/user/{id:string}".to_owned())
         .inputs([Field::new("id", Type::String)])

--- a/src/commands/new/component/http.rs
+++ b/src/commands/new/component/http.rs
@@ -27,7 +27,7 @@ pub(crate) async fn handle(
   let _span = span.enter();
   let name = crate::commands::new::sanitize_name(&opts.name);
   let files: Result<Vec<File>> = span.in_scope(|| {
-    info!("Initializing wick http component: {}", name);
+    info!("initializing wick http component: {}", name);
 
     let resource_name = "HTTP_URL";
 

--- a/src/commands/new/component/sql.rs
+++ b/src/commands/new/component/sql.rs
@@ -27,7 +27,7 @@ pub(crate) async fn handle(
   let _span = span.enter();
   let name = crate::commands::new::sanitize_name(&opts.name);
   let files: Result<Vec<File>> = span.in_scope(|| {
-    info!("Initializing wick sql db component: {}", name);
+    info!("initializing wick sql component: {}", name);
 
     let mut config = ComponentConfiguration::default();
     config.set_name(name.clone());

--- a/src/commands/new/component/sql.rs
+++ b/src/commands/new/component/sql.rs
@@ -45,7 +45,7 @@ pub(crate) async fn handle(
       .resource(resource_name)
       .operations([SqlOperationKind::Query(
         SqlOperationDefinitionBuilder::default()
-          .name("operation_name".to_owned())
+          .name("example_query".to_owned())
           .inputs([Field::new("id", Type::String)])
           .query("SELECT * FROM users WHERE id = $1".to_owned())
           .arguments(["id".to_owned()])

--- a/src/commands/new/component/wasmrs.rs
+++ b/src/commands/new/component/wasmrs.rs
@@ -56,7 +56,7 @@ pub(crate) async fn handle(
       .reference(AssetReference::new(format!("./build/{}", &name)))
       .operations([
         OperationDefinitionBuilder::default()
-          .name("operation_name".to_owned())
+          .name("my_operation".to_owned())
           .inputs([Field::new("id", Type::String)])
           .outputs([Field::new("output", Type::Named("user_object".to_owned()))])
           .build()

--- a/src/commands/new/component/wasmrs.rs
+++ b/src/commands/new/component/wasmrs.rs
@@ -33,8 +33,8 @@ pub(crate) async fn handle(
   let name = crate::commands::new::sanitize_name(&opts.name);
 
   let files: Result<Vec<File>> = span.in_scope(|| {
-    info!("Initializing wick http component: {}", name);
-    info!("Note: WebAssembly components are often better suited by cloning a boilerplate project. See https://github.com/candlecorp/wick for directions.");
+    info!("initializing wick wasmrs component: {}", name);
+    info!("note: WebAssembly components are often better suited by cloning a boilerplate project. See https://github.com/candlecorp/wick for directions.");
 
     let mut config = ComponentConfiguration::default();
     config.set_name(name.clone());

--- a/src/commands/query.rs
+++ b/src/commands/query.rs
@@ -90,7 +90,7 @@ pub(crate) async fn handle(
 
   if !errors.is_empty() {
     for error in errors {
-      error!("Error parsing query: {}", error);
+      error!("error parsing query: {}", error);
     }
     return Err(anyhow!("Errors parsing queries"));
   }
@@ -127,11 +127,11 @@ pub(crate) async fn handle(
 
           json.push(result);
         }
-        Err(e) => error!("Error: {}", e),
+        Err(e) => error!("error: {}", e),
       };
     }
   } else {
-    debug!("No queries successfully parsed");
+    debug!("no queries successfully parsed");
   }
 
   Ok(StructuredOutput::new(lines.join("\n"), json!({"results":json})))

--- a/src/commands/registry/push.rs
+++ b/src/commands/registry/push.rs
@@ -33,14 +33,14 @@ pub(crate) async fn handle(
   settings: wick_settings::Settings,
   span: tracing::Span,
 ) -> Result<StructuredOutput> {
-  span.in_scope(|| debug!("Push artifact"));
+  span.in_scope(|| debug!("push artifact"));
 
   let mut package = wick_package::WickPackage::from_path(&opts.source)
     .instrument(span.clone())
     .await?;
 
   let Some(registry) = package.registry_mut() else {
-    span.in_scope(|| error!("No registry provided in package"));
+    span.in_scope(|| error!("no registry provided in package"));
     return Err(anyhow!("No registry provided in package"));
   };
 

--- a/src/commands/run.rs
+++ b/src/commands/run.rs
@@ -72,7 +72,7 @@ pub(crate) async fn handle(
 
   if !opts.dryrun {
     host.start()?;
-    span.in_scope(|| debug!("Waiting on triggers to finish..."));
+    span.in_scope(|| debug!("waiting on triggers to finish..."));
 
     host.wait_for_done().instrument(span.clone()).await?;
   } else {

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -39,19 +39,19 @@ pub(crate) async fn handle(
   let mut host = ComponentHostBuilder::default().manifest(config).span(span).build()?;
 
   host.start(None).await?;
-  info!("Host started");
+  info!("host started");
   #[allow(clippy::option_if_let_else)]
   match host.get_server_info() {
     Some(info) => {
       wick_component_cli::print_info(info);
     }
     None => {
-      warn!("No server information available, did you intend to start a host without GRPC or a mesh connection?");
+      warn!("no server information available, did you intend to start a host without GRPC or a mesh connection?");
     }
   };
-  info!("Waiting for Ctrl-C");
+  info!("waiting for Ctrl-C");
   let _ = tokio::signal::ctrl_c().await;
-  info!("Ctrl-C received, shutting down");
+  info!("ctrl-C received, shutting down");
   host.stop().await;
   Ok(StructuredOutput::new("", json!({})))
 }

--- a/src/commands/wasm/sign.rs
+++ b/src/commands/wasm/sign.rs
@@ -42,8 +42,8 @@ pub(crate) async fn handle(
   span: tracing::Span,
 ) -> Result<StructuredOutput> {
   span.in_scope(|| {
-    debug!("Signing module");
-    debug!("Reading from {}", opts.interface);
+    debug!("signing module");
+    debug!("reading from {}", opts.interface);
   });
 
   let interface = WickConfiguration::fetch(&opts.interface, wick_config::FetchOptions::default())
@@ -99,13 +99,13 @@ pub(crate) async fn handle(
       }
     }
   };
-  span.in_scope(|| debug!("Destination : {}", destination));
+  span.in_scope(|| debug!("destination : {}", destination));
 
   let mut outfile = File::create(&destination).unwrap();
 
   span.in_scope(|| match outfile.write(&signed) {
     Ok(_) => {
-      info!("Successfully signed {}", destination,);
+      info!("successfully signed {}", destination,);
       Ok(StructuredOutput::new(
         format!("Successfully signed: {}", destination),
         json!({

--- a/src/io.rs
+++ b/src/io.rs
@@ -76,11 +76,11 @@ pub(crate) async fn init_files(files: &[File], dry_run: bool) -> Result<Structur
   }
 
   for file in files {
-    info!("Writing file: {}", file.path.display());
+    info!(file = %file.path.display(), "writing file");
 
     if dry_run {
       info!(
-        "Dry run: not writing {} bytes to {}",
+        "dry run: not writing {} bytes to {}",
         file.contents.len(),
         file.path.display()
       );

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -111,7 +111,7 @@ pub(crate) async fn get_or_create(
   let seed = match read_to_string(&path).await {
     Ok(seed) => seed,
     Err(_e) => {
-      info!("No keypair found at \"{}\". Generating new keypair.", path);
+      info!("no keypair found at \"{}\". Generating new keypair.", path);
 
       let kp = KeyPair::new(kp_type);
       let seed = kp.seed()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -220,11 +220,11 @@ async fn async_start() -> Result<(GlobalOptions, StructuredOutput), (GlobalOptio
 
   let res = span.in_scope(|| match res {
     Ok(output) => {
-      debug!("Done");
+      debug!("done");
       Ok((options, output))
     }
     Err(e) => {
-      error!("Error: {}", e);
+      error!("error: {}", e);
       Err((options, anyhow!("{}", e)))
     }
   });

--- a/src/oci.rs
+++ b/src/oci.rs
@@ -6,14 +6,14 @@ pub(crate) async fn pull(
     Ok(pull_result) => pull_result,
     Err(e) => {
       if let wick_package::Error::Oci(wick_oci_utils::error::OciError::WouldOverwrite(files)) = &e {
-        warn!("Pulling {} will overwrite the following files", &reference);
+        warn!("pulling {} will overwrite the following files", &reference);
         for file in files {
           warn!("{}", file.display());
         }
-        error!("Refusing to overwrite files, pass --force to ignore.");
+        error!("refusing to overwrite files, pass --force to ignore.");
         return Err(anyhow!("Pull failed"));
       }
-      error!("Failed to pull {}: {}", &reference, e);
+      error!("failed to pull {}: {}", &reference, e);
       return Err(anyhow!("Pull failed"));
     }
   };


### PR DESCRIPTION
This PR improves the output of `wick list` which hasn't gotten much love in a while and doesn't support outputting any configuration information.

Old output:

```console
Component: operation_name(input: object) -> (output: object)
```

```console
Components:
  └─ my_component with: { some_value: string }
     └─ operation_name (input: object): (output: object) with: { op_config_value: i64 }
```

Note: this PR also re-adds `Cargo.lock` to git which is required for CI cache and wasn't the source of cargo publish problems after all.
