### PR TITLE
Fixed custom max_packet_size on imported components

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5911,7 +5911,7 @@ dependencies = [
 
 [[package]]
 name = "wick-cli"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "atty",
@@ -6110,7 +6110,7 @@ dependencies = [
 
 [[package]]
 name = "wick-host"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6539,7 +6539,7 @@ dependencies = [
 
 [[package]]
 name = "wick-trigger-http"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ wick-component-cli = { path = "./crates/wick/wick-component-cli", version = "0.3
 wick-component-codegen = { path = "./crates/wick/wick-component-codegen", version = "0.6.0" }
 wick-component-wasmrs = { path = "./crates/wick/wick-component-wasmrs", version = "0.3.0" }
 wick-config = { path = "./crates/wick/wick-config", version = "0.28.0", default-features = false }
-wick-host = { path = "./crates/wick/wick-host", version = "0.6.0" }
+wick-host = { path = "./crates/wick/wick-host", version = "0.6.1" }
 wick-interface-types = { path = "./crates/wick/wick-interface-types", version = "0.17.0" }
 wick-invocation-server = { path = "./crates/wick/wick-invocation-server", version = "0.3.0" }
 wick-oci-utils = { path = "./crates/wick/wick-oci-utils", version = "0.5.0", default-features = false }
@@ -115,7 +115,7 @@ wick-runtime = { path = "./crates/wick/wick-runtime", version = "0.24.0" }
 wick-test = { path = "./crates/wick/wick-test", version = "0.3.0" }
 wick-trigger = { path = "./crates/wick/wick-trigger", version = "0.1.0" }
 wick-trigger-cli = { path = "./crates/wick/wick-trigger-cli", version = "0.1.0" }
-wick-trigger-http = { path = "./crates/wick/wick-trigger-http", version = "0.1.0" }
+wick-trigger-http = { path = "./crates/wick/wick-trigger-http", version = "0.1.1" }
 wick-trigger-time = { path = "./crates/wick/wick-trigger-time", version = "0.1.0" }
 wick-trigger-wasm-command = { path = "./crates/wick/wick-trigger-wasm-command", version = "0.1.1" }
 wick-wascap = { path = "./crates/wick/wick-wascap", version = "0.3.0" }

--- a/crates/wick/wick-host/Cargo.toml
+++ b/crates/wick/wick-host/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wick-host"
-version = "0.6.0"
+version = "0.6.1"
 authors = ["Jarrod Overson <jsoverson@gmail.com>"]
 edition = "2021"
 license = "Elastic-2.0"

--- a/crates/wick/wick-runtime/src/components.rs
+++ b/crates/wick/wick-runtime/src/components.rs
@@ -146,7 +146,7 @@ pub(crate) async fn init_manifest_component(
   opts.rng_seed = rng.seed();
 
   let uuid = rng.uuid();
-  let _scope = init_child(uuid, manifest.clone(), id.clone(), opts).await?;
+  let _scope = init_child(uuid, manifest.clone(), id.clone(), opts, kind.max_packet_size()).await?;
 
   let component = Arc::new(scope_component::ScopeComponent::new(uuid));
   let service = NativeComponentService::new(component);

--- a/crates/wick/wick-runtime/src/runtime.rs
+++ b/crates/wick/wick-runtime/src/runtime.rs
@@ -41,6 +41,9 @@ pub struct RuntimeInit {
 
   #[builder(setter(custom = true))]
   pub(crate) initial_components: ComponentRegistry,
+
+  #[builder(default)]
+  pub(crate) max_packet_size: Option<u32>,
 }
 
 impl Runtime {
@@ -248,6 +251,7 @@ impl RuntimeBuilder {
     Runtime::new(
       seed.unwrap_or_else(new_seed),
       RuntimeInit {
+        max_packet_size: self.max_packet_size.flatten(),
         manifest: definition,
         allow_latest: self.allow_latest.unwrap_or_default(),
         allowed_insecure: self.allowed_insecure.unwrap_or_default(),

--- a/crates/wick/wick-runtime/src/runtime/scope/child_init.rs
+++ b/crates/wick/wick-runtime/src/runtime/scope/child_init.rs
@@ -17,16 +17,18 @@ pub(crate) struct ChildInit {
   pub(crate) allowed_insecure: Vec<String>,
   pub(crate) root_config: Option<RuntimeConfig>,
   pub(crate) provided: Option<HandlerMap>,
+  pub(crate) max_packet_size: Option<u32>,
   #[allow(unused)]
   pub(crate) span: Span,
 }
 
 impl std::fmt::Debug for ChildInit {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    f.debug_struct("ComponentInitOptions")
+    f.debug_struct("ChildInit")
       .field("rng_seed", &self.rng_seed)
       .field("runtime_id", &self.runtime_id)
       .field("allow_latest", &self.allow_latest)
+      .field("max_packet_size", &self.max_packet_size)
       .field("allowed_insecure", &self.allowed_insecure)
       .field("root_config", &self.root_config)
       .field("provided", &self.provided.as_ref().map(|p| p.inner().keys()))
@@ -39,6 +41,7 @@ pub(crate) fn init_child(
   manifest: ComponentConfiguration,
   namespace: String,
   opts: ChildInit,
+  max_packet_size: Option<u32>,
 ) -> BoxFuture<'static, Result<Scope, ScopeError>> {
   let child_span = info_span!(parent:&opts.span,"scope",id=%namespace);
   let mut components = ComponentRegistry::default();
@@ -61,6 +64,7 @@ pub(crate) fn init_child(
       constraints: Default::default(),
       span: child_span,
       initial_components: components,
+      max_packet_size,
     };
 
     let init = ScopeInit::new_with_id(Some(opts.runtime_id), uid, opts.rng_seed, config);

--- a/crates/wick/wick-trigger-http/Cargo.toml
+++ b/crates/wick/wick-trigger-http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wick-trigger-http"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 license = "Elastic-2.0"
 repository = "https://github.com/candlecorp/wick"


### PR DESCRIPTION
This PR fixes the behavior of `max_packet_size` on imported components. Prior to this it was ignored in favor of the definitions default.