### PR TITLE
Made wick-config deps feature-dependent

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,7 +93,7 @@ debug = true
 # crates/wick
 #
 flow-component = { path = "./crates/wick/flow-component", version = "0.5.0", default-features = false }
-flow-expression-parser = { path = "./crates/wick/flow-expression-parser", version = "0.5.0" }
+flow-expression-parser = { path = "./crates/wick/flow-expression-parser", version = "0.5.0", default-features = false }
 flow-graph = { path = "./crates/wick/flow-graph", version = "0.21.0" }
 flow-graph-interpreter = { path = "./crates/wick/flow-graph-interpreter", version = "0.20.0" }
 wick-logger = { path = "./crates/wick/wick-logger", version = "0.2.0" }

--- a/crates/wick/flow-expression-parser/Cargo.toml
+++ b/crates/wick/flow-expression-parser/Cargo.toml
@@ -8,6 +8,9 @@ repository = "https://github.com/candlecorp/wick"
 description = "Parser for flow expressions in the Wick configuration manifest."
 readme = "README.md"
 
+[features]
+default = ["std"]
+std = ["seeded-random/std"]
 
 [dependencies]
 regex = { workspace = true }
@@ -17,7 +20,7 @@ thiserror = { workspace = true }
 nom = { workspace = true, features = ["alloc"] }
 liquid-json = { workspace = true, features = ["serde"] }
 once_cell = { workspace = true }
-seeded-random = { workspace = true, features = ["std", "rng", "uuid"] }
+seeded-random = { workspace = true, features = ["rng", "uuid"] }
 parking_lot = { workspace = true }
 
 

--- a/crates/wick/flow-expression-parser/src/ast.rs
+++ b/crates/wick/flow-expression-parser/src/ast.rs
@@ -7,7 +7,11 @@ use parking_lot::Mutex;
 
 use crate::{parse, Error};
 
+#[cfg(feature = "std")]
 pub(crate) static RNG: Lazy<Mutex<seeded_random::Random>> = Lazy::new(|| Mutex::new(seeded_random::Random::new()));
+#[cfg(not(feature = "std"))]
+pub(crate) static RNG: Lazy<Mutex<seeded_random::Random>> =
+  Lazy::new(|| Mutex::new(seeded_random::Random::from_seed(seeded_random::Seed::unsafe_new(0))));
 
 /// Set the seed for the RNG.
 ///

--- a/crates/wick/flow-graph-interpreter/Cargo.toml
+++ b/crates/wick/flow-graph-interpreter/Cargo.toml
@@ -17,7 +17,7 @@ wick-packet = { workspace = true, features = ["invocation", "rt-tokio"] }
 flow-graph = { workspace = true }
 flow-component = { workspace = true, features = ["invocation"] }
 wick-config = { workspace = true, features = ["config"] }
-flow-expression-parser = { workspace = true }
+flow-expression-parser = { workspace = true, features = ["std"] }
 wick-interface-types = { workspace = true }
 seeded-random = { workspace = true, features = ["uuid", "rng", "std"] }
 thiserror = { workspace = true }

--- a/crates/wick/wick-config/Cargo.toml
+++ b/crates/wick/wick-config/Cargo.toml
@@ -11,47 +11,90 @@ readme = "README.md"
 
 [features]
 default = ["v1", "v0", "config"]
-config = []
-v1 = []
-v0 = []
+config = [
+  "wick-asset-reference",
+  "flow-component",
+  "flow-expression-parser/std",
+  "wick-packet",
+  "liquid-json",
+  "url",
+  "derive-asset-container",
+  "asset-container",
+  "tracing",
+  "derive_builder",
+  "glob",
+  "parking_lot",
+  "option-utils",
+  "property",
+  "normpath",
+  "async-recursion",
+  "wildmatch",
+]
+v1 = [
+  "liquid-json",
+  "num-traits",
+  "serde-value",
+  "serde_with",
+  "flow-expression-parser",
+]
+v0 = [
+  "liquid-json",
+  "num-traits",
+  "serde-value",
+  "serde-with-expand-env",
+  "flow-expression-parser",
+]
 
 [dependencies]
-flow-component = { workspace = true }
-flow-expression-parser = { workspace = true }
-wick-packet = { workspace = true, default-features = false, features = [
-  "validation",
-  "std",
-  "rng",
-] }
+
+flow-expression-parser = { workspace = true, default-features = false, optional = true }
 wick-interface-types = { workspace = true, features = [
   "yaml",
   "parser",
   "value",
 ] }
-wick-asset-reference = { workspace = true }
-regex = { workspace = true }
+
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+
+regex = { workspace = true }
 serde_yaml = { workspace = true }
-serde_with = { workspace = true, features = ["std", "macros"] }
 thiserror = { workspace = true }
