### PR TITLE
Changed `wick query` from jaq to liquid

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,27 +34,27 @@ wick-package = { workspace = true }
 wick-logger = { workspace = true }
 flow-expression-parser = { workspace = true }
 seeded-random = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
-tracing = { workspace = true }
-serde_json = { workspace = true }
-serde_yaml = { workspace = true }
 anyhow = { workspace = true }
-dialoguer = { workspace = true, features = ["password"] }
-human-panic = { workspace = true }
-futures = { workspace = true }
-thiserror = { workspace = true }
-clap = { workspace = true, default-features = true, features = ["derive"] }
-nkeys = { workspace = true }
 atty = { workspace = true }
-jaq-core = { workspace = true, features = ["serde_json"] }
+clap = { workspace = true, default-features = true, features = ["derive"] }
+dhat = { workspace = true, optional = true }
+dialoguer = { workspace = true, features = ["password"] }
+futures = { workspace = true }
+human-panic = { workspace = true }
+liquid = { workspace = true }
+liquid-json = { workspace = true, features = ["serde"] }
 markup-converter = { workspace = true }
+nkeys = { workspace = true }
+once_cell = { workspace = true }
 openssl = { workspace = true, features = ["vendored"], optional = true }
 option-utils = { workspace = true }
-structured-output = { workspace = true }
 regex = { workspace = true }
-dhat = { workspace = true, optional = true }
-once_cell = { workspace = true }
-liquid-json = { workspace = true, features = ["serde"] }
+serde_json = { workspace = true }
+serde_yaml = { workspace = true }
+structured-output = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt", "rt-multi-thread"] }
+tracing = { workspace = true }
 
 [dev-dependencies]
 test_bin = { workspace = true }
@@ -199,7 +199,7 @@ hyper-reverse-proxy = { version = "0.5", default-features = false }
 itertools = { version = "0.11", default-features = false, features = [
   "use_std",
 ] }
-jaq-core = { version = "0.10", default-features = false }
+
 json_dotpath = { version = "1.1.0", default-features = false }
 lazy_static = { version = "1.4", default-features = false }
 liquid = { package = "loose-liquid", version = "0.27", default-features = false }

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -87,7 +87,7 @@ pub(crate) enum CliCommand {
   #[clap(subcommand, name = "rpc")]
   Rpc(rpc::SubCommands),
 
-  /// Command to query JSON, YAML, or TOML file.
+  /// Command to apply a liquid template to a JSON, YAML, or TOML file.
   #[clap(name = "query")]
   Query(query::Options),
 }

--- a/tests/invoke.rs
+++ b/tests/invoke.rs
@@ -1,23 +1,6 @@
-static DIR: &str = "invoke";
+mod utils;
 
-#[rstest::rstest]
-#[case("v1-wasmrs.toml")]
-#[case("stdin.toml")]
-#[case("app.toml")]
-fn wick_invoke(#[case] file: &'static str) {
-  let kind = "unit";
-  let file = format!("tests/{}/{}/{}", DIR, kind, file);
-
-  trycmd::TestCases::new().case(file);
-}
-
-// mod integration_test {
-//   use super::DIR;
-//   #[rstest::rstest]
-//   #[case("postgres.toml")]
-//   fn wick_run(#[case] file: &'static str) {
-//     let kind = "integration";
-//     let file = format!("tests/{}/{}/{}", kind, DIR, file);
-//     trycmd::TestCases::new().case(file);
-//   }
-// }
+utils::test_cases!(
+  unit: ["v1-wasmrs.toml", "stdin.toml", "app.toml"],
+  integration: []
+);

--- a/tests/new.rs
+++ b/tests/new.rs
@@ -1,27 +1,15 @@
-static DIR: &str = "new";
+mod utils;
 
-#[rstest::rstest]
-#[case("app.toml")]
-#[case("app-cli.toml")]
-#[case("app-http.toml")]
-#[case("app-time.toml")]
-#[case("component-composite.toml")]
-#[case("component-sql.toml")]
-#[case("component-http.toml")]
-#[case("component-wasm.toml")]
-fn wick_new(#[case] file: &'static str) {
-  let kind = "unit";
-  let file = format!("tests/{}/{}/{}", DIR, kind, file);
-
-  trycmd::TestCases::new().case(file);
-}
-
-// mod integration_test {
-//   use super::DIR;
-//   #[rstest::rstest]
-//   fn wick_run(#[case] file: &'static str) {
-//     let kind = "integration";
-//     let file = format!("tests/{}/{}/{}", kind, DIR, file);
-//     trycmd::TestCases::new().case(file);
-//   }
-// }
+utils::test_cases!(
+  unit: [
+    "app.toml",
+    "app-cli.toml",
+    "app-http.toml",
+    "app-time.toml",
+    "component-composite.toml",
+    "component-sql.toml",
+    "component-http.toml",
+    "component-wasm.toml"
+  ],
+  integration: []
+);

