### PR TITLE
Improved `wick reg push` to support immutable tags

### DIFF
--- a/crates/misc/asset-container/src/assets.rs
+++ b/crates/misc/asset-container/src/assets.rs
@@ -41,7 +41,7 @@ where
     self.asset.fetch_with_progress(options)
   }
 
-  fn fetch(&self, options: Self::Options) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, Error>> + Send + Sync + '_>> {
+  fn fetch(&self, options: Self::Options) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, Error>> + Send + '_>> {
     self.asset.fetch(options)
   }
 
@@ -406,7 +406,7 @@ pub trait AssetManager {
 pub trait Asset: AssetManager {
   type Options: Clone;
   fn fetch_with_progress(&self, options: Self::Options) -> Pin<Box<dyn Stream<Item = Progress> + Send + '_>>;
-  fn fetch(&self, options: Self::Options) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, Error>> + Send + Sync + '_>>;
+  fn fetch(&self, options: Self::Options) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, Error>> + Send + '_>>;
   fn name(&self) -> &str;
   fn update_baseurl(&self, baseurl: &Path);
 }
@@ -432,7 +432,7 @@ where
     )
   }
 
-  fn fetch(&self, options: Self::Options) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, Error>> + Send + Sync + '_>> {
+  fn fetch(&self, options: Self::Options) -> Pin<Box<dyn Future<Output = Result<Vec<u8>, Error>> + Send + '_>> {
     Box::pin(async move {
       match self {
         Some(a) => a.fetch(options).await,

--- a/crates/misc/asset-container/tests/assets.rs
+++ b/crates/misc/asset-container/tests/assets.rs
@@ -135,9 +135,7 @@ impl Asset for LocationReference {
   fn fetch(
     &self,
     _options: Self::Options,
-  ) -> std::pin::Pin<
-    Box<dyn futures::Future<Output = std::result::Result<Vec<u8>, asset_container::Error>> + Send + Sync>,
-  > {
+  ) -> std::pin::Pin<Box<dyn futures::Future<Output = std::result::Result<Vec<u8>, asset_container::Error>> + Send>> {
     let mut path = self
       .baseurl
       .lock()

--- a/crates/misc/derive-asset-container/tests/derive.rs
+++ b/crates/misc/derive-asset-container/tests/derive.rs
@@ -146,9 +146,7 @@ impl Asset for TestAsset {
   fn fetch(
     &self,
     _options: Self::Options,
-  ) -> std::pin::Pin<
-    Box<dyn futures::Future<Output = std::result::Result<Vec<u8>, asset_container::Error>> + Send + Sync>,
-  > {
+  ) -> std::pin::Pin<Box<dyn futures::Future<Output = std::result::Result<Vec<u8>, asset_container::Error>> + Send>> {
     let path = self.path.clone();
     Box::pin(async move {
       let mut file = tokio::fs::File::open(&path)

--- a/crates/wick/wick-asset-reference/src/asset_reference.rs
+++ b/crates/wick/wick-asset-reference/src/asset_reference.rs
@@ -213,7 +213,7 @@ impl Asset for AssetReference {
   fn fetch(
     &self,
     options: OciOptions,
-  ) -> std::pin::Pin<Box<dyn Future<Output = Result<Vec<u8>, assets::Error>> + Send + Sync>> {
+  ) -> std::pin::Pin<Box<dyn Future<Output = Result<Vec<u8>, assets::Error>> + Send>> {
     let asset = self.clone();
 
     Box::pin(async move {

--- a/crates/wick/wick-oci-utils/src/lib.rs
+++ b/crates/wick/wick-oci-utils/src/lib.rs
@@ -183,6 +183,19 @@ pub enum WickPackageKind {
   TYPES,
 }
 
+impl WickPackageKind {
+  /// Get the media type for the kind.
+  #[must_use]
+  pub const fn media_type(&self) -> &'static str {
+    use self::package::media_types;
+    match self {
+      Self::APPLICATION => media_types::APPLICATION,
+      Self::COMPONENT => media_types::COMPONENT,
+      Self::TYPES => media_types::TYPES,
+    }
+  }
+}
+
 /// Retrieve a manifest from an OCI url.
 pub async fn fetch_image_manifest(image: &str, options: &OciOptions) -> Result<(OciImageManifest, String), OciError> {
   if !options.allow_latest && image.ends_with(":latest") {

--- a/crates/wick/wick-oci-utils/src/package/push.rs
+++ b/crates/wick/wick-oci-utils/src/package/push.rs
@@ -1,27 +1,38 @@
 use std::collections::HashMap;
 
-use oci_distribution::client::{Client, ClientConfig, ImageLayer, PushResponse};
+use oci_distribution::client::{Client, ClientConfig, ImageLayer};
 use oci_distribution::manifest::{OciDescriptor, OciImageManifest};
+use oci_distribution::Reference;
 use sha256::digest;
 
 use super::annotations::Annotations;
 use super::{annotations, media_types, PackageFile};
-use crate::{Error, OciOptions};
+use crate::{Error, OciOptions, WickPackageKind};
+
+#[derive(Debug, Clone)]
+#[non_exhaustive]
+pub struct PushResponse {
+  /// Pullable url for the config
+  pub config_url: String,
+  /// Pullable url for the manifest
+  pub manifest_url: String,
+  /// The OCI reference for the pushed image
+  pub reference: String,
+  /// Pullable url for any additional tags referencing this manifest
+  pub tags: Vec<String>,
+}
+
 /// Push a Wick package to a registry.
 pub async fn push(
   reference: &str,
+  kind: WickPackageKind,
   config_json: String,
   files: Vec<PackageFile>,
   annotations: Annotations,
+  tags: Vec<String>,
   options: &OciOptions,
 ) -> Result<PushResponse, Error> {
-  let image_config = oci_distribution::client::Config {
-    data: config_json.as_bytes().to_vec(),
-    media_type: media_types::CONFIG.to_owned(),
-    annotations: None,
-  };
-
-  let mut image_layer_descriptors: Vec<OciDescriptor> = Vec::new();
+  let mut layers: Vec<OciDescriptor> = Vec::new();
   let mut image_layers: Vec<ImageLayer> = Vec::new();
 
   for file in files {
@@ -47,35 +58,29 @@ pub async fn push(
       urls: None,
     };
 
-    image_layer_descriptors.push(image_layer_descriptor);
+    layers.push(image_layer_descriptor);
     image_layers.push(image_layer);
   }
 
   let image_annotations: HashMap<String, String> = annotations.inner().clone();
 
-  let image_manifest = OciImageManifest {
-    schema_version: 2,
-    config: OciDescriptor {
-      media_type: image_config.media_type.clone(),
-      digest: format!("sha256:{}", digest(config_json.clone())),
-      size: image_config.data.clone().len() as i64,
-      annotations: None,
-      urls: None,
-    },
-    layers: image_layer_descriptors,
-    media_type: Some(media_types::MANIFEST.to_owned()),
-    annotations: Some(image_annotations),
-  };
+  let (image_config, image_manifest) = gen_manifest(
+    &config_json,
+    layers,
+    Some(image_annotations),
+    Some(kind.media_type().to_owned()),
+  );
 
   let (image_ref, protocol) = crate::utils::parse_reference_and_protocol(reference, &options.allow_insecure)?;
   let client_config = ClientConfig {
     protocol,
     ..Default::default()
   };
+
   let mut client = Client::new(client_config);
   let auth = options.get_auth();
 
-  let result = client
+  let push_response = match client
     .push(
       &image_ref,
       &image_layers,
@@ -83,13 +88,58 @@ pub async fn push(
       &auth,
       Some(image_manifest.clone()),
     )
-    .await;
-
-  match result {
-    Ok(push_response) => Ok(push_response),
+    .await
+  {
+    Ok(push_response) => push_response,
     Err(e) => {
-      tracing::error!(manifest = %image_manifest, error = %e, "Push failed");
-      Err(Error::PushFailed(e.to_string()))
+      tracing::error!(manifest = %image_ref, error = %e, "Push failed");
+      return Err(Error::PushFailed(e.to_string()));
     }
+  };
+
+  let mut pushed_tags = Vec::new();
+  for tag in tags {
+    let image_ref = Reference::with_tag(image_ref.registry().to_owned(), image_ref.repository().to_owned(), tag);
+
+    client
+      .push_manifest(&image_ref, &(image_manifest.clone().into()))
+      .await?;
+    pushed_tags.push(image_ref.to_string());
   }
+
+  Ok(PushResponse {
+    config_url: push_response.config_url,
+    manifest_url: push_response.manifest_url,
+    reference: image_ref.to_string(),
+    tags: pushed_tags,
+  })
+}
+
+fn gen_manifest(
+  config_json: &str,
+  layers: Vec<OciDescriptor>,
+  annotations: Option<HashMap<String, String>>,
+  artifact_type: Option<String>,
+) -> (oci_distribution::client::Config, OciImageManifest) {
+  let image_config = oci_distribution::client::Config {
+    data: config_json.as_bytes().to_vec(),
+    media_type: media_types::CONFIG.to_owned(),
+    annotations: None,
+  };
+
+  let manifest = OciImageManifest {
+    schema_version: 2,
+    config: OciDescriptor {
+      media_type: image_config.media_type.clone(),
+      digest: format!("sha256:{}", digest(config_json.clone())),
+      size: image_config.data.len() as i64,
+      annotations: None,
+      urls: None,
+    },
+    layers,
+    media_type: Some(media_types::MANIFEST.to_owned()),
+    annotations,
+    artifact_type,
+  };
+  (image_config, manifest)
 }

--- a/crates/wick/wick-package/tests/wick_package_integration.rs
+++ b/crates/wick/wick-package/tests/wick_package_integration.rs
@@ -43,7 +43,7 @@ mod integration_test {
     let reference = expected
       .tagged_reference(&test_timestamp.as_secs().to_string())
       .unwrap();
-    let push_result = package.push(&reference, &options).await;
+    let push_result = package.push(&reference, Vec::new(), &options).await;
     if push_result.is_err() {
       panic!("Failed to push WickPackage: {:?}", push_result);
     };

--- a/crates/wick/wick-package/tests/wick_package_types_integration.rs
+++ b/crates/wick/wick-package/tests/wick_package_types_integration.rs
@@ -43,7 +43,7 @@ mod integration_test {
     let reference = expected
       .tagged_reference(&test_timestamp.as_secs().to_string())
       .unwrap();
-    let push_result = package.push(&reference, &options).await;
+    let push_result = package.push(&reference, Vec::new(), &options).await;
     if push_result.is_err() {
       panic!("Failed to push WickPackage: {:?}", push_result);
     };


### PR DESCRIPTION
The previous implementation worked around a limitation in oci-distribution but made pushing to registries with immutable tags impossible. This PR depends on https://github.com/krustlet/oci-distribution/pull/93 and will fix both the unnecessary clones and the immutable tag issue.