-tracing = { workspace = true }
-serde-value = { workspace = true }
-num-traits = { workspace = true }
-serde-with-expand-env = { workspace = true }
-asset-container = { workspace = true }
-derive-asset-container = { workspace = true }
-derive_builder = { workspace = true }
-tokio = { workspace = true, features = ["fs"] }
-url = { workspace = true, features = ["serde"] }
-glob = { workspace = true }
-parking_lot = { workspace = true }
-liquid-json = { workspace = true, features = ["serde"] }
-option-utils = { workspace = true }
-property = { workspace = true }
-normpath = { workspace = true }
-async-recursion = { workspace = true }
-wildmatch = { workspace = true }
+
+# config + v1 + v0
+liquid-json = { workspace = true, features = ["serde"], optional = true }
+
+# config
+flow-component = { workspace = true, optional = true }
+wick-packet = { workspace = true, default-features = false, features = [
+  "validation",
+  "std",
+  "rng",
+], optional = true }
+url = { workspace = true, features = ["serde"], optional = true }
+wick-asset-reference = { workspace = true, optional = true }
+derive-asset-container = { workspace = true, optional = true }
+asset-container = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
+derive_builder = { workspace = true, optional = true }
+glob = { workspace = true, optional = true }
+parking_lot = { workspace = true, optional = true }
+option-utils = { workspace = true, optional = true }
+property = { workspace = true, optional = true }
+normpath = { workspace = true, optional = true }
+async-recursion = { workspace = true, optional = true }
+wildmatch = { workspace = true, optional = true }
+
+# v1 & v0
+num-traits = { workspace = true, optional = true }
+
+# v1
+serde_with = { workspace = true, features = ["std", "macros"], optional = true }
+
+# v0
+serde-value = { workspace = true, optional = true }
+serde-with-expand-env = { workspace = true, optional = true }
+
 
 [dev-dependencies]
 wick-xdg = { workspace = true }

--- a/crates/wick/wick-config/Justfile
+++ b/crates/wick/wick-config/Justfile
@@ -1,9 +1,9 @@
 features:
   - cargo build --features=config --no-default-features
   - cargo build --features=v1 --no-default-features
+  - cargo build --features=v1 --no-default-features --target=wasm32-unknown-unknown
   - cargo build --features=v0 --no-default-features
   - cargo build --features=v0 --features=config --no-default-features
-
 
 clean:
   rm -f docs/*

--- a/crates/wick/wick-config/src/error.rs
+++ b/crates/wick/wick-config/src/error.rs
@@ -1,6 +1,5 @@
 use std::path::PathBuf;
 
-use derive_builder::UninitializedFieldError;
 use thiserror::Error;
 
 // type BoxedSyncSendError = Box<dyn std::error::Error + Sync + std::marker::Send>;
@@ -14,10 +13,12 @@ pub enum ManifestError {
   VersionError(String),
 
   /// Error related to asset references.
+  #[cfg(feature = "config")]
   #[error(transparent)]
   AssetReference(#[from] wick_asset_reference::Error),
 
   /// Error related to fetching asset references.
+  #[cfg(feature = "config")]
   #[error(transparent)]
   AssetContainer(#[from] asset_container::Error),
 
@@ -112,6 +113,7 @@ pub enum ManifestError {
   ConfigurationTemplate(String),
 
   /// Passed [wick_packet::RuntimeConfig] is invalid for the configuration required by this component.
+  #[cfg(feature = "config")]
   #[error(transparent)]
   ConfigurationInvalid(#[from] wick_packet::Error),
 
@@ -133,6 +135,7 @@ pub enum ManifestError {
   Reference(#[from] ReferenceError),
 
   /// Error building a configuration
+  #[cfg(feature = "config")]
   #[error(transparent)]
   Builder(#[from] BuilderError),
 
@@ -166,6 +169,8 @@ pub enum ReferenceError {
     actual: crate::config::resources::ResourceKind,
   },
 }
+
+#[cfg(feature = "config")]
 /// Errors generated when building a configuration.
 #[derive(Error, Debug)]
 pub enum BuilderError {
@@ -176,13 +181,17 @@ pub enum BuilderError {
   #[error("Invalid builder configuration: {0}")]
   ValidationError(String),
 }
+
+#[cfg(feature = "config")]
 impl From<String> for BuilderError {
   fn from(s: String) -> Self {
     Self::ValidationError(s)
   }
 }
-impl From<UninitializedFieldError> for BuilderError {
-  fn from(value: UninitializedFieldError) -> Self {
+
+#[cfg(feature = "config")]
+impl From<derive_builder::UninitializedFieldError> for BuilderError {
+  fn from(value: derive_builder::UninitializedFieldError) -> Self {
     Self::UninitializedField(value.field_name())
   }
 }

--- a/crates/wick/wick-config/src/lib.rs
+++ b/crates/wick/wick-config/src/lib.rs
@@ -137,6 +137,7 @@ pub mod config;
 pub mod error;
 mod utils;
 
+#[allow(unused)]
 pub(crate) use utils::impl_from_for;
 
 /// Wick Manifest v0 implementation.
@@ -169,11 +170,15 @@ mod feature_config {
     type Config;
     fn validate(config: &Self::Config, resolver: &Resolver) -> Result<(), flow_component::ComponentError>;
   }
+  pub use wick_asset_reference::{
+    normalize_path,
+    AssetReference,
+    Error as AssetError,
+    FetchOptions,
+    FetchableAssetReference,
+  };
 }
 #[cfg(feature = "config")]
 pub use feature_config::*;
-pub use wick_asset_reference::Error as AssetError;
 
 pub(crate) type Result<T> = std::result::Result<T, Error>;
-
-pub use wick_asset_reference::{normalize_path, AssetReference, FetchOptions, FetchableAssetReference};

--- a/crates/wick/wick-config/src/utils.rs
+++ b/crates/wick/wick-config/src/utils.rs
@@ -18,6 +18,7 @@ pub(crate) fn opt_str_to_ipv4addr(v: &Option<String>) -> Result<Option<Ipv4Addr>
 }
 
 /// Utility macro for implementing `From` for a type.
+#[allow(unused)]
 macro_rules! impl_from_for {
   ($root:ident, $variant: ident, $type:ty) => {
     impl From<$type> for $root {


### PR DESCRIPTION
This PR makes the `wick-config` dependencies optional and feature-specific. The purpose of this is to make (at least) v1 configs easily usable in `wasm32-unknown-unknown` targets so we can make wick components that generate configuration more easily.