### PR TITLE
Added more progress events at startup

### DIFF
--- a/crates/wick/wick-runtime/src/components.rs
+++ b/crates/wick/wick-runtime/src/components.rs
@@ -212,7 +212,7 @@ pub(crate) async fn init_impl(
     }
     config::ComponentImplementation::Composite(_) => {
       let uuid = rng.uuid();
-      let _scope = init_child(uuid, manifest.clone(), Some(id.clone()), opts).await?;
+      let _scope = init_child(uuid, manifest.clone(), id.clone(), opts).await?;
 
       let component = Arc::new(scope_component::ScopeComponent::new(uuid));
       let service = NativeComponentService::new(component);

--- a/crates/wick/wick-runtime/src/runtime/scope/child_init.rs
+++ b/crates/wick/wick-runtime/src/runtime/scope/child_init.rs
@@ -36,10 +36,10 @@ impl std::fmt::Debug for ChildInit {
 pub(crate) fn init_child(
   uid: Uuid,
   manifest: ComponentConfiguration,
-  namespace: Option<String>,
+  namespace: String,
   opts: ChildInit,
 ) -> BoxFuture<'static, Result<Scope, ScopeError>> {
-  let child_span = info_span!(parent:opts.span,"runtime:child",id=%uid);
+  let child_span = info_span!(parent:&opts.span,"scope",id=%namespace);
   let mut components = ComponentRegistry::default();
 
   Box::pin(async move {
@@ -56,7 +56,7 @@ pub(crate) fn init_child(
       manifest,
       allow_latest: opts.allow_latest,
       allowed_insecure: opts.allowed_insecure,
-      namespace,
+      namespace: Some(namespace),
       constraints: Default::default(),
       span: child_span,
       initial_components: components,

--- a/src/commands/invoke.rs
+++ b/src/commands/invoke.rs
@@ -150,7 +150,7 @@ pub(crate) async fn handle(
         e
       )
     })?;
-    trace!(args= ?args, "parsed CLI arguments");
+    span.in_scope(|| trace!(args= ?args, "parsed CLI arguments"));
     let mut packets = Vec::new();
     let mut seen_ports = HashSet::new();
     for packet in args {
@@ -160,8 +160,10 @@ pub(crate) async fn handle(
     for port in seen_ports {
       packets.push(Ok(Packet::done(port)));
     }
-    debug!(cli_packets= ?packets, "wick invoke");
+    span.in_scope(|| debug!(cli_packets= ?packets, "wick invoke"));
     let stream = PacketStream::new(futures::stream::iter(packets));
+
+    span.in_scope(|| info!(operation=%target,path= ?path_parts, "host loaded, invoking operation"));
 
     let invocation = Invocation::new(Entity::server(host.namespace()), target, stream, inherent_data, &span);
 

--- a/src/wick_host.rs
+++ b/src/wick_host.rs
@@ -34,6 +34,7 @@ pub(crate) async fn build_host(
   manifest.set_root_config(root_config);
   let host = match manifest.manifest() {
     WickConfiguration::Component(_) => {
+      span.in_scope(|| info!("initializing component host"));
       let manifest = manifest.finish()?.try_component_config()?;
 
       let manifest = merge_config(manifest, &oci, server_settings);
@@ -48,6 +49,7 @@ pub(crate) async fn build_host(
       WickHost::Component(host)
     }
     WickConfiguration::App(_) => {
+      span.in_scope(|| info!("initializing application host"));
       let env: HashMap<String, String> = std::env::vars().collect();
       manifest.set_env(env);
       let app_config = manifest.finish()?.try_app_config()?;


### PR DESCRIPTION
With the increasing size of applications, the time between a `run` or an `invoke` and seeing anything happen is growing.

This adds progress events after each component is instantiated, as well as the time it took to do so to highlight progress and potential spots for improvement.

Example output attached.

<img width="883" alt="Screenshot 2023-08-31 at 6 53 21 PM" src="https://github.com/candlecorp/wick/assets/842798/37b3bbef-dd41-4d8d-a9e2-34670845b6ea">