--- a/tests/query.rs
+++ b/tests/query.rs
@@ -1,0 +1,8 @@
+mod utils;
+
+utils::test_cases!(
+  unit: [
+    "jq-style.toml", "no-curlies.toml", "with-curlies.toml"
+  ],
+  integration: []
+);

--- a/tests/query/unit/jq-style.toml
+++ b/tests/query/unit/jq-style.toml
@@ -1,0 +1,6 @@
+#:schema https://raw.githubusercontent.com/assert-rs/trycmd/main/schema.json
+bin.name = "wick"
+args = ["query", "-f", "Cargo.toml", "   .package.name   "]
+stdout = """
+wick-cli
+"""

--- a/tests/query/unit/no-curlies.toml
+++ b/tests/query/unit/no-curlies.toml
@@ -1,0 +1,6 @@
+#:schema https://raw.githubusercontent.com/assert-rs/trycmd/main/schema.json
+bin.name = "wick"
+args = ["query", "-f", "Cargo.toml", "   package.name   "]
+stdout = """
+wick-cli
+"""

--- a/tests/query/unit/with-curlies.toml
+++ b/tests/query/unit/with-curlies.toml
@@ -1,0 +1,6 @@
+#:schema https://raw.githubusercontent.com/assert-rs/trycmd/main/schema.json
+bin.name = "wick"
+args = ["query", "-f", "Cargo.toml", "   {{ package.name }}   "]
+stdout = """
+   wick-cli[..]
+"""

--- a/tests/run.rs
+++ b/tests/run.rs
@@ -1,28 +1,17 @@
-static DIR: &str = "run";
+mod utils;
 
-#[rstest::rstest]
-#[case("anonymous-component.toml")]
-#[case("imported-component.toml")]
-#[case("stdin.toml")]
-#[case("file-reader.toml")]
-#[case("file-reader-lockdown-fail.toml")]
-#[case("file-reader-lockdown-pass.toml")]
-#[case("file-reader-lockdown-pass-wildcard-dir.toml")]
-#[case("file-reader-lockdown-pass-wildcard-components.toml")]
-fn wick_run(#[case] file: &'static str) {
-  let kind = "unit";
-  let file = format!("tests/{}/{}/{}", DIR, kind, file);
-
-  trycmd::TestCases::new().case(file);
-}
-
-mod integration_test {
-  use super::DIR;
-  #[rstest::rstest]
-  #[case("postgres.toml")]
-  fn wick_run(#[case] file: &'static str) {
-    let kind = "integration";
-    let file = format!("tests/{}/{}/{}", DIR, kind, file);
-    trycmd::TestCases::new().case(file);
-  }
-}
+utils::test_cases!(
+  unit: [
+    "anonymous-component.toml",
+    "imported-component.toml",
+    "stdin.toml",
+    "file-reader.toml",
+    "file-reader-lockdown-fail.toml",
+    "file-reader-lockdown-pass.toml",
+    "file-reader-lockdown-pass-wildcard-dir.toml",
+    "file-reader-lockdown-pass-wildcard-components.toml"
+  ],
+  integration: [
+    "postgres.toml"
+  ]
+);

--- a/tests/serve.rs
+++ b/tests/serve.rs
@@ -6,7 +6,7 @@ use utils::*;
 use wick_packet::Packet;
 
 #[test_logger::test(tokio::test)]
-async fn test_wick_serve() -> utils::TestResult<()> {
+async fn test_wick_serve() -> anyhow::Result<()> {
   debug!("Starting collection");
   let (p_tx, p_handle, port) = start_collection(
     "wick",

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,20 +1,9 @@
-static DIR: &str = "test";
+mod utils;
 
-#[rstest::rstest]
-#[case("wasm.toml")]
-fn wick_run(#[case] file: &'static str) {
-  let kind = "unit";
-  let file = format!("tests/{}/{}/{}", DIR, kind, file);
-
-  trycmd::TestCases::new().case(file);
-}
-
-// mod integration_test {
-//   use super::DIR;
-//   #[rstest::rstest]
-//   fn wick_run(#[case] file: &'static str) {
-//     let kind = "integration";
-//     let file = format!("tests/{}/{}/{}", kind, DIR, file);
-//     trycmd::TestCases::new().case(file);
-//   }
-// }
+utils::test_cases!(
+  unit: [
+    "wasm.toml"
+  ],
+  integration: [
+  ]
+);


### PR DESCRIPTION
`wick query` was a holdover from ancient times and we've since adopted liquid as the common templating solution.

Since `wick query` was mostly used for value extraction, we can get the same usefulness with liquid and maintain near 100% backwards compat.