### PR TITLE
Added ability for `wick reg pull` to pull to the local dir (vs module hierarchy)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2638,77 +2638,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
-name = "liquid"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f68ae1011499ae2ef879f631891f21c78e309755f4a5e483c4a8f12e10b609"
-dependencies = [
- "doc-comment",
- "liquid-core",
- "liquid-derive",
- "liquid-lib",
- "serde",
-]
-
-[[package]]
-name = "liquid-core"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e0724dfcaad5cfb7965ea0f178ca0870b8d7315178f4a7179f5696f7f04d5f"
-dependencies = [
- "anymap2",
- "itertools 0.10.5",
- "kstring",
- "liquid-derive",
- "num-traits",
- "pest",
- "pest_derive",
- "regex",
- "serde",
- "time 0.3.28",
-]
-
-[[package]]
-name = "liquid-derive"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2fb41a9bb4257a3803154bdf7e2df7d45197d1941c9b1a90ad815231630721"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.29",
-]
-
-[[package]]
 name = "liquid-json"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2ca2e69be23a333da932de11a7e9384a34388484fa1e6397b96677e3e5b8bd"
+checksum = "5fda1293f31a41ad176e3010dd595a2546185d03d698953d77e6b270e39df3ce"
 dependencies = [
  "base64 0.21.3",
- "liquid",
- "liquid-core",
- "liquid-lib",
+ "loose-liquid",
+ "loose-liquid-core",
+ "loose-liquid-lib",
  "once_cell",
  "regex",
  "serde",
  "serde_json",
  "thiserror",
-]
-
-[[package]]
-name = "liquid-lib"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2a17e273a6fb1fb6268f7a5867ddfd0bd4683c7e19b51084f3d567fad4348c0"
-dependencies = [
- "itertools 0.10.5",
- "liquid-core",
- "once_cell",
- "percent-encoding",
- "regex",
- "time 0.3.28",
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -2726,6 +2669,63 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "loose-liquid"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f63f0abe02457a2deef7569256795cef63508e0cac98db080235bded31d7a7"
+dependencies = [
+ "doc-comment",
+ "loose-liquid-core",
+ "loose-liquid-derive",
+ "loose-liquid-lib",
+ "serde",
+]
+
+[[package]]
+name = "loose-liquid-core"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7af79546e1a0ee1ccdf060851d483882bde7fa44867b96ae3f65c8b60a57000a"
+dependencies = [
+ "anymap2",
+ "itertools 0.11.0",
+ "kstring",
+ "loose-liquid-derive",
+ "num-traits",
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde",
+ "time 0.3.28",
+]
+
+[[package]]
+name = "loose-liquid-derive"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "292ff081244def41f5f038322867d60472efcf42620703e930d50015cc526af6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.29",
+]
+
+[[package]]
+name = "loose-liquid-lib"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bc580906c4e98055fa02642f3c548653b4ba3988d9a43bb74a9a1ec604be28b"
+dependencies = [
+ "itertools 0.11.0",
+ "loose-liquid-core",
+ "once_cell",
+ "percent-encoding",
+ "regex",
+ "time 0.3.28",
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "mach"
@@ -6780,7 +6780,7 @@ dependencies = [
  "hyper-staticfile",
  "itertools 0.11.0",
  "lazy_static",
- "liquid",
+ "loose-liquid",
  "once_cell",
  "openapiv3",
  "parking_lot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -203,8 +203,8 @@ itertools = { version = "0.11", default-features = false, features = [
 jaq-core = { version = "0.10", default-features = false }
 json_dotpath = { version = "1.1.0", default-features = false }
 lazy_static = { version = "1.4", default-features = false }
-liquid = { version = "0.26", default-features = false }
-liquid-json = { version = "0.5", default-features = false }
+liquid = { package = "loose-liquid", version = "0.27", default-features = false }
+liquid-json = { version = "0.6", default-features = false }
 markup-converter = { version = "0.2", default-features = false }
 mslnk = { version = "0.1.8", default-features = false }
 nkeys = { version = "0.3", default-features = false }

--- a/crates/wick/wick-oci-utils/src/options.rs
+++ b/crates/wick/wick-oci-utils/src/options.rs
@@ -24,7 +24,11 @@ pub struct OciOptions {
   #[getset(get = "pub", set = "pub")]
   pub(crate) cache_dir: PathBuf,
   #[getset(get = "pub", set = "pub")]
+  pub(crate) flatten: bool,
+  #[getset(get = "pub", set = "pub")]
   pub(crate) on_existing: OnExisting,
+  #[getset(get = "pub", set = "pub")]
+  pub(crate) ignore_manifest: bool,
 }
 
 impl Default for OciOptions {
@@ -35,8 +39,10 @@ impl Default for OciOptions {
       allow_insecure: vec![],
       username: None,
       password: None,
+      flatten: false,
       cache_dir: xdg.global().cache().clone(),
       on_existing: OnExisting::Ignore,
+      ignore_manifest: false,
     }
   }
 }

--- a/crates/wick/wick-oci-utils/src/package.rs
+++ b/crates/wick/wick-oci-utils/src/package.rs
@@ -13,16 +13,16 @@ pub mod media_types;
 /// Represents a single file in a Wick package.
 #[derive(Debug, Clone)]
 pub struct PackageFile {
-  path: PathBuf,
+  package_path: PathBuf,
   hash: String,
   media_type: String,
   contents: bytes::Bytes,
 }
 
 impl PackageFile {
-  pub fn new(path: PathBuf, hash: String, media_type: String, contents: bytes::Bytes) -> Self {
+  pub fn new(package_path: PathBuf, hash: String, media_type: String, contents: bytes::Bytes) -> Self {
     Self {
-      path,
+      package_path,
       hash,
       media_type,
       contents,
@@ -31,8 +31,8 @@ impl PackageFile {
 
   /// Get path for the file.
   #[must_use]
-  pub const fn path(&self) -> &PathBuf {
-    &self.path
+  pub const fn package_path(&self) -> &PathBuf {
+    &self.package_path
   }
 
   /// Get hash for the file.

--- a/crates/wick/wick-oci-utils/src/package/push.rs
+++ b/crates/wick/wick-oci-utils/src/package/push.rs
@@ -27,7 +27,7 @@ pub async fn push(
   for file in files {
     let mut annotations_map: HashMap<String, String> = HashMap::new();
 
-    annotations_map.insert(annotations::TITLE.to_owned(), file.path().display().to_string());
+    annotations_map.insert(annotations::TITLE.to_owned(), file.package_path().display().to_string());
     let media_type = file.media_type().to_owned();
     let digest = file.hash().to_owned();
     let data = file.into_contents();

--- a/crates/wick/wick-package/tests/wick_package_types_integration.rs
+++ b/crates/wick/wick-package/tests/wick_package_types_integration.rs
@@ -28,7 +28,7 @@ mod integration_test {
     // Run the push operation
     let package_path = Path::new("./tests/files/mytypes.wick");
     println!("Package path: {:?}", package_path);
-    let mut package = WickPackage::from_path(package_path).await.unwrap();
+    let mut package = WickPackage::from_path(None, package_path).await.unwrap();
     // Set the host to the whatever docker registry the tests are using.
     package.registry_mut().map(|r| r.set_host(host));
 
@@ -71,22 +71,26 @@ mod integration_test {
     // Sort both the pushed_files and pulled_files by path
     let mut pushed_files_sorted = pushed_files.clone();
     let mut pulled_files_sorted = pulled_files.clone();
-    pushed_files_sorted.sort_by_key(|file| file.path());
-    pulled_files_sorted.sort_by_key(|file| file.path());
+    pushed_files_sorted.sort_by_key(|file| file.package_path());
+    pulled_files_sorted.sort_by_key(|file| file.package_path());
 
     for (pushed_file, pulled_file) in pushed_files_sorted.iter().zip(pulled_files_sorted.iter()) {
-      let pushed_file_path = pushed_file.path().to_str().unwrap().trim_start_matches(&crate_dir);
+      let pushed_file_path = pushed_file
+        .package_path()
+        .to_str()
+        .unwrap()
+        .trim_start_matches(&crate_dir);
       let pulled_file_path = pulled_file
-        .path()
+        .package_path()
         .to_str()
         .unwrap()
         .trim_start_matches(tempdir.to_str().unwrap());
       assert_eq!(pushed_file_path, pulled_file_path, "Mismatch in file paths");
       //if pushed_file.path() ends with .tar.gz, don't compare hashes
-      if pushed_file.path().to_str().unwrap().ends_with(".tar.gz") {
+      if pushed_file.package_path().to_str().unwrap().ends_with(".tar.gz") {
         continue;
       }
-      println!("Comparing hashes for file: {:?}", pushed_file.path());
+      println!("Comparing hashes for file: {:?}", pushed_file.package_path());
       assert_eq!(pushed_file.hash(), pulled_file.hash(), "Mismatch in file hashes");
       assert_eq!(
         pushed_file.media_type(),

--- a/examples/components/config-generator/Cargo.lock
+++ b/examples/components/config-generator/Cargo.lock
@@ -914,15 +914,6 @@ checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
@@ -983,77 +974,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
-name = "liquid"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f68ae1011499ae2ef879f631891f21c78e309755f4a5e483c4a8f12e10b609"
-dependencies = [
- "doc-comment",
- "liquid-core",
- "liquid-derive",
- "liquid-lib",
- "serde",
-]
-
-[[package]]
-name = "liquid-core"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79e0724dfcaad5cfb7965ea0f178ca0870b8d7315178f4a7179f5696f7f04d5f"
-dependencies = [
- "anymap2",
- "itertools 0.10.5",
- "kstring",
- "liquid-derive",
- "num-traits",
- "pest",
- "pest_derive",
- "regex",
- "serde",
- "time",
-]
-
-[[package]]
-name = "liquid-derive"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc2fb41a9bb4257a3803154bdf7e2df7d45197d1941c9b1a90ad815231630721"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.32",
-]
-
-[[package]]
 name = "liquid-json"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d2ca2e69be23a333da932de11a7e9384a34388484fa1e6397b96677e3e5b8bd"
+checksum = "5fda1293f31a41ad176e3010dd595a2546185d03d698953d77e6b270e39df3ce"
 dependencies = [
  "base64 0.21.4",
- "liquid",
- "liquid-core",
- "liquid-lib",
+ "loose-liquid",
+ "loose-liquid-core",
+ "loose-liquid-lib",
  "once_cell",
  "regex",
  "serde",
  "serde_json",
  "thiserror",
-]
-
-[[package]]
-name = "liquid-lib"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2a17e273a6fb1fb6268f7a5867ddfd0bd4683c7e19b51084f3d567fad4348c0"
-dependencies = [
- "itertools 0.10.5",
- "liquid-core",
- "once_cell",
- "percent-encoding",
- "regex",
- "time",
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -1071,6 +1005,63 @@ name = "log"
 version = "0.4.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+
+[[package]]
+name = "loose-liquid"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f63f0abe02457a2deef7569256795cef63508e0cac98db080235bded31d7a7"
+dependencies = [
+ "doc-comment",
+ "loose-liquid-core",
+ "loose-liquid-derive",
+ "loose-liquid-lib",
+ "serde",
+]
+
+[[package]]
+name = "loose-liquid-core"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7af79546e1a0ee1ccdf060851d483882bde7fa44867b96ae3f65c8b60a57000a"
+dependencies = [
+ "anymap2",
+ "itertools",
+ "kstring",
+ "loose-liquid-derive",
+ "num-traits",
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "loose-liquid-derive"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "292ff081244def41f5f038322867d60472efcf42620703e930d50015cc526af6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.32",
+]
+
+[[package]]
+name = "loose-liquid-lib"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bc580906c4e98055fa02642f3c548653b4ba3988d9a43bb74a9a1ec604be28b"
+dependencies = [
+ "itertools",
+ "loose-liquid-core",
+ "once_cell",
+ "percent-encoding",
+ "regex",
+ "time",
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "memchr"
@@ -2415,7 +2406,7 @@ dependencies = [
  "check_keyword",
  "derive_builder",
  "heck",
- "itertools 0.11.0",
+ "itertools",
  "prettyplease",
  "proc-macro2",
  "quote",

--- a/integration-tests/cli-tests/tests/cmd/run/wasm-component-calls.toml
+++ b/integration-tests/cli-tests/tests/cmd/run/wasm-component-calls.toml
@@ -22,6 +22,7 @@ triggers:
   - kind: wick/router/static@v1
     path: /
     volume: DIR
+    indexes: true
 
 Printing packets received from app_config.static_site_raw()
 kind: wick/app@v1
@@ -43,6 +44,7 @@ triggers:
   - kind: wick/router/static@v1
     path: /
     volume: DIR
+    indexes: true
 
 Printing packets received from the app_config.component().call()
 kind: wick/app@v1
@@ -64,5 +66,6 @@ triggers:
   - kind: wick/router/static@v1
     path: /
     volume: DIR
+    indexes: true
 
 """

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -39,7 +39,7 @@ pub(crate) async fn handle(
   let oci_opts = reconcile_fetch_options(&opts.application, &settings, opts.oci, None);
   let app_as_path = PathBuf::from(&opts.application);
   let package = if app_as_path.exists() {
-    WickPackage::from_path(&app_as_path).await?
+    WickPackage::from_path(None, &app_as_path).await?
   } else {
     crate::oci::pull(opts.application, oci_opts).await?
   };

--- a/src/commands/registry/push.rs
+++ b/src/commands/registry/push.rs
@@ -35,7 +35,7 @@ pub(crate) async fn handle(
 ) -> Result<StructuredOutput> {
   span.in_scope(|| debug!("push artifact"));
 
-  let mut package = wick_package::WickPackage::from_path(&opts.source)
+  let mut package = wick_package::WickPackage::from_path(None, &opts.source)
     .instrument(span.clone())
     .await?;
 


### PR DESCRIPTION
This PR adds a few options to the fetch options so that `wick reg pull` can optionally pull directly to the local directory vs. pulling everything to the standard wick module hierarchy, i.e.:

Instead of 

```console
$ wick reg pull common/azureblob:0.5.0
Pulled file:
- ./registry.candle.dev/common/azureblob/0.5.0/azureblob.wick
- ./registry.candle.dev/common/azureblob/0.5.0/azureblob-http-client.wick
```

You can add `-F` (for flatten) to get:

```console
$ wick reg pull common/azureblob:0.5.0 -F
Pulled file:
- ./azureblob.wick
- ./azureblob-http-client.wick
```

This makes it easier to use existing registry components as templates to jump off of.