### PR TITLE
Fixed config template rendering for ops defined in triggers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ crates/wick-rpc/src/generated/wick.rs
 crates/**/src/generated/mod.rs
 /crates/integration/*/build
 docs/static/rustdoc/
+/dump
 
 # Test & scratch files
 .wick-test.sqlite3.db

--- a/crates/components/wick-http-client/src/component.rs
+++ b/crates/components/wick-http-client/src/component.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use flow_component::{BoxFuture, Component, ComponentError, RuntimeCallback};
+use flow_component::{BoxFuture, Component, ComponentError, IntoComponentResult, RuntimeCallback};
 use futures::{Stream, StreamExt, TryStreamExt};
 use reqwest::header::CONTENT_TYPE;
 use reqwest::{ClientBuilder, Method, Request, RequestBuilder};
@@ -44,8 +44,8 @@ impl HttpClientComponent {
     validate(&config, resolver)?;
     let addr: UrlResource = resolver(config.resource())
       .and_then(|r| r.try_resource())
-      .map_err(ComponentError::new)?
-      .into();
+      .and_then(|r| r.try_url())
+      .into_component_error()?;
 
     let mut sig = ComponentSignature::new("wick/component/http");
     sig.metadata.version = metadata.map(|v| v.version().to_owned());

--- a/crates/components/wick-sql/src/common.rs
+++ b/crates/components/wick-sql/src/common.rs
@@ -38,7 +38,7 @@ pub(crate) fn gen_signature(
 pub(crate) fn convert_url_resource(resolver: &Resolver, id: &str) -> Result<Url> {
   let addr = resolver(id).and_then(|r| r.try_resource())?;
 
-  let resource: UrlResource = addr.into();
+  let resource: UrlResource = addr.try_into()?;
   resource.url().value().cloned().ok_or(Error::InvalidResourceConfig)
 }
 

--- a/crates/components/wick-sql/src/mssql_tiberius/component.rs
+++ b/crates/components/wick-sql/src/mssql_tiberius/component.rs
@@ -215,7 +215,11 @@ fn row_to_json(row: &Row) -> Value {
 #[cfg(test)]
 mod test {
   use anyhow::Result;
-  use wick_config::config::components::{SqlComponentConfigBuilder, SqlOperationDefinitionBuilder, SqlOperationKind};
+  use wick_config::config::components::{
+    SqlComponentConfigBuilder,
+    SqlOperationDefinition,
+    SqlQueryOperationDefinitionBuilder,
+  };
   use wick_config::config::{ResourceDefinition, TcpPort};
   use wick_interface_types::{Field, Type};
 
@@ -234,7 +238,7 @@ mod test {
       .tls(false)
       .build()
       .unwrap();
-    let op = SqlOperationDefinitionBuilder::default()
+    let op = SqlQueryOperationDefinitionBuilder::default()
       .name("test")
       .query("select * from users where user_id = $1;")
       .inputs([Field::new("input", Type::I32)])
@@ -243,7 +247,7 @@ mod test {
       .build()
       .unwrap();
 
-    config.operations_mut().push(SqlOperationKind::Query(op));
+    config.operations_mut().push(SqlOperationDefinition::Query(op));
     let mut app_config = wick_config::config::AppConfiguration::default();
     app_config.add_resource("db", ResourceDefinition::TcpPort(TcpPort::new("0.0.0.0", 11111)));
 

--- a/crates/components/wick-sql/src/sqlx/component.rs
+++ b/crates/components/wick-sql/src/sqlx/component.rs
@@ -221,7 +221,11 @@ async fn init_context(config: &SqlComponentConfig, addr: &Url) -> Result<Context
 #[cfg(test)]
 mod test {
   use anyhow::Result;
-  use wick_config::config::components::{SqlComponentConfigBuilder, SqlOperationDefinitionBuilder, SqlOperationKind};
+  use wick_config::config::components::{
+    SqlComponentConfigBuilder,
+    SqlOperationDefinition,
+    SqlQueryOperationDefinitionBuilder,
+  };
   use wick_config::config::{ResourceDefinition, TcpPort};
   use wick_interface_types::{Field, Type};
 
@@ -240,7 +244,7 @@ mod test {
       .tls(false)
       .build()
       .unwrap();
-    let op = SqlOperationDefinitionBuilder::default()
+    let op = SqlQueryOperationDefinitionBuilder::default()
       .name("test")
       .query("select * from users where user_id = $1;")
       .inputs([Field::new("input", Type::I32)])
@@ -249,7 +253,7 @@ mod test {
       .build()
       .unwrap();
 
-    config.operations_mut().push(SqlOperationKind::Query(op));
+    config.operations_mut().push(SqlOperationDefinition::Query(op));
     let mut app_config = wick_config::config::AppConfiguration::default();
     app_config.add_resource("db", ResourceDefinition::TcpPort(TcpPort::new("0.0.0.0", 11111)));
 

--- a/crates/wick/flow-component/src/lib.rs
+++ b/crates/wick/flow-component/src/lib.rs
@@ -109,6 +109,7 @@ pub use serde_json::Value;
 pub struct ComponentError {
   source: Box<dyn std::error::Error + Send + Sync>,
 }
+
 impl std::error::Error for ComponentError {}
 impl std::fmt::Display for ComponentError {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -139,6 +140,24 @@ impl From<Box<dyn std::error::Error + Send + Sync>> for ComponentError {
 impl From<anyhow::Error> for ComponentError {
   fn from(source: anyhow::Error) -> Self {
     Self::message(&source.to_string())
+  }
+}
+
+/// Trait that allows for conversion of a result into a component error.
+pub trait IntoComponentResult<T, E>
+where
+  E: std::error::Error + Send + Sync + 'static,
+{
+  /// Convert a Result<T,E> into a Result<T, ComponentError>.
+  fn into_component_error(self) -> Result<T, ComponentError>;
+}
+
+impl<T, E> IntoComponentResult<T, E> for Result<T, E>
+where
+  E: std::error::Error + Send + Sync + 'static,
+{
+  fn into_component_error(self) -> Result<T, ComponentError> {
+    self.map_err(ComponentError::new)
   }
 }
 

--- a/crates/wick/wick-config/src/config/app_config/triggers.rs
+++ b/crates/wick/wick-config/src/config/app_config/triggers.rs
@@ -1,15 +1,57 @@
-use serde_json::Value;
+use std::collections::HashMap;
 
-use crate::config::*;
+use serde_json::Value;
+use wick_asset_reference::AssetReference;
+use wick_packet::RuntimeConfig;
+
 use crate::error::ManifestError;
 use crate::ExpandImports;
 mod cli;
 mod http;
 mod time;
 
-pub use cli::*;
-pub use http::*;
-pub use time::*;
+pub use cli::{CliConfig, CliConfigBuilder, CliConfigBuilderError};
+pub use http::{
+  Contact,
+  Documentation,
+  HttpRouterConfig,
+  HttpRouterKind,
+  HttpTriggerConfig,
+  HttpTriggerConfigBuilder,
+  HttpTriggerConfigBuilderError,
+  Info,
+  License,
+  Middleware,
+  MiddlewareBuilder,
+  MiddlewareBuilderError,
+  ProxyRouterConfig,
+  ProxyRouterConfigBuilder,
+  ProxyRouterConfigBuilderError,
+  RawRouterConfig,
+  RawRouterConfigBuilder,
+  RawRouterConfigBuilderError,
+  RestRoute,
+  RestRouterConfig,
+  RestRouterConfigBuilder,
+  RestRouterConfigBuilderError,
+  StaticRouterConfig,
+  StaticRouterConfigBuilder,
+  StaticRouterConfigBuilderError,
+  Tools,
+  WickRouter,
+};
+pub use time::{
+  ScheduleConfig,
+  ScheduleConfigBuilder,
+  ScheduleConfigBuilderError,
+  TimeTriggerConfig,
+  TimeTriggerConfigBuilder,
+  TimeTriggerConfigBuilderError,
+};
+
+use self::common::template_config::Renderable;
+use self::common::ImportBinding;
+use crate::config::common;
 
 #[derive(Debug, Clone, derive_asset_container::AssetManager, serde::Serialize)]
 #[asset(asset(AssetReference))]
@@ -32,6 +74,20 @@ impl TriggerDefinition {
       TriggerDefinition::Cli(_) => TriggerKind::Cli,
       TriggerDefinition::Http(_) => TriggerKind::Http,
       TriggerDefinition::Time(_) => TriggerKind::Time,
+    }
+  }
+}
+
+impl Renderable for TriggerDefinition {
+  fn render_config(
+    &mut self,
+    root_config: Option<&RuntimeConfig>,
+    env: Option<&HashMap<String, String>>,
+  ) -> Result<(), ManifestError> {
+    match self {
+      TriggerDefinition::Cli(v) => v.render_config(root_config, env),
+      TriggerDefinition::Http(v) => v.render_config(root_config, env),
+      TriggerDefinition::Time(v) => v.render_config(root_config, env),
     }
   }
 }

--- a/crates/wick/wick-config/src/config/app_config/triggers/cli.rs
+++ b/crates/wick/wick-config/src/config/app_config/triggers/cli.rs
@@ -1,5 +1,9 @@
-use wick_asset_reference::AssetReference;
+use std::collections::HashMap;
 
+use wick_asset_reference::AssetReference;
+use wick_packet::RuntimeConfig;
+
+use crate::config::template_config::Renderable;
 use crate::config::{ComponentOperationExpression, ImportBinding};
 use crate::error::ManifestError;
 use crate::ExpandImports;
@@ -28,5 +32,15 @@ impl ExpandImports for CliConfig {
     let id = format!("trigger_{}", trigger_index);
     self.operation_mut().maybe_import(&id, bindings);
     Ok(())
+  }
+}
+
+impl Renderable for CliConfig {
+  fn render_config(
+    &mut self,
+    root_config: Option<&RuntimeConfig>,
+    env: Option<&HashMap<String, String>>,
+  ) -> Result<(), ManifestError> {
+    self.operation.render_config(root_config, env)
   }
 }

--- a/crates/wick/wick-config/src/config/app_config/triggers/http.rs
+++ b/crates/wick/wick-config/src/config/app_config/triggers/http.rs
@@ -1,10 +1,24 @@
-pub use middleware::Middleware;
-use wick_asset_reference::AssetReference;
+use std::collections::HashMap;
 
-pub use self::proxy_router::ProxyRouterConfig;
-pub use self::raw_router::RawRouterConfig;
-pub use self::rest_router::{Contact, Documentation, Info, License, RestRoute, RestRouterConfig, Tools};
-pub use self::static_router::StaticRouterConfig;
+pub use middleware::{Middleware, MiddlewareBuilder, MiddlewareBuilderError};
+use wick_asset_reference::AssetReference;
+use wick_packet::RuntimeConfig;
+
+pub use self::proxy_router::{ProxyRouterConfig, ProxyRouterConfigBuilder, ProxyRouterConfigBuilderError};
+pub use self::raw_router::{RawRouterConfig, RawRouterConfigBuilder, RawRouterConfigBuilderError};
+pub use self::rest_router::{
+  Contact,
+  Documentation,
+  Info,
+  License,
+  RestRoute,
+  RestRouterConfig,
+  RestRouterConfigBuilder,
+  RestRouterConfigBuilderError,
+  Tools,
+};
+pub use self::static_router::{StaticRouterConfig, StaticRouterConfigBuilder, StaticRouterConfigBuilderError};
+use crate::config::common::template_config::Renderable;
 use crate::config::ImportBinding;
 use crate::error::ManifestError;
 use crate::ExpandImports;
@@ -42,6 +56,31 @@ pub enum HttpRouterConfig {
   RestRouter(RestRouterConfig),
   StaticRouter(StaticRouterConfig),
   ProxyRouter(ProxyRouterConfig),
+}
+
+impl Renderable for HttpRouterConfig {
+  fn render_config(
+    &mut self,
+    root_config: Option<&RuntimeConfig>,
+    env: Option<&HashMap<String, String>>,
+  ) -> Result<(), ManifestError> {
+    match self {
+      HttpRouterConfig::RawRouter(v) => v.render_config(root_config, env),
+      HttpRouterConfig::RestRouter(v) => v.render_config(root_config, env),
+      HttpRouterConfig::StaticRouter(v) => v.render_config(root_config, env),
+      HttpRouterConfig::ProxyRouter(v) => v.render_config(root_config, env),
+    }
+  }
+}
+
+impl Renderable for HttpTriggerConfig {
+  fn render_config(
+    &mut self,
+    root_config: Option<&RuntimeConfig>,
+    env: Option<&HashMap<String, String>>,
+  ) -> Result<(), ManifestError> {
+    self.routers.render_config(root_config, env)
+  }
 }
 
 impl ExpandImports for HttpTriggerConfig {

--- a/crates/wick/wick-config/src/config/app_config/triggers/http/middleware.rs
+++ b/crates/wick/wick-config/src/config/app_config/triggers/http/middleware.rs
@@ -1,8 +1,21 @@
+use std::collections::HashMap;
+
+use wick_packet::RuntimeConfig;
+
 use super::WickRouter;
+use crate::config::template_config::Renderable;
 use crate::config::{self, ComponentOperationExpression, ImportBinding};
 use crate::error::ManifestError;
 
-#[derive(Debug, Clone, PartialEq, derive_asset_container::AssetManager, property::Property, serde::Serialize)]
+#[derive(
+  Debug,
+  Clone,
+  derive_builder::Builder,
+  PartialEq,
+  derive_asset_container::AssetManager,
+  property::Property,
+  serde::Serialize,
+)]
 #[property(get(public), set(private), mut(public, suffix = "_mut"))]
 #[asset(asset(config::AssetReference))]
 /// Request and response operations that run before and after the main operation.
@@ -13,6 +26,17 @@ pub struct Middleware {
   /// The middleware to apply to responses.
   #[serde(skip_serializing_if = "Vec::is_empty")]
   pub(crate) response: Vec<ComponentOperationExpression>,
+}
+
+impl Renderable for Middleware {
+  fn render_config(
+    &mut self,
+    root_config: Option<&RuntimeConfig>,
+    env: Option<&HashMap<String, String>>,
+  ) -> Result<(), ManifestError> {
+    self.request.render_config(root_config, env)?;
+    self.response.render_config(root_config, env)
+  }
 }
 
 pub(super) fn expand_for_middleware_components(

--- a/crates/wick/wick-config/src/config/app_config/triggers/http/proxy_router.rs
+++ b/crates/wick/wick-config/src/config/app_config/triggers/http/proxy_router.rs
@@ -1,11 +1,17 @@
+use std::collections::HashMap;
+
 use wick_asset_reference::AssetReference;
+use wick_packet::RuntimeConfig;
 
 use super::index_to_router_id;
 use super::middleware::expand_for_middleware_components;
+use crate::config::template_config::Renderable;
 use crate::config::{self, ImportBinding};
 use crate::error::ManifestError;
 
-#[derive(Debug, Clone, derive_asset_container::AssetManager, property::Property, serde::Serialize)]
+#[derive(
+  Debug, Clone, derive_builder::Builder, derive_asset_container::AssetManager, property::Property, serde::Serialize,
+)]
 #[asset(asset(AssetReference))]
 #[property(get(public), set(private), mut(disable))]
 
@@ -24,6 +30,16 @@ pub struct ProxyRouterConfig {
   /// Whether or not to strip the router's path from the proxied request.
   #[asset(skip)]
   pub(crate) strip_path: bool,
+}
+
+impl Renderable for ProxyRouterConfig {
+  fn render_config(
+    &mut self,
+    root_config: Option<&RuntimeConfig>,
+    env: Option<&HashMap<String, String>>,
+  ) -> Result<(), ManifestError> {
+    self.middleware.render_config(root_config, env)
+  }
 }
 
 impl super::WickRouter for ProxyRouterConfig {

--- a/crates/wick/wick-config/src/config/app_config/triggers/http/raw_router.rs
+++ b/crates/wick/wick-config/src/config/app_config/triggers/http/raw_router.rs
@@ -1,11 +1,17 @@
+use std::collections::HashMap;
+
 use wick_asset_reference::AssetReference;
+use wick_packet::RuntimeConfig;
 
 use super::index_to_router_id;
 use super::middleware::expand_for_middleware_components;
+use crate::config::template_config::Renderable;
 use crate::config::{self, ComponentOperationExpression, ImportBinding};
 use crate::error::ManifestError;
 
-#[derive(Debug, Clone, derive_asset_container::AssetManager, property::Property, serde::Serialize)]
+#[derive(
+  Debug, Clone, derive_builder::Builder, derive_asset_container::AssetManager, property::Property, serde::Serialize,
+)]
 #[asset(asset(AssetReference))]
 #[property(get(public), set(private), mut(public, suffix = "_mut"))]
 #[must_use]
@@ -34,6 +40,17 @@ impl super::WickRouter for RawRouterConfig {
 
   fn path(&self) -> &str {
     &self.path
+  }
+}
+
+impl Renderable for RawRouterConfig {
+  fn render_config(
+    &mut self,
+    root_config: Option<&RuntimeConfig>,
+    env: Option<&HashMap<String, String>>,
+  ) -> Result<(), ManifestError> {
+    self.operation.render_config(root_config, env)?;
+    self.middleware.render_config(root_config, env)
   }
 }
 

--- a/crates/wick/wick-config/src/config/app_config/triggers/http/rest_router.rs
+++ b/crates/wick/wick-config/src/config/app_config/triggers/http/rest_router.rs
@@ -1,12 +1,24 @@
+use std::collections::HashMap;
+
 use wick_asset_reference::AssetReference;
+use wick_packet::RuntimeConfig;
 
 use super::index_to_router_id;
 use super::middleware::expand_for_middleware_components;
 use crate::config::common::HttpMethod;
+use crate::config::template_config::Renderable;
 use crate::config::{self, ComponentOperationExpression, ImportBinding};
 use crate::error::ManifestError;
 
-#[derive(Debug, Clone, PartialEq, derive_asset_container::AssetManager, property::Property, serde::Serialize)]
+#[derive(
+  Debug,
+  Clone,
+  PartialEq,
+  derive_builder::Builder,
+  derive_asset_container::AssetManager,
+  property::Property,
+  serde::Serialize,
+)]
 #[asset(asset(AssetReference))]
 #[property(get(public), set(private), mut(public, suffix = "_mut"))]
 pub struct RestRouterConfig {
@@ -29,6 +41,27 @@ pub struct RestRouterConfig {
   #[asset(skip)]
   #[serde(skip_serializing_if = "Option::is_none")]
   pub(crate) info: Option<Info>,
+}
+
+impl Renderable for RestRouterConfig {
+  fn render_config(
+    &mut self,
+    root_config: Option<&RuntimeConfig>,
+    env: Option<&HashMap<String, String>>,
+  ) -> Result<(), ManifestError> {
+    self.middleware.render_config(root_config, env)?;
+    self.routes.render_config(root_config, env)
+  }
+}
+
+impl Renderable for RestRoute {
+  fn render_config(
+    &mut self,
+    root_config: Option<&RuntimeConfig>,
+    env: Option<&HashMap<String, String>>,
+  ) -> Result<(), ManifestError> {
+    self.operation.render_config(root_config, env)
+  }
 }
 
 impl super::WickRouter for RestRouterConfig {
@@ -116,7 +149,15 @@ pub struct Contact {
   pub(crate) email: Option<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, derive_asset_container::AssetManager, property::Property, serde::Serialize)]
+#[derive(
+  Debug,
+  Clone,
+  PartialEq,
+  derive_builder::Builder,
+  derive_asset_container::AssetManager,
+  property::Property,
+  serde::Serialize,
+)]
 #[asset(asset(AssetReference))]
 #[property(get(public), set(private), mut(public, suffix = "_mut"))]
 /// A route to serve and the operation that handles it.

--- a/crates/wick/wick-config/src/config/app_config/triggers/http/static_router.rs
+++ b/crates/wick/wick-config/src/config/app_config/triggers/http/static_router.rs
@@ -1,11 +1,17 @@
+use std::collections::HashMap;
+
 use wick_asset_reference::AssetReference;
+use wick_packet::RuntimeConfig;
 
 use super::index_to_router_id;
 use super::middleware::expand_for_middleware_components;
+use crate::config::template_config::Renderable;
 use crate::config::{self, ImportBinding};
 use crate::error::ManifestError;
 
-#[derive(Debug, Clone, derive_asset_container::AssetManager, property::Property, serde::Serialize)]
+#[derive(
+  Debug, Clone, derive_builder::Builder, derive_asset_container::AssetManager, property::Property, serde::Serialize,
+)]
 #[asset(asset(AssetReference))]
 #[property(get(public), set(private), mut(disable))]
 #[must_use]
@@ -35,6 +41,16 @@ impl super::WickRouter for StaticRouterConfig {
 
   fn path(&self) -> &str {
     &self.path
+  }
+}
+
+impl Renderable for StaticRouterConfig {
+  fn render_config(
+    &mut self,
+    root_config: Option<&RuntimeConfig>,
+    env: Option<&HashMap<String, String>>,
+  ) -> Result<(), ManifestError> {
+    self.middleware.render_config(root_config, env)
   }
 }
 

--- a/crates/wick/wick-config/src/config/app_config/triggers/time.rs
+++ b/crates/wick/wick-config/src/config/app_config/triggers/time.rs
@@ -1,6 +1,10 @@
+use std::collections::HashMap;
+
 use wick_asset_reference::AssetReference;
+use wick_packet::RuntimeConfig;
 
 use super::OperationInputConfig;
+use crate::config::template_config::Renderable;
 use crate::config::{ComponentOperationExpression, ImportBinding};
 use crate::error::ManifestError;
 use crate::ExpandImports;
@@ -25,6 +29,16 @@ pub struct TimeTriggerConfig {
   #[builder(default)]
   #[serde(skip_serializing_if = "Vec::is_empty")]
   pub(crate) payload: Vec<OperationInputConfig>,
+}
+
+impl Renderable for TimeTriggerConfig {
+  fn render_config(
+    &mut self,
+    root_config: Option<&RuntimeConfig>,
+    env: Option<&HashMap<String, String>>,
+  ) -> Result<(), ManifestError> {
+    self.operation.render_config(root_config, env)
+  }
 }
 
 #[derive(

--- a/crates/wick/wick-config/src/config/common/bindings.rs
+++ b/crates/wick/wick-config/src/config/common/bindings.rs
@@ -4,6 +4,7 @@ use std::collections::HashMap;
 
 use wick_packet::RuntimeConfig;
 
+use super::template_config::Renderable;
 use super::{ComponentDefinition, HighLevelComponent, ImportDefinition, InterfaceDefinition};
 use crate::config::components::WasmComponent;
 use crate::config::{self};
@@ -19,6 +20,16 @@ pub struct ImportBinding {
   pub(crate) id: String,
   /// The kind/type of the collection.
   pub(crate) kind: ImportDefinition,
+}
+
+impl Renderable for ImportBinding {
+  fn render_config(
+    &mut self,
+    root_config: Option<&RuntimeConfig>,
+    env: Option<&HashMap<String, String>>,
+  ) -> Result<(), crate::error::ManifestError> {
+    self.kind.render_config(root_config, env)
+  }
 }
 
 impl ImportBinding {

--- a/crates/wick/wick-config/src/config/common/component_definition.rs
+++ b/crates/wick/wick-config/src/config/common/component_definition.rs
@@ -98,6 +98,19 @@ impl ComponentOperationExpression {
   }
 }
 
+impl Renderable for ComponentOperationExpression {
+  fn render_config(
+    &mut self,
+    root_config: Option<&RuntimeConfig>,
+    env: Option<&HashMap<String, String>>,
+  ) -> Result<(), ManifestError> {
+    if let Some(config) = self.config.as_mut() {
+      config.set_value(Some(config.render(root_config, None, env, None)?));
+    }
+    Ok(())
+  }
+}
+
 impl std::str::FromStr for ComponentOperationExpression {
   type Err = crate::Error;
 

--- a/crates/wick/wick-config/src/config/common/import_definition.rs
+++ b/crates/wick/wick-config/src/config/common/import_definition.rs
@@ -18,6 +18,9 @@ pub enum ImportDefinition {
   Types(config::components::TypesComponent),
 }
 
+crate::impl_from_for!(ImportDefinition, Component, config::ComponentDefinition);
+crate::impl_from_for!(ImportDefinition, Types, config::components::TypesComponent);
+
 impl ImportDefinition {
   /// Returns true if the definition is a reference to another component.
   #[must_use]
@@ -34,6 +37,33 @@ impl ImportDefinition {
     match self {
       ImportDefinition::Component(v) => v.config().and_then(|v| v.value()),
       ImportDefinition::Types(_) => None,
+    }
+  }
+
+  /// Get the configuration kind for this import.
+  #[must_use]
+  pub fn kind(&self) -> ImportKind {
+    match self {
+      ImportDefinition::Component(_) => ImportKind::Component,
+      ImportDefinition::Types(_) => ImportKind::Types,
+    }
+  }
+}
+
+/// The kind of import an [ImportDefinition] is.
+#[derive(Debug, Clone, Copy)]
+pub enum ImportKind {
+  /// A component import.
+  Component,
+  /// A types import.
+  Types,
+}
+
+impl std::fmt::Display for ImportKind {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    match self {
+      ImportKind::Component => write!(f, "component"),
+      ImportKind::Types => write!(f, "types"),
     }
   }
 }

--- a/crates/wick/wick-config/src/config/common/liquid_json_config.rs
+++ b/crates/wick/wick-config/src/config/common/liquid_json_config.rs
@@ -104,6 +104,15 @@ impl LiquidJsonConfig {
   }
 
   #[must_use]
+  pub fn new_template(template: HashMap<String, LiquidJsonValue>) -> Self {
+    Self {
+      value: None,
+      template,
+      root_config: None,
+    }
+  }
+
+  #[must_use]
   /// Retrieve the runtime configuration
   pub fn value(&self) -> Option<&RuntimeConfig> {
     self.value.as_ref()
@@ -138,5 +147,27 @@ impl From<HashMap<String, Value>> for LiquidJsonConfig {
 impl From<LiquidJsonConfig> for HashMap<String, LiquidJsonValue> {
   fn from(value: LiquidJsonConfig) -> Self {
     value.template
+  }
+}
+
+impl TryFrom<Value> for LiquidJsonConfig {
+  type Error = Error;
+
+  fn try_from(value: Value) -> Result<Self, Self::Error> {
+    let value = match value {
+      Value::Object(map) => map,
+      _ => return Err(Error::ConfigurationTemplate("expected object".to_owned())),
+    };
+
+    let mut template = HashMap::new();
+    for (k, v) in value {
+      template.insert(k, v.into());
+    }
+
+    Ok(Self {
+      value: None,
+      template,
+      root_config: None,
+    })
   }
 }

--- a/crates/wick/wick-config/src/config/common/template_config.rs
+++ b/crates/wick/wick-config/src/config/common/template_config.rs
@@ -166,3 +166,35 @@ pub(crate) trait Renderable {
     env: Option<&HashMap<String, String>>,
   ) -> Result<(), ManifestError>;
 }
+
+impl<T> Renderable for Option<T>
+where
+  T: Renderable,
+{
+  fn render_config(
+    &mut self,
+    root_config: Option<&RuntimeConfig>,
+    env: Option<&HashMap<String, String>>,
+  ) -> Result<(), ManifestError> {
+    if let Some(v) = self {
+      v.render_config(root_config, env)?;
+    }
+    Ok(())
+  }
+}
+
+impl<T> Renderable for Vec<T>
+where
+  T: Renderable,
+{
+  fn render_config(
+    &mut self,
+    root_config: Option<&RuntimeConfig>,
+    env: Option<&HashMap<String, String>>,
+  ) -> Result<(), ManifestError> {
+    for el in self.iter_mut() {
+      el.render_config(root_config, env)?;
+    }
+    Ok(())
+  }
+}

--- a/crates/wick/wick-config/src/config/component_config.rs
+++ b/crates/wick/wick-config/src/config/component_config.rs
@@ -283,7 +283,7 @@ impl ComponentConfiguration {
   /// Initialize the configuration.
   pub(super) fn initialize(&mut self) -> Result<&Self> {
     // This pre-renders the component config's resources without access to the environment.
-    let root_config = self.root_config.clone();
+    let root_config = self.root_config.as_ref();
     trace!(
       num_resources = self.resources.len(),
       num_imports = self.import.len(),
@@ -291,12 +291,8 @@ impl ComponentConfiguration {
       "initializing component"
     );
 
-    for resource in self.resources.iter_mut() {
-      resource.kind.render_config(root_config.as_ref(), None)?;
-    }
-    for import in self.import.iter_mut() {
-      import.kind.render_config(root_config.as_ref(), None)?;
-    }
+    self.resources.render_config(root_config, None)?;
+    self.import.render_config(root_config, None)?;
 
     Ok(self)
   }

--- a/crates/wick/wick-config/src/error.rs
+++ b/crates/wick/wick-config/src/error.rs
@@ -85,6 +85,10 @@ pub enum ManifestError {
   #[error(transparent)]
   TypeParser(#[from] wick_interface_types::ParserError),
 
+  /// Error converting an enum to a specific variant.
+  #[error("could not convert a {0} into a {1}")]
+  VariantError(String, String),
+
   /// Error parsing YAML as a string.
   #[error("Error parsing YAML as a string")]
   Utf8,

--- a/crates/wick/wick-config/src/lib.rs
+++ b/crates/wick/wick-config/src/lib.rs
@@ -105,6 +105,8 @@ pub mod config;
 pub mod error;
 mod utils;
 
+pub(crate) use utils::impl_from_for;
+
 /// Wick Manifest v0 implementation.
 #[cfg(feature = "v0")]
 pub mod v0;

--- a/crates/wick/wick-config/src/v1/conversions.rs
+++ b/crates/wick/wick-config/src/v1/conversions.rs
@@ -1200,7 +1200,7 @@ impl TryFrom<v1::SqlComponent> for components::SqlComponentConfig {
   }
 }
 
-impl TryFrom<v1::SqlQueryKind> for components::SqlOperationKind {
+impl TryFrom<v1::SqlQueryKind> for components::SqlOperationDefinition {
   type Error = crate::Error;
   fn try_from(value: v1::SqlQueryKind) -> Result<Self> {
     Ok(match value {
@@ -1210,7 +1210,7 @@ impl TryFrom<v1::SqlQueryKind> for components::SqlOperationKind {
   }
 }
 
-impl TryFrom<v1::SqlQueryOperationDefinition> for components::SqlOperationDefinition {
+impl TryFrom<v1::SqlQueryOperationDefinition> for components::SqlQueryOperationDefinition {
   type Error = crate::Error;
   fn try_from(value: v1::SqlQueryOperationDefinition) -> Result<Self> {
     Ok(Self {
@@ -1302,20 +1302,20 @@ impl TryFrom<components::SqlComponentConfig> for v1::SqlComponent {
   }
 }
 
-impl TryFrom<components::SqlOperationKind> for v1::SqlQueryKind {
+impl TryFrom<components::SqlOperationDefinition> for v1::SqlQueryKind {
   type Error = crate::Error;
 
-  fn try_from(value: components::SqlOperationKind) -> std::result::Result<Self, Self::Error> {
+  fn try_from(value: components::SqlOperationDefinition) -> std::result::Result<Self, Self::Error> {
     Ok(match value {
-      components::SqlOperationKind::Query(v) => Self::SqlQueryOperationDefinition(v.try_into()?),
-      components::SqlOperationKind::Exec(v) => Self::SqlExecOperationDefinition(v.try_into()?),
+      components::SqlOperationDefinition::Query(v) => Self::SqlQueryOperationDefinition(v.try_into()?),
+      components::SqlOperationDefinition::Exec(v) => Self::SqlExecOperationDefinition(v.try_into()?),
     })
   }
 }
 
-impl TryFrom<components::SqlOperationDefinition> for v1::SqlQueryOperationDefinition {
+impl TryFrom<components::SqlQueryOperationDefinition> for v1::SqlQueryOperationDefinition {
   type Error = crate::Error;
-  fn try_from(value: components::SqlOperationDefinition) -> Result<Self> {
+  fn try_from(value: components::SqlQueryOperationDefinition) -> Result<Self> {
     Ok(Self {
       name: value.name,
       inputs: value.inputs.try_map_into()?,

--- a/src/commands/new/component/sql.rs
+++ b/src/commands/new/component/sql.rs
@@ -1,7 +1,11 @@
 use anyhow::Result;
 use clap::Args;
 use structured_output::StructuredOutput;
-use wick_config::config::components::{SqlComponentConfigBuilder, SqlOperationDefinitionBuilder, SqlOperationKind};
+use wick_config::config::components::{
+  SqlComponentConfigBuilder,
+  SqlOperationDefinition,
+  SqlQueryOperationDefinitionBuilder,
+};
 use wick_config::config::{self, ComponentConfiguration};
 use wick_interface_types::{Field, Type};
 
@@ -43,8 +47,8 @@ pub(crate) async fn handle(
 
     let component = SqlComponentConfigBuilder::default()
       .resource(resource_name)
-      .operations([SqlOperationKind::Query(
-        SqlOperationDefinitionBuilder::default()
+      .operations([SqlOperationDefinition::Query(
+        SqlQueryOperationDefinitionBuilder::default()
           .name("example_query".to_owned())
           .inputs([Field::new("id", Type::String)])
           .query("SELECT * FROM users WHERE id = $1".to_owned())


### PR DESCRIPTION
This PR fixes how inline operation configuration templates are rendered. Previously, operations in Triggers defined with configuration blocks were not rendered.

This PR also adds some `Builder` derivations that were found as gaps during writing a regression test for this issue.