### PR TITLE
Added `__dirname` to configuration context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # rust
 **/target
 crates/*/**/Cargo.lock
+integration-tests/*/**/Cargo.lock
 
 # .env
 DEV.env

--- a/crates/wick/flow-graph-interpreter/src/graph/operation_settings.rs
+++ b/crates/wick/flow-graph-interpreter/src/graph/operation_settings.rs
@@ -20,34 +20,25 @@ impl OperationSettings {
 pub(crate) struct LiquidOperationConfig {
   root: Option<RuntimeConfig>,
   template: Option<LiquidJsonConfig>,
-  value: Option<RuntimeConfig>,
+  op_config: Option<RuntimeConfig>,
 }
 
 impl LiquidOperationConfig {
-  #[must_use]
-  pub(crate) fn new_value(value: Option<RuntimeConfig>) -> Self {
-    Self {
-      template: None,
-      value,
-      root: None,
-    }
-  }
-
   pub(crate) fn render(&self, inherent: &InherentData) -> Result<Option<RuntimeConfig>, InterpreterError> {
     if let Some(template) = self.template() {
       Ok(Some(
         template
-          .render(self.root.as_ref(), self.value.as_ref(), None, Some(inherent))
+          .render(None, self.root.as_ref(), self.op_config.as_ref(), None, Some(inherent))
           .map_err(|e| InterpreterError::Configuration(e.to_string()))?,
       ))
     } else {
-      Ok(self.value.clone())
+      Ok(self.op_config.clone())
     }
   }
 
   #[must_use]
-  pub(crate) fn value(&self) -> Option<&RuntimeConfig> {
-    self.value.as_ref()
+  pub(crate) fn op_config(&self) -> Option<&RuntimeConfig> {
+    self.op_config.as_ref()
   }
 
   #[must_use]
@@ -68,8 +59,8 @@ impl LiquidOperationConfig {
     self.template = template;
   }
 
-  pub(crate) fn set_value(&mut self, value: Option<RuntimeConfig>) {
-    self.value = value;
+  pub(crate) fn set_op_config(&mut self, config: Option<RuntimeConfig>) {
+    self.op_config = config;
   }
 }
 
@@ -77,7 +68,7 @@ impl From<Option<LiquidJsonConfig>> for LiquidOperationConfig {
   fn from(value: Option<LiquidJsonConfig>) -> Self {
     LiquidOperationConfig {
       template: value,
-      value: None,
+      op_config: None,
       root: None,
     }
   }
@@ -87,7 +78,7 @@ impl From<Option<RuntimeConfig>> for LiquidOperationConfig {
   fn from(value: Option<RuntimeConfig>) -> Self {
     LiquidOperationConfig {
       template: None,
-      value,
+      op_config: value,
       root: None,
     }
   }

--- a/crates/wick/flow-graph-interpreter/src/interpreter.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter.rs
@@ -62,6 +62,7 @@ impl Interpreter {
     namespace: Option<String>,
     components: Option<HandlerMap>,
     callback: Arc<RuntimeCallback>,
+    root_config: Option<&RuntimeConfig>,
     parent_span: &Span,
   ) -> Result<Self, Error> {
     let span = info_span!(parent: parent_span, "interpreter");
@@ -107,7 +108,7 @@ impl Interpreter {
 
     // Make the self:: component
     let components = Arc::new(handlers);
-    let self_component = SelfComponent::new(components.clone(), program.state(), &dispatcher);
+    let self_component = SelfComponent::new(components.clone(), program.state(), &dispatcher, root_config);
 
     // If we expose a component, expose its signature as our own.
     // Otherwise expose our self signature.

--- a/crates/wick/flow-graph-interpreter/src/interpreter/components/self_component.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/components/self_component.rs
@@ -4,7 +4,6 @@ use flow_component::{Component, ComponentError, RuntimeCallback};
 use wick_interface_types::ComponentSignature;
 use wick_packet::{Invocation, PacketStream, RuntimeConfig};
 
-use crate::graph::LiquidOperationConfig;
 use crate::interpreter::channel::InterpreterDispatchChannel;
 use crate::interpreter::executor::SchematicExecutor;
 use crate::interpreter::program::ProgramState;
@@ -28,13 +27,14 @@ impl InnerSelf {
     components: Arc<HandlerMap>,
     state: &ProgramState,
     dispatcher: &InterpreterDispatchChannel,
+    root_config: Option<&RuntimeConfig>,
   ) -> Self {
     let schematics: Arc<Vec<SchematicExecutor>> = Arc::new(
       state
         .network
         .schematics()
         .iter()
-        .map(|s| SchematicExecutor::new(s.clone(), dispatcher.clone()))
+        .map(|s| SchematicExecutor::new(s.clone(), dispatcher.clone(), root_config.cloned()))
         .collect(),
     );
     let signature = state.components.get(SelfComponent::ID).unwrap().clone();
@@ -58,8 +58,9 @@ impl SelfComponent {
     components: Arc<HandlerMap>,
     state: &ProgramState,
     dispatcher: &InterpreterDispatchChannel,
+    root_config: Option<&RuntimeConfig>,
   ) -> Self {
-    let inner_self = InnerSelf::new(components, state, dispatcher);
+    let inner_self = InnerSelf::new(components, state, dispatcher, root_config);
     Self {
       inner: Arc::new(inner_self),
     }
@@ -75,8 +76,6 @@ impl Component for SelfComponent {
   ) -> BoxFuture<Result<PacketStream, ComponentError>> {
     invocation.trace(|| debug!(target = %invocation.target, namespace = Self::ID));
 
-    let op_config = LiquidOperationConfig::new_value(config);
-
     let operation = invocation.target.operation_id().to_owned();
     let fut = self
       .inner
@@ -88,7 +87,7 @@ impl Component for SelfComponent {
           invocation,
           self.inner.components.clone(),
           self.clone(),
-          op_config,
+          config,
           callback,
         )
       })

--- a/crates/wick/flow-graph-interpreter/src/interpreter/executor.rs
+++ b/crates/wick/flow-graph-interpreter/src/interpreter/executor.rs
@@ -2,14 +2,13 @@ use std::sync::Arc;
 
 use flow_component::RuntimeCallback;
 use seeded_random::Seed;
-use wick_packet::{Invocation, PacketStream};
+use wick_packet::{Invocation, PacketStream, RuntimeConfig};
 
 use self::context::ExecutionContext;
 use self::error::ExecutionError;
 use super::channel::InterpreterDispatchChannel;
 use super::components::self_component::SelfComponent;
 use crate::graph::types::*;
-use crate::graph::LiquidOperationConfig;
 use crate::HandlerMap;
 
 pub(crate) mod error;
@@ -22,14 +21,20 @@ type Result<T> = std::result::Result<T, ExecutionError>;
 #[must_use]
 pub(crate) struct SchematicExecutor {
   channel: InterpreterDispatchChannel,
+  root_config: Option<RuntimeConfig>,
   schematic: Arc<Schematic>,
 }
 
 impl SchematicExecutor {
-  pub(crate) fn new(schematic: Schematic, channel: InterpreterDispatchChannel) -> Self {
+  pub(crate) fn new(
+    schematic: Schematic,
+    channel: InterpreterDispatchChannel,
+    root_config: Option<RuntimeConfig>,
+  ) -> Self {
     Self {
       channel,
       schematic: Arc::new(schematic),
+      root_config,
     }
   }
 
@@ -43,7 +48,7 @@ impl SchematicExecutor {
     invocation: Invocation,
     components: Arc<HandlerMap>,
     self_component: SelfComponent,
-    config: LiquidOperationConfig,
+    config: Option<RuntimeConfig>,
     callback: Arc<RuntimeCallback>,
   ) -> Result<PacketStream> {
     invocation
@@ -58,6 +63,7 @@ impl SchematicExecutor {
       &components,
       &self_component,
       callback,
+      self.root_config.clone(),
       config,
       seed,
     );

--- a/crates/wick/flow-graph-interpreter/tests/test/mod.rs
+++ b/crates/wick/flow-graph-interpreter/tests/test/mod.rs
@@ -56,6 +56,7 @@ pub async fn base_setup(
     None,
     Some(collections),
     panic_callback(),
+    None,
     &tracing::Span::current(),
   )?;
 

--- a/crates/wick/flow-graph-interpreter/tests/validation.rs
+++ b/crates/wick/flow-graph-interpreter/tests/validation.rs
@@ -50,7 +50,14 @@ async fn interp(path: &str, sig: ComponentSignature) -> std::result::Result<Inte
   let components = collections(sig);
   let network = from_def(&mut load(path).await.unwrap(), &components).unwrap();
 
-  Interpreter::new(network, None, Some(components), panic_callback(), &Span::current())
+  Interpreter::new(
+    network,
+    None,
+    Some(components),
+    panic_callback(),
+    None,
+    &Span::current(),
+  )
 }
 
 #[test_logger::test(tokio::test)]

--- a/crates/wick/wick-config/src/config.rs
+++ b/crates/wick/wick-config/src/config.rs
@@ -354,15 +354,6 @@ impl WickConfiguration {
     self
   }
 
-  /// Get the root runtime config for a [WickConfiguration].
-  fn get_root_config(&self) -> Option<&RuntimeConfig> {
-    match self {
-      WickConfiguration::App(v) => v.root_config.as_ref(),
-      WickConfiguration::Component(v) => v.root_config.as_ref(),
-      _ => None,
-    }
-  }
-
   /// Set the environment variables for a [WickConfiguration].
   fn set_env(&mut self, env: Option<HashMap<String, String>>) -> &mut Self {
     match self {
@@ -496,7 +487,9 @@ impl WickConfiguration {
         v.initialize()?;
       }
       WickConfiguration::Types(_) => (),
-      WickConfiguration::Tests(_) => (),
+      WickConfiguration::Tests(v) => {
+        v.initialize()?;
+      }
       WickConfiguration::Lockdown(v) => {
         v.initialize()?;
       }

--- a/crates/wick/wick-config/src/config/app_config/triggers.rs
+++ b/crates/wick/wick-config/src/config/app_config/triggers.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::Path;
 
 use serde_json::Value;
 use wick_asset_reference::AssetReference;
@@ -81,13 +82,14 @@ impl TriggerDefinition {
 impl Renderable for TriggerDefinition {
   fn render_config(
     &mut self,
+    source: Option<&Path>,
     root_config: Option<&RuntimeConfig>,
     env: Option<&HashMap<String, String>>,
   ) -> Result<(), ManifestError> {
     match self {
-      TriggerDefinition::Cli(v) => v.render_config(root_config, env),
-      TriggerDefinition::Http(v) => v.render_config(root_config, env),
-      TriggerDefinition::Time(v) => v.render_config(root_config, env),
+      TriggerDefinition::Cli(v) => v.render_config(source, root_config, env),
+      TriggerDefinition::Http(v) => v.render_config(source, root_config, env),
+      TriggerDefinition::Time(v) => v.render_config(source, root_config, env),
     }
   }
 }

--- a/crates/wick/wick-config/src/config/app_config/triggers/cli.rs
+++ b/crates/wick/wick-config/src/config/app_config/triggers/cli.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::Path;
 
 use wick_asset_reference::AssetReference;
 use wick_packet::RuntimeConfig;
@@ -38,9 +39,10 @@ impl ExpandImports for CliConfig {
 impl Renderable for CliConfig {
   fn render_config(
     &mut self,
+    source: Option<&Path>,
     root_config: Option<&RuntimeConfig>,
     env: Option<&HashMap<String, String>>,
   ) -> Result<(), ManifestError> {
-    self.operation.render_config(root_config, env)
+    self.operation.render_config(source, root_config, env)
   }
 }

--- a/crates/wick/wick-config/src/config/app_config/triggers/http.rs
+++ b/crates/wick/wick-config/src/config/app_config/triggers/http.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::Path;
 
 pub use middleware::{Middleware, MiddlewareBuilder, MiddlewareBuilderError};
 use wick_asset_reference::AssetReference;
@@ -61,14 +62,15 @@ pub enum HttpRouterConfig {
 impl Renderable for HttpRouterConfig {
   fn render_config(
     &mut self,
+    source: Option<&Path>,
     root_config: Option<&RuntimeConfig>,
     env: Option<&HashMap<String, String>>,
   ) -> Result<(), ManifestError> {
     match self {
-      HttpRouterConfig::RawRouter(v) => v.render_config(root_config, env),
-      HttpRouterConfig::RestRouter(v) => v.render_config(root_config, env),
-      HttpRouterConfig::StaticRouter(v) => v.render_config(root_config, env),
-      HttpRouterConfig::ProxyRouter(v) => v.render_config(root_config, env),
+      HttpRouterConfig::RawRouter(v) => v.render_config(source, root_config, env),
+      HttpRouterConfig::RestRouter(v) => v.render_config(source, root_config, env),
+      HttpRouterConfig::StaticRouter(v) => v.render_config(source, root_config, env),
+      HttpRouterConfig::ProxyRouter(v) => v.render_config(source, root_config, env),
     }
   }
 }
@@ -76,10 +78,11 @@ impl Renderable for HttpRouterConfig {
 impl Renderable for HttpTriggerConfig {
   fn render_config(
     &mut self,
+    source: Option<&Path>,
     root_config: Option<&RuntimeConfig>,
     env: Option<&HashMap<String, String>>,
   ) -> Result<(), ManifestError> {
-    self.routers.render_config(root_config, env)
+    self.routers.render_config(source, root_config, env)
   }
 }
 

--- a/crates/wick/wick-config/src/config/app_config/triggers/http/middleware.rs
+++ b/crates/wick/wick-config/src/config/app_config/triggers/http/middleware.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::Path;
 
 use wick_packet::RuntimeConfig;
 
@@ -31,11 +32,12 @@ pub struct Middleware {
 impl Renderable for Middleware {
   fn render_config(
     &mut self,
+    source: Option<&Path>,
     root_config: Option<&RuntimeConfig>,
     env: Option<&HashMap<String, String>>,
   ) -> Result<(), ManifestError> {
-    self.request.render_config(root_config, env)?;
-    self.response.render_config(root_config, env)
+    self.request.render_config(source, root_config, env)?;
+    self.response.render_config(source, root_config, env)
   }
 }
 

--- a/crates/wick/wick-config/src/config/app_config/triggers/http/proxy_router.rs
+++ b/crates/wick/wick-config/src/config/app_config/triggers/http/proxy_router.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::Path;
 
 use wick_asset_reference::AssetReference;
 use wick_packet::RuntimeConfig;
@@ -35,10 +36,11 @@ pub struct ProxyRouterConfig {
 impl Renderable for ProxyRouterConfig {
   fn render_config(
     &mut self,
+    source: Option<&Path>,
     root_config: Option<&RuntimeConfig>,
     env: Option<&HashMap<String, String>>,
   ) -> Result<(), ManifestError> {
-    self.middleware.render_config(root_config, env)
+    self.middleware.render_config(source, root_config, env)
   }
 }
 

--- a/crates/wick/wick-config/src/config/app_config/triggers/http/raw_router.rs
+++ b/crates/wick/wick-config/src/config/app_config/triggers/http/raw_router.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::Path;
 
 use wick_asset_reference::AssetReference;
 use wick_packet::RuntimeConfig;
@@ -46,11 +47,12 @@ impl super::WickRouter for RawRouterConfig {
 impl Renderable for RawRouterConfig {
   fn render_config(
     &mut self,
+    source: Option<&Path>,
     root_config: Option<&RuntimeConfig>,
     env: Option<&HashMap<String, String>>,
   ) -> Result<(), ManifestError> {
-    self.operation.render_config(root_config, env)?;
-    self.middleware.render_config(root_config, env)
+    self.operation.render_config(source, root_config, env)?;
+    self.middleware.render_config(source, root_config, env)
   }
 }
 

--- a/crates/wick/wick-config/src/config/app_config/triggers/http/rest_router.rs
+++ b/crates/wick/wick-config/src/config/app_config/triggers/http/rest_router.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::Path;
 
 use wick_asset_reference::AssetReference;
 use wick_packet::RuntimeConfig;
@@ -46,21 +47,23 @@ pub struct RestRouterConfig {
 impl Renderable for RestRouterConfig {
   fn render_config(
     &mut self,
+    source: Option<&Path>,
     root_config: Option<&RuntimeConfig>,
     env: Option<&HashMap<String, String>>,
   ) -> Result<(), ManifestError> {
-    self.middleware.render_config(root_config, env)?;
-    self.routes.render_config(root_config, env)
+    self.middleware.render_config(source, root_config, env)?;
+    self.routes.render_config(source, root_config, env)
   }
 }
 
 impl Renderable for RestRoute {
   fn render_config(
     &mut self,
+    source: Option<&Path>,
     root_config: Option<&RuntimeConfig>,
     env: Option<&HashMap<String, String>>,
   ) -> Result<(), ManifestError> {
-    self.operation.render_config(root_config, env)
+    self.operation.render_config(source, root_config, env)
   }
 }
 

--- a/crates/wick/wick-config/src/config/app_config/triggers/http/static_router.rs
+++ b/crates/wick/wick-config/src/config/app_config/triggers/http/static_router.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::Path;
 
 use wick_asset_reference::AssetReference;
 use wick_packet::RuntimeConfig;
@@ -47,10 +48,11 @@ impl super::WickRouter for StaticRouterConfig {
 impl Renderable for StaticRouterConfig {
   fn render_config(
     &mut self,
+    source: Option<&Path>,
     root_config: Option<&RuntimeConfig>,
     env: Option<&HashMap<String, String>>,
   ) -> Result<(), ManifestError> {
-    self.middleware.render_config(root_config, env)
+    self.middleware.render_config(source, root_config, env)
   }
 }
 

--- a/crates/wick/wick-config/src/config/app_config/triggers/time.rs
+++ b/crates/wick/wick-config/src/config/app_config/triggers/time.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::Path;
 
 use wick_asset_reference::AssetReference;
 use wick_packet::RuntimeConfig;
@@ -34,10 +35,11 @@ pub struct TimeTriggerConfig {
 impl Renderable for TimeTriggerConfig {
   fn render_config(
     &mut self,
+    source: Option<&Path>,
     root_config: Option<&RuntimeConfig>,
     env: Option<&HashMap<String, String>>,
   ) -> Result<(), ManifestError> {
-    self.operation.render_config(root_config, env)
+    self.operation.render_config(source, root_config, env)
   }
 }
 

--- a/crates/wick/wick-config/src/config/common/bindings.rs
+++ b/crates/wick/wick-config/src/config/common/bindings.rs
@@ -1,6 +1,7 @@
 #![allow(missing_docs)] // delete when we move away from the `property` crate.
 
 use std::collections::HashMap;
+use std::path::Path;
 
 use wick_packet::RuntimeConfig;
 
@@ -25,10 +26,11 @@ pub struct ImportBinding {
 impl Renderable for ImportBinding {
   fn render_config(
     &mut self,
+    source: Option<&Path>,
     root_config: Option<&RuntimeConfig>,
     env: Option<&HashMap<String, String>>,
   ) -> Result<(), crate::error::ManifestError> {
-    self.kind.render_config(root_config, env)
+    self.kind.render_config(source, root_config, env)
   }
 }
 

--- a/crates/wick/wick-config/src/config/common/component_definition.rs
+++ b/crates/wick/wick-config/src/config/common/component_definition.rs
@@ -1,5 +1,6 @@
 #![allow(missing_docs, deprecated)]
 use std::collections::HashMap;
+use std::path::Path;
 
 // delete when we move away from the `property` crate.
 use serde::de::{IgnoredAny, SeqAccess, Visitor};
@@ -101,11 +102,12 @@ impl ComponentOperationExpression {
 impl Renderable for ComponentOperationExpression {
   fn render_config(
     &mut self,
+    source: Option<&Path>,
     root_config: Option<&RuntimeConfig>,
     env: Option<&HashMap<String, String>>,
   ) -> Result<(), ManifestError> {
     if let Some(config) = self.config.as_mut() {
-      config.set_value(Some(config.render(root_config, None, env, None)?));
+      config.set_value(Some(config.render(source, root_config, None, env, None)?));
     }
     Ok(())
   }
@@ -241,11 +243,12 @@ impl ComponentDefinition {
 impl Renderable for ComponentDefinition {
   fn render_config(
     &mut self,
+    source: Option<&Path>,
     root_config: Option<&RuntimeConfig>,
     env: Option<&HashMap<String, String>>,
   ) -> Result<(), ManifestError> {
     let val = if let Some(config) = self.config() {
-      Some(config.render(root_config, None, env, None)?)
+      Some(config.render(source, root_config, None, env, None)?)
     } else {
       None
     };

--- a/crates/wick/wick-config/src/config/common/import_definition.rs
+++ b/crates/wick/wick-config/src/config/common/import_definition.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::Path;
 
 use wick_packet::RuntimeConfig;
 
@@ -71,11 +72,12 @@ impl std::fmt::Display for ImportKind {
 impl Renderable for ImportDefinition {
   fn render_config(
     &mut self,
+    source: Option<&Path>,
     root_config: Option<&RuntimeConfig>,
     env: Option<&HashMap<String, String>>,
   ) -> Result<(), ManifestError> {
     match self {
-      ImportDefinition::Component(v) => v.render_config(root_config, env),
+      ImportDefinition::Component(v) => v.render_config(source, root_config, env),
       ImportDefinition::Types(_) => Ok(()),
     }
   }

--- a/crates/wick/wick-config/src/config/common/resources.rs
+++ b/crates/wick/wick-config/src/config/common/resources.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use asset_container::{Asset, AssetFlags};
 use url::Url;
@@ -34,10 +34,11 @@ pub struct ResourceBinding {
 impl Renderable for ResourceBinding {
   fn render_config(
     &mut self,
+    source: Option<&Path>,
     root_config: Option<&RuntimeConfig>,
     env: Option<&HashMap<String, String>>,
   ) -> Result<(), ManifestError> {
-    self.kind.render_config(root_config, env)
+    self.kind.render_config(source, root_config, env)
   }
 }
 
@@ -92,14 +93,15 @@ pub enum ResourceDefinition {
 impl Renderable for ResourceDefinition {
   fn render_config(
     &mut self,
+    source: Option<&Path>,
     root_config: Option<&RuntimeConfig>,
     env: Option<&HashMap<String, String>>,
   ) -> Result<(), ManifestError> {
     match self {
-      ResourceDefinition::TcpPort(v) => v.render_config(root_config, env),
-      ResourceDefinition::UdpPort(v) => v.render_config(root_config, env),
-      ResourceDefinition::Url(v) => v.render_config(root_config, env),
-      ResourceDefinition::Volume(v) => v.render_config(root_config, env),
+      ResourceDefinition::TcpPort(v) => v.render_config(source, root_config, env),
+      ResourceDefinition::UdpPort(v) => v.render_config(source, root_config, env),
+      ResourceDefinition::Url(v) => v.render_config(source, root_config, env),
+      ResourceDefinition::Volume(v) => v.render_config(source, root_config, env),
     }
   }
 }
@@ -175,10 +177,11 @@ impl Volume {
 impl Renderable for Volume {
   fn render_config(
     &mut self,
+    source: Option<&Path>,
     root_config: Option<&RuntimeConfig>,
     env: Option<&HashMap<String, String>>,
   ) -> Result<(), ManifestError> {
-    self.path.set_value(self.path.render(root_config, env)?);
+    self.path.set_value(self.path.render(source, root_config, env)?);
     Ok(())
   }
 }
@@ -197,7 +200,7 @@ impl asset_container::AssetManager for Volume {
     )
   }
 
-  fn set_baseurl(&self, baseurl: &std::path::Path) {
+  fn set_baseurl(&self, baseurl: &Path) {
     if let Some(path) = &self.path.value {
       path.update_baseurl(baseurl);
       match self.path() {
@@ -251,10 +254,11 @@ impl std::fmt::Display for UrlResource {
 impl Renderable for UrlResource {
   fn render_config(
     &mut self,
+    source: Option<&Path>,
     root_config: Option<&RuntimeConfig>,
     env: Option<&HashMap<String, String>>,
   ) -> Result<(), ManifestError> {
-    self.url.set_value(self.url.render(root_config, env)?);
+    self.url.set_value(self.url.render(source, root_config, env)?);
     Ok(())
   }
 }
@@ -288,11 +292,12 @@ impl TcpPort {
 impl Renderable for TcpPort {
   fn render_config(
     &mut self,
+    source: Option<&Path>,
     root_config: Option<&RuntimeConfig>,
     env: Option<&HashMap<String, String>>,
   ) -> Result<(), ManifestError> {
-    self.port.set_value(self.port.render(root_config, env)?);
-    self.host.set_value(self.host.render(root_config, env)?);
+    self.port.set_value(self.port.render(source, root_config, env)?);
+    self.host.set_value(self.host.render(source, root_config, env)?);
     Ok(())
   }
 }
@@ -326,11 +331,12 @@ impl UdpPort {
 impl Renderable for UdpPort {
   fn render_config(
     &mut self,
+    source: Option<&Path>,
     root_config: Option<&RuntimeConfig>,
     env: Option<&HashMap<String, String>>,
   ) -> Result<(), ManifestError> {
-    self.port.set_value(self.port.render(root_config, env)?);
-    self.host.set_value(self.host.render(root_config, env)?);
+    self.port.set_value(self.port.render(source, root_config, env)?);
+    self.host.set_value(self.host.render(source, root_config, env)?);
     Ok(())
   }
 }

--- a/crates/wick/wick-config/src/config/common/template_config.rs
+++ b/crates/wick/wick-config/src/config/common/template_config.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::Path;
 use std::str::FromStr;
 
 use liquid_json::LiquidJsonValue;
@@ -121,11 +122,22 @@ where
   }
 
   /// Render a [TemplateConfig] into the desired value, creating a context from the passed configuration.
-  pub fn render(&self, root: Option<&RuntimeConfig>, env: Option<&HashMap<String, String>>) -> Result<T, crate::Error> {
+  pub fn render(
+    &self,
+    source: Option<&Path>,
+    root: Option<&RuntimeConfig>,
+    env: Option<&HashMap<String, String>>,
+  ) -> Result<T, crate::Error> {
     if let Some(value) = &self.value {
       return Ok(value.clone());
     }
-    let ctx = LiquidJsonConfig::make_context(None, root, None, env, None)?;
+
+    let base = source.map(|source| {
+      let dirname = source.parent().unwrap_or_else(|| Path::new("<unavailable>"));
+      serde_json::json!({"__dirname": dirname})
+    });
+
+    let ctx = LiquidJsonConfig::make_context(base, root, None, env, None)?;
 
     if let Some(template) = &self.template {
       let rendered = template
@@ -162,6 +174,7 @@ fn value_to_string(value: &Value) -> Result<String, ManifestError> {
 pub(crate) trait Renderable {
   fn render_config(
     &mut self,
+    source: Option<&Path>,
     root_config: Option<&RuntimeConfig>,
     env: Option<&HashMap<String, String>>,
   ) -> Result<(), ManifestError>;
@@ -173,11 +186,12 @@ where
 {
   fn render_config(
     &mut self,
+    source: Option<&Path>,
     root_config: Option<&RuntimeConfig>,
     env: Option<&HashMap<String, String>>,
   ) -> Result<(), ManifestError> {
     if let Some(v) = self {
-      v.render_config(root_config, env)?;
+      v.render_config(source, root_config, env)?;
     }
     Ok(())
   }
@@ -189,11 +203,12 @@ where
 {
   fn render_config(
     &mut self,
+    source: Option<&Path>,
     root_config: Option<&RuntimeConfig>,
     env: Option<&HashMap<String, String>>,
   ) -> Result<(), ManifestError> {
     for el in self.iter_mut() {
-      el.render_config(root_config, env)?;
+      el.render_config(source, root_config, env)?;
     }
     Ok(())
   }

--- a/crates/wick/wick-config/src/config/common/test_case.rs
+++ b/crates/wick/wick-config/src/config/common/test_case.rs
@@ -1,7 +1,14 @@
-#![allow(missing_docs)] // delete when we move away from the `property` crate.
-use liquid_json::LiquidJsonValue;
+#![allow(missing_docs)]
+use std::collections::HashMap;
+use std::path::Path;
 
+// delete when we move away from the `property` crate.
+use liquid_json::LiquidJsonValue;
+use wick_packet::{InherentData, RuntimeConfig};
+
+use super::template_config::Renderable;
 use crate::config::{LiquidJsonConfig, TemplateConfig};
+use crate::error::ManifestError;
 
 #[derive(Debug, Clone, PartialEq, property::Property, serde::Serialize, derive_builder::Builder)]
 #[property(get(public), set(private), mut(disable))]
@@ -30,6 +37,26 @@ pub struct TestCase {
   #[builder(default)]
   #[serde(skip_serializing_if = "Vec::is_empty")]
   pub(crate) outputs: Vec<TestPacketData>,
+}
+
+impl Renderable for TestCase {
+  fn render_config(
+    &mut self,
+    source: Option<&Path>,
+    root_config: Option<&RuntimeConfig>,
+    env: Option<&HashMap<String, String>>,
+  ) -> Result<(), ManifestError> {
+    if let Some(config) = self.config.as_mut() {
+      config.set_value(Some(config.render(
+        source,
+        root_config,
+        None,
+        env,
+        Some(&InherentData::unsafe_default()),
+      )?));
+    }
+    Ok(())
+  }
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Copy, property::Property, serde::Serialize, derive_builder::Builder)]

--- a/crates/wick/wick-config/src/config/lockdown_config.rs
+++ b/crates/wick/wick-config/src/config/lockdown_config.rs
@@ -61,9 +61,9 @@ impl LockdownConfiguration {
       resource_restrictions = ?self.resources,
       "initializing lockdown configuration"
     );
-    for resource in self.resources.iter_mut() {
-      resource.render_config(None, self.env.as_ref())?;
-    }
+    self
+      .resources
+      .render_config(self.source.as_deref(), None, self.env.as_ref())?;
 
     Ok(self)
   }

--- a/crates/wick/wick-config/src/config/lockdown_config/resources.rs
+++ b/crates/wick/wick-config/src/config/lockdown_config/resources.rs
@@ -1,6 +1,7 @@
 #![allow(missing_docs)] // delete when we move away from the `property` crate.
 
 use std::collections::HashMap;
+use std::path::Path;
 
 use wick_packet::RuntimeConfig;
 
@@ -20,13 +21,14 @@ pub enum ResourceRestriction {
 impl Renderable for ResourceRestriction {
   fn render_config(
     &mut self,
+    source: Option<&Path>,
     root_config: Option<&RuntimeConfig>,
     env: Option<&HashMap<String, String>>,
   ) -> Result<(), ManifestError> {
     match self {
-      Self::Volume(restriction) => restriction.render_config(root_config, env),
-      Self::Url(restriction) => restriction.render_config(root_config, env),
-      Self::TcpPort(restriction) | Self::UdpPort(restriction) => restriction.render_config(root_config, env),
+      Self::Volume(restriction) => restriction.render_config(source, root_config, env),
+      Self::Url(restriction) => restriction.render_config(source, root_config, env),
+      Self::TcpPort(restriction) | Self::UdpPort(restriction) => restriction.render_config(source, root_config, env),
     }
   }
 }
@@ -55,10 +57,11 @@ impl VolumeRestriction {
 impl Renderable for VolumeRestriction {
   fn render_config(
     &mut self,
+    source: Option<&Path>,
     root_config: Option<&RuntimeConfig>,
     env: Option<&HashMap<String, String>>,
   ) -> Result<(), ManifestError> {
-    self.allow.set_value(self.allow.render(root_config, env)?);
+    self.allow.set_value(self.allow.render(source, root_config, env)?);
     Ok(())
   }
 }
@@ -87,10 +90,11 @@ impl UrlRestriction {
 impl Renderable for UrlRestriction {
   fn render_config(
     &mut self,
+    source: Option<&Path>,
     root_config: Option<&RuntimeConfig>,
     env: Option<&HashMap<String, String>>,
   ) -> Result<(), ManifestError> {
-    self.allow.set_value(self.allow.render(root_config, env)?);
+    self.allow.set_value(self.allow.render(source, root_config, env)?);
     Ok(())
   }
 }
@@ -120,11 +124,12 @@ impl PortRestriction {
 impl Renderable for PortRestriction {
   fn render_config(
     &mut self,
+    source: Option<&Path>,
     root_config: Option<&RuntimeConfig>,
     env: Option<&HashMap<String, String>>,
   ) -> Result<(), ManifestError> {
-    self.address.set_value(self.address.render(root_config, env)?);
-    self.port.set_value(self.port.render(root_config, env)?);
+    self.address.set_value(self.address.render(source, root_config, env)?);
+    self.port.set_value(self.port.render(source, root_config, env)?);
     Ok(())
   }
 }

--- a/crates/wick/wick-config/src/config/test_config.rs
+++ b/crates/wick/wick-config/src/config/test_config.rs
@@ -3,7 +3,10 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use asset_container::AssetManager;
+use tracing::trace;
+use wick_packet::{InherentData, RuntimeConfig};
 
+use super::template_config::Renderable;
 use super::LiquidJsonConfig;
 use crate::config::test_case;
 use crate::error::ManifestError;
@@ -70,6 +73,44 @@ impl TestConfiguration {
   /// Validate this configuration is good.
   pub fn validate(&self) -> Result<(), ManifestError> {
     /* placeholder */
+    Ok(())
+  }
+
+  /// Initialize the configuration, rendering template configuration when possibles.
+  pub fn initialize(&mut self) -> Result<&Self, ManifestError> {
+    let source = self.source.clone();
+
+    trace!(
+      source = ?source,
+      "initializing test configuration"
+    );
+
+    let env = self.env.clone();
+
+    self.render_config(source.as_deref(), None, env.as_ref())?;
+
+    Ok(self)
+  }
+}
+
+impl Renderable for TestConfiguration {
+  fn render_config(
+    &mut self,
+    source: Option<&Path>,
+    root_config: Option<&RuntimeConfig>,
+    env: Option<&HashMap<String, String>>,
+  ) -> Result<(), ManifestError> {
+    if let Some(config) = self.config.as_mut() {
+      config.set_value(Some(config.render(
+        source,
+        root_config,
+        None,
+        env,
+        Some(&InherentData::unsafe_default()),
+      )?));
+    }
+
+    self.cases.render_config(source, root_config, env)?;
     Ok(())
   }
 }

--- a/crates/wick/wick-config/src/lockdown/port.rs
+++ b/crates/wick/wick-config/src/lockdown/port.rs
@@ -96,7 +96,7 @@ mod test {
       restriction.1,
       restriction.2,
     );
-    restriction.render_config(None, None)?;
+    restriction.render_config(None, None, None)?;
     assert_eq!(
       is_allowed(component_id, "ID", &volume, &restriction),
       Ok(()),
@@ -129,7 +129,7 @@ mod test {
       restriction.1,
       restriction.2,
     );
-    restriction.render_config(None, None)?;
+    restriction.render_config(None, None, None)?;
     assert_eq!(
       is_allowed(component_id, "ID", &volume, &restriction),
       Err(failure),

--- a/crates/wick/wick-config/src/lockdown/url.rs
+++ b/crates/wick/wick-config/src/lockdown/url.rs
@@ -86,7 +86,7 @@ mod test {
       restriction.0.into_iter().map(Into::into).collect::<Vec<_>>(),
       restriction.1,
     );
-    restriction.render_config(None, None)?;
+    restriction.render_config(None, None, None)?;
     assert_eq!(
       is_allowed(component_id, "ID", &volume, &restriction),
       Ok(()),
@@ -112,7 +112,7 @@ mod test {
       restriction.0.into_iter().map(Into::into).collect::<Vec<_>>(),
       restriction.1,
     );
-    restriction.render_config(None, None)?;
+    restriction.render_config(None, None, None)?;
     assert_eq!(
       is_allowed(component_id, "ID", &volume, &restriction),
       Err(failure),

--- a/crates/wick/wick-config/src/lockdown/volume.rs
+++ b/crates/wick/wick-config/src/lockdown/volume.rs
@@ -137,7 +137,7 @@ mod test {
       restriction.0.into_iter().map(Into::into).collect::<Vec<_>>(),
       restriction.1,
     );
-    restriction.render_config(None, None)?;
+    restriction.render_config(None, None, None)?;
     assert_eq!(
       is_allowed(component_id, "VOLUME_ID", &volume, &restriction),
       Ok(()),
@@ -169,7 +169,7 @@ mod test {
       restriction.0.into_iter().map(Into::into).collect::<Vec<_>>(),
       restriction.1,
     );
-    restriction.render_config(None, Some(&env))?;
+    restriction.render_config(None, None, Some(&env))?;
     assert_eq!(
       is_allowed(component_id, "VOLUME_ID", &volume, &restriction),
       Err(failure),

--- a/crates/wick/wick-config/src/utils/config.rs
+++ b/crates/wick/wick-config/src/utils/config.rs
@@ -1,50 +1,35 @@
-use std::collections::HashMap;
 use std::sync::Arc;
 
 use parking_lot::RwLock;
-use wick_packet::RuntimeConfig;
 
-use crate::config::template_config::Renderable;
 use crate::config::{ImportBinding, ImportDefinition, OwnedConfigurationItem, ResourceBinding};
 use crate::{Error, Resolver, Result};
 
 pub(crate) type RwOption<T> = Arc<RwLock<Option<T>>>;
 
-pub(crate) fn make_resolver(
-  imports: Vec<ImportBinding>,
-  resources: Vec<ResourceBinding>,
-  runtime_config: Option<RuntimeConfig>,
-  env: Option<HashMap<String, String>>,
-) -> Box<Resolver> {
-  Box::new(move |name| resolve(name, &imports, &resources, runtime_config.as_ref(), env.as_ref()))
+pub(crate) fn make_resolver(imports: Vec<ImportBinding>, resources: Vec<ResourceBinding>) -> Box<Resolver> {
+  Box::new(move |name| resolve(name, &imports, &resources))
 }
 
 pub(crate) fn resolve(
   name: &str,
   imports: &[ImportBinding],
   resources: &[ResourceBinding],
-  runtime_config: Option<&RuntimeConfig>,
-  env: Option<&HashMap<String, String>>,
 ) -> Result<OwnedConfigurationItem> {
   tracing::trace!("resolving {}, imports: {:?}, resources: {:?}", name, imports, resources);
   if let Some(import) = imports.iter().find(|i| i.id == name) {
     match &import.kind {
       ImportDefinition::Component(component) => {
-        let mut component = component.clone();
-        return match component.render_config(runtime_config, env) {
-          Ok(_) => Ok(OwnedConfigurationItem::Component(component)),
-          Err(e) => Err(e),
-        };
+        let component = component.clone();
+
+        return Ok(OwnedConfigurationItem::Component(component));
       }
       ImportDefinition::Types(_) => todo!(),
     }
   }
   if let Some(resource) = resources.iter().find(|i| i.id == name) {
-    let mut resource = resource.kind.clone();
-    return match resource.render_config(runtime_config, env) {
-      Ok(_) => Ok(OwnedConfigurationItem::Resource(resource)),
-      Err(e) => Err(e),
-    };
+    let resource = resource.kind.clone();
+    return Ok(OwnedConfigurationItem::Resource(resource));
   }
   Err(Error::IdNotFound {
     id: name.to_owned(),

--- a/crates/wick/wick-runtime/src/runtime/scope/init.rs
+++ b/crates/wick/wick-runtime/src/runtime/scope/init.rs
@@ -162,6 +162,7 @@ impl ScopeInit {
       Some(self.namespace()),
       Some(components),
       make_link_callback(self.id),
+      self.manifest.root_config(),
       &self.span,
     )
     .map_err(init_err(self.manifest.source()))?;

--- a/crates/wick/wick-runtime/src/triggers/http/routers/rest.rs
+++ b/crates/wick/wick-runtime/src/triggers/http/routers/rest.rs
@@ -203,16 +203,7 @@ impl RestHandler {
         InherentData::unsafe_default(),
         &span,
       );
-      let runtime_config = if let Some(config) = route.operation.config() {
-        // TODO:FIX These operations are being rendered without access to the root config.
-        Some(
-          config
-            .render(None, None, None, Some(&invocation.inherent))
-            .map_err(|e| HttpError::OperationError(e.to_string()))?,
-        )
-      } else {
-        None
-      };
+      let runtime_config = route.operation.config().and_then(|c| c.value().cloned());
 
       let stream = runtime
         .invoke(invocation, runtime_config)

--- a/crates/wick/wick-test/src/runner.rs
+++ b/crates/wick/wick-test/src/runner.rs
@@ -7,7 +7,6 @@ use wick_interface_types::{Field, OperationSignature};
 use wick_packet::{Entity, Invocation, RuntimeConfig};
 
 use crate::assertion_packet::ToAssertionPacket;
-use crate::utils::render_config;
 use crate::{get_payload, TestError, UnitTest};
 
 #[must_use]
@@ -63,9 +62,8 @@ async fn run_unit<'a>(
 ) -> Result<TestBlock, TestError> {
   let span = info_span!("unit test", name = def.test.name());
 
-  let op_config = render_config(def.test.config(), None)?;
+  let op_config = def.test.config().and_then(|v| v.value().cloned());
   let signature = get_operation(&component, def.test.operation())?;
-
   validate_config(def.test.name(), op_config.as_ref(), &signature.config)?;
 
   let (stream, inherent, explicit_done) = get_payload(def, root_config.as_ref(), op_config.as_ref())?;

--- a/crates/wick/wick-test/src/test_group.rs
+++ b/crates/wick/wick-test/src/test_group.rs
@@ -26,13 +26,6 @@ impl<'a> TestGroup<'a> {
     }
   }
 
-  pub fn get_tests<'b>(&'a mut self) -> Vec<&'a mut UnitTest<'b>>
-  where
-    'a: 'b,
-  {
-    self.tests.iter_mut().collect()
-  }
-
   pub fn name(mut self, name: String) -> Self {
     self.name = name;
     self
@@ -47,8 +40,8 @@ impl<'a> TestGroup<'a> {
     let name = self.name.clone();
     let config = self.root_config.clone();
     let tests = self
-      .get_tests()
-      .into_iter()
+      .tests
+      .iter_mut()
       .filter(|test| {
         if filter.is_empty() {
           return true;

--- a/crates/wick/wick-test/src/test_suite.rs
+++ b/crates/wick/wick-test/src/test_suite.rs
@@ -1,7 +1,6 @@
 use tap_harness::TestRunner;
 use wick_config::config::TestConfiguration;
 
-use crate::utils::render_config;
 use crate::{ComponentFactory, TestError, TestGroup};
 
 #[derive(Debug, Default)]
@@ -19,7 +18,7 @@ impl<'a> TestSuite<'a> {
       .iter()
       .map(|config| {
         Ok(TestGroup::from_test_cases(
-          render_config(config.config(), None)?,
+          config.config().and_then(|c| c.value().cloned()),
           config.cases(),
         ))
       })
@@ -32,7 +31,7 @@ impl<'a> TestSuite<'a> {
     'b: 'a,
   {
     self.tests.push(TestGroup::from_test_cases(
-      render_config(config.config(), None)?,
+      config.config().and_then(|c| c.value().cloned()),
       config.cases(),
     ));
     Ok(())

--- a/crates/wick/wick-test/src/utils.rs
+++ b/crates/wick/wick-test/src/utils.rs
@@ -4,16 +4,7 @@ use either::Either;
 use wasmrs_codec::messagepack;
 use wick_config::config::test_case::{ErrorPayload, PacketFlag, SuccessPayload};
 use wick_config::config::LiquidJsonConfig;
-use wick_packet::{
-  InherentData,
-  Packet,
-  PacketError,
-  PacketPayload,
-  RuntimeConfig,
-  CLOSE_BRACKET,
-  DONE_FLAG,
-  OPEN_BRACKET,
-};
+use wick_packet::{Packet, PacketError, PacketPayload, RuntimeConfig, CLOSE_BRACKET, DONE_FLAG, OPEN_BRACKET};
 
 use crate::error::TestError;
 
@@ -60,7 +51,7 @@ pub(crate) fn gen_packet(
       PacketPayload::Err(PacketError::new(
         error
           .error()
-          .render(None, Some(&std::env::vars().collect()))
+          .render(None, None, Some(&std::env::vars().collect()))
           .config_error()?,
       )),
       convert_flags(error.flag()),
@@ -79,16 +70,4 @@ fn convert_flags(flag: Option<&PacketFlag>) -> u8 {
     }
   }
   byte
-}
-
-pub(crate) fn render_config(
-  config: Option<&LiquidJsonConfig>,
-  inherent: Option<&InherentData>,
-) -> Result<Option<RuntimeConfig>, TestError> {
-  if let Some(config) = config {
-    let env = std::env::vars().collect();
-    Ok(Some(config.render(None, None, Some(&env), inherent).config_error()?))
-  } else {
-    Ok(None)
-  }
 }

--- a/examples/components/tests.wick
+++ b/examples/components/tests.wick
@@ -9,6 +9,9 @@ component:
   kind: wick/component/composite@v1
   operations:
     - name: echo
+      with:
+        - name: op_config_val
+          type: string
       uses:
         - name: SENDER
           operation: core::sender
@@ -16,6 +19,7 @@ component:
             output:
               num: 42
               string: 'Hello, world!'
+              from_context: '{{ctx.config.op_config_val}}'
       flow:
         - SENDER -> <>
 tests:
@@ -23,14 +27,17 @@ tests:
     cases:
       - name: strict_equal
         operation: echo
+        with: { op_config_val: 'strict_equal' }
         inputs: []
         outputs:
           - name: output
             value:
               string: 'Hello, world!'
               num: 42
+              from_context: 'strict_equal'
       - name: assertions
         operation: echo
+        with: { op_config_val: 'assertions' }
         inputs: []
         outputs:
           - name: output

--- a/examples/components/wasi-fs/component.wick
+++ b/examples/components/wasi-fs/component.wick
@@ -53,7 +53,7 @@ component:
     #       type: int
 tests:
   - with:
-      root: '.'
+      root: '{{__dirname}}'
     cases:
       - operation: read_string
         inputs:

--- a/src/commands/config/dot.rs
+++ b/src/commands/config/dot.rs
@@ -65,7 +65,7 @@ pub(crate) async fn handle(
   config.set_root_config(root_config);
   let manifest = config.finish()?.try_component_config()?;
 
-  let manifest = merge_config(&manifest, &opts.oci, None);
+  let manifest = merge_config(manifest, &opts.oci, None);
 
   let mut host = ComponentHostBuilder::default().manifest(manifest).span(span).build()?;
 

--- a/src/commands/serve.rs
+++ b/src/commands/serve.rs
@@ -34,7 +34,7 @@ pub(crate) async fn handle(
   manifest.set_root_config(with_config);
   let manifest = manifest.finish()?.try_component_config()?;
 
-  let config = merge_config(&manifest, &opts.oci, Some(opts.cli));
+  let config = merge_config(manifest, &opts.oci, Some(opts.cli));
 
   let mut host = ComponentHostBuilder::default().manifest(config).span(span).build()?;
 

--- a/src/commands/test.rs
+++ b/src/commands/test.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::Result;
@@ -54,7 +55,19 @@ pub(crate) async fn handle(
     .into_inner()
     .try_component_config()?;
 
-  let mut suite = TestSuite::from_configuration(root_manifest.tests())?;
+  let mut tests = root_manifest.tests().to_vec();
+
+  let env: HashMap<_, _> = std::env::vars().collect();
+  for test in tests.iter_mut() {
+    // We need to explicitly initialize this part
+    // because we stole them from the unitialized component
+    // config.
+    test.set_env(env.clone());
+    test.set_source(root_manifest.source().unwrap());
+    test.initialize()?;
+  }
+
+  let mut suite = TestSuite::from_configuration(&tests)?;
 
   let test_files: Vec<_> = futures::future::join_all(opts.tests.iter().map(|path| {
     WickConfiguration::fetch(path, oci_opts.clone())
@@ -70,29 +83,29 @@ pub(crate) async fn handle(
 
   let server_options = DefaultCliOptions { ..Default::default() };
 
-  let manifest = merge_config(&root_manifest, &opts.oci, Some(server_options));
+  let manifest = merge_config(root_manifest, &opts.oci, Some(server_options));
 
   let factory: ComponentFactory = Box::new(move |config| {
-    let mut builder = UninitializedConfiguration::new(WickConfiguration::Component(manifest.clone()));
+    let builder = UninitializedConfiguration::new(WickConfiguration::Component(manifest.clone()));
     let span = span.clone();
 
     let task = async move {
-      builder.set_root_config(config);
-      let manifest = builder
-        .finish()
-        .map_err(|e| wick_test::TestError::Factory(e.to_string()))?
-        .try_component_config()
-        .unwrap();
+      let mut manifest = builder.into_inner().try_component_config().unwrap();
+      manifest.set_root_config(config);
+      manifest
+        .initialize()
+        .map_err(|e| wick_test::TestError::Factory(e.to_string()))?;
 
       let mut host = ComponentHostBuilder::default()
         .manifest(manifest)
         .span(span)
         .build()
-        .map_err(|e| wick_test::TestError::Factory(e.to_string()))?;
+        .map_err(|e| wick_test::TestError::Factory(format!("could not build host: {}", e.to_string())))?;
       host
         .start_runtime(opts.seed.map(Seed::unsafe_new))
         .await
         .map_err(|e| wick_test::TestError::Factory(e.to_string()))?;
+
       let component: SharedComponent = Arc::new(wick_host::HostComponent::new(host));
       Ok(component)
     };

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -44,11 +44,11 @@ pub(crate) async fn fetch_wick_tree(
 }
 
 pub(crate) fn merge_config(
-  def: &ComponentConfiguration,
+  def: ComponentConfiguration,
   local_cli_opts: &crate::options::oci::OciOptions,
   server_cli_opts: Option<DefaultCliOptions>,
 ) -> ComponentConfiguration {
-  let mut merged_manifest = def.clone();
+  let mut merged_manifest = def;
   let mut host_config = merged_manifest.host().cloned().unwrap_or_default();
 
   host_config.set_allow_latest(local_cli_opts.allow_latest || host_config.allow_latest());

--- a/src/wick_host.rs
+++ b/src/wick_host.rs
@@ -36,7 +36,7 @@ pub(crate) async fn build_host(
     WickConfiguration::Component(_) => {
       let manifest = manifest.finish()?.try_component_config()?;
 
-      let manifest = merge_config(&manifest, &oci, server_settings);
+      let manifest = merge_config(manifest, &oci, server_settings);
 
       let mut host = ComponentHostBuilder::default()
         .id(manifest.name().map_or_else(|| "component".to_owned(), |s| s.clone()))


### PR DESCRIPTION
This PR makes `__dirname` available to configuration templates.

`__dirname` is set to the filename the configuration exists in.

Up for discussion: `__dirname` is available on the root as it feels different than the `ctx` namespace we have right now, i.e. `{{ __dirname }}` vs `{{ ctx.__dirname }}`.

The ctx context is relative to the component, configuration, its operations, etc. `__dirname` just *is*.